### PR TITLE
client: extract Client to an interface

### DIFF
--- a/pd-client/client_test.go
+++ b/pd-client/client_test.go
@@ -57,7 +57,7 @@ var (
 
 type testClientSuite struct {
 	srv    *server.Server
-	client *Client
+	client Client
 }
 
 func (s *testClientSuite) SetUpSuite(c *C) {


### PR DESCRIPTION
aims to make library user easier to write mock testing