### PR TITLE
server: add IsLeader check when create new client conn and cleanup.

### DIFF
--- a/server/leader.go
+++ b/server/leader.go
@@ -43,17 +43,12 @@ func (s *Server) getLeaderPath() string {
 }
 
 func (s *Server) leaderLoop() {
-	defer func() {
-		s.wg.Done()
-		s.enableLeader(false)
-	}()
+	defer s.wg.Done()
 
 	for {
 		if s.IsClosed() {
 			return
 		}
-
-		s.enableLeader(false)
 
 		leader, err := s.getLeader()
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -149,13 +149,13 @@ func (s *Server) Run() error {
 			break
 		}
 
-		if !s.IsLeader() {
-			log.Infof("server %s is not leader, close connection directly", s.cfg.Addr)
+		c, err := newConn(s, conn)
+		if err != nil {
+			log.Warn(errors.ErrorStack(err))
 			conn.Close()
 			continue
 		}
 
-		c := newConn(s, conn)
 		s.wg.Add(1)
 		go c.run()
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -151,7 +151,7 @@ func (s *Server) Run() error {
 
 		c, err := newConn(s, conn)
 		if err != nil {
-			log.Warn(errors.ErrorStack(err))
+			log.Warn(err)
 			conn.Close()
 			continue
 		}

--- a/server/tso.go
+++ b/server/tso.go
@@ -5,13 +5,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/coreos/etcd/clientv3"
 	"github.com/golang/protobuf/proto"
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/pingcap/kvproto/pkg/pdpb"
+	"golang.org/x/net/context"
 )
 
 const (
@@ -72,7 +71,6 @@ func (s *Server) saveTimestamp(now time.Time) error {
 
 func (s *Server) syncTimestamp() error {
 	last, err := s.loadTimestamp()
-
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/server/util.go
+++ b/server/util.go
@@ -14,7 +14,7 @@ const (
 	requestTimeout = 10 * time.Second
 )
 
-// a helper function to get value with key from etcd.
+// A helper function to get value with key from etcd.
 // TODO: return the value revision for outer use.
 func getValue(c *clientv3.Client, key string, opts ...clientv3.OpOption) ([]byte, error) {
 	kv := clientv3.NewKV(c)
@@ -36,7 +36,7 @@ func getValue(c *clientv3.Client, key string, opts ...clientv3.OpOption) ([]byte
 	return resp.Kvs[0].Value, nil
 }
 
-// return boolean to indicate whether the key exists or not.
+// Return boolean to indicate whether the key exists or not.
 // TODO: return the value revision for outer use.
 func getProtoMsg(c *clientv3.Client, key string, msg proto.Message, opts ...clientv3.OpOption) (bool, error) {
 	value, err := getValue(c, key, opts...)


### PR DESCRIPTION
I move `IsLeader` check into `newConn` function, then connsLock can make sure that only leader can create new connection, so that we can remove some redundant `enableLeader` function calls.

@siddontang  PTAL