### PR TITLE
[DNM]Add basic select algorithm.

### DIFF
--- a/server/cache.go
+++ b/server/cache.go
@@ -135,8 +135,8 @@ func (s *StoreInfo) clone() *StoreInfo {
 	}
 }
 
-// fractionUsed is the used fraction of storage capacity.
-func (s *StoreInfo) fractionUsed() float64 {
+// usedFraction is the used fraction of storage capacity.
+func (s *StoreInfo) usedFraction() float64 {
 	if s.stats.GetCapacity() == 0 {
 		return 0
 	}

--- a/server/selector.go
+++ b/server/selector.go
@@ -1,0 +1,146 @@
+package server
+
+import (
+	"github.com/pingcap/kvproto/pkg/metapb"
+)
+
+// Selector is an interface to select regions and stores for leader-transfer/rebalance.
+type Selector interface {
+	// Select selects one pair regions to do leader transfer.
+	SelectTransferredPeers(cluster *ClusterInfo, excluded map[uint64]struct{}) (*RegionInfo, *metapb.Peer)
+	// SelectGoodPeer selects one region peer to be transferred to.
+	SelectGoodPeer(cluster *ClusterInfo, peers map[uint64]*metapb.Peer) *metapb.Peer
+	// SelectBadRegion selects one region to be transferred.
+	SelectBadRegion(cluster *ClusterInfo, excluded map[uint64]struct{}) *RegionInfo
+	// SelectGoodStore selects one store to be rebalanced to.
+	SelectGoodStore(stores map[uint64]*StoreInfo, excluded map[uint64]struct{}) *StoreInfo
+	// SelectBadStore selects one store to be rebalanced.
+	SelectBadStore(stores map[uint64]*StoreInfo, excluded map[uint64]struct{}) *StoreInfo
+}
+
+const (
+	// If the used fraction of one storage is greater than this value,
+	// it will never be used as a selected target and it should be rebalanced.
+	maxUsedFraction = 0.6
+)
+
+var (
+	_ Selector = &regionCountSelector{}
+)
+
+type regionCountSelector struct {
+}
+
+func (rs *regionCountSelector) SelectBadStore(stores map[uint64]*StoreInfo, excluded map[uint64]struct{}) *StoreInfo {
+	var badStore *StoreInfo
+	for _, store := range stores {
+		if store == nil {
+			continue
+		}
+
+		if _, ok := excluded[store.store.GetId()]; ok {
+			continue
+		}
+
+		if store.fractionUsed() <= maxUsedFraction {
+			continue
+		}
+
+		if badStore == nil {
+			badStore = store
+			continue
+		}
+
+		if store.fractionUsed() > badStore.fractionUsed() {
+			badStore = store
+		}
+	}
+
+	return badStore
+}
+
+func (rs *regionCountSelector) SelectGoodStore(stores map[uint64]*StoreInfo, excluded map[uint64]struct{}) *StoreInfo {
+	var goodStore *StoreInfo
+	for _, store := range stores {
+		if store == nil {
+			continue
+		}
+
+		if _, ok := excluded[store.store.GetId()]; ok {
+			continue
+		}
+
+		if store.fractionUsed() > maxUsedFraction {
+			continue
+		}
+
+		if goodStore == nil {
+			goodStore = store
+			continue
+		}
+
+		if store.fractionUsed() < goodStore.fractionUsed() {
+			goodStore = store
+		}
+	}
+
+	return goodStore
+}
+
+func (rs *regionCountSelector) SelectBadRegion(cluster *ClusterInfo, excluded map[uint64]struct{}) *RegionInfo {
+	stores := cluster.getStores()
+	store := rs.SelectBadStore(stores, excluded)
+	if store == nil {
+		return nil
+	}
+
+	// Random select one bad region leader peer from bad store.
+	storeID := store.store.GetId()
+	return cluster.regions.randRegion(storeID)
+}
+
+func (rs *regionCountSelector) SelectGoodPeer(cluster *ClusterInfo, peers map[uint64]*metapb.Peer) *metapb.Peer {
+	stores := make(map[uint64]*StoreInfo, len(peers))
+	for storeID := range peers {
+		stores[storeID] = cluster.getStore(storeID)
+	}
+
+	store := rs.SelectGoodStore(stores, nil)
+	if store == nil {
+		return nil
+	}
+
+	storeID := store.store.GetId()
+	return peers[storeID]
+}
+
+func (rs *regionCountSelector) SelectTransferredPeers(cluster *ClusterInfo, excluded map[uint64]struct{}) (*RegionInfo, *metapb.Peer) {
+	// First select one bad store region from cluster info.
+	region := rs.SelectBadRegion(cluster, excluded)
+	if region == nil {
+		return nil, nil
+	}
+
+	leaderPeer := region.peer
+	if leaderPeer == nil {
+		return nil, nil
+	}
+
+	// Second select one good store to do region leader transfer.
+	followerPeers := make(map[uint64]*metapb.Peer)
+	for _, peer := range region.region.GetPeers() {
+		if peer.GetId() == leaderPeer.GetId() {
+			continue
+		}
+
+		storeID := peer.GetStoreId()
+		followerPeers[storeID] = peer
+	}
+
+	peer := rs.SelectGoodPeer(cluster, followerPeers)
+	if peer == nil {
+		return nil, nil
+	}
+
+	return region, peer
+}


### PR DESCRIPTION
Make a basic algorithm for transferred/rebalanced region selector by using space used fraction, see regionCapacitySelector. 
You can call SelectTransferRegion to get a transferred region and the target peer.
And also it is easy to add an rebalanced function.

/cc @shenli @siddontang @disksing Call for discussions, can this do what we want to do?