### PR TITLE
server: use IDAllocator to let balancer easy test.

### DIFF
--- a/server/balancer_worker.go
+++ b/server/balancer_worker.go
@@ -33,7 +33,7 @@ type balanceWorker struct {
 
 	wg       sync.WaitGroup
 	interval time.Duration
-	cluster  *raftCluster
+	cluster  *ClusterInfo
 
 	// should we extract to another structure, so
 	// Balancer can use it?
@@ -45,7 +45,7 @@ type balanceWorker struct {
 	quit chan struct{}
 }
 
-func newBalanceWorker(cluster *raftCluster, balancer Balancer) *balanceWorker {
+func newBalanceWorker(cluster *ClusterInfo, balancer Balancer) *balanceWorker {
 	bw := &balanceWorker{
 		interval:         defaultBalanceInterval,
 		cluster:          cluster,

--- a/server/cache.go
+++ b/server/cache.go
@@ -395,6 +395,8 @@ type ClusterInfo struct {
 	stores      map[uint64]*StoreInfo
 	regions     *RegionsInfo
 	clusterRoot string
+
+	idAlloc IDAllocator
 }
 
 func newClusterInfo(clusterRoot string) *ClusterInfo {

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -80,6 +80,7 @@ func (c *raftCluster) Start(meta metapb.Cluster) error {
 	c.storeConns.SetIdleTimeout(idleTimeout)
 
 	c.cachedCluster = newClusterInfo(c.clusterRoot)
+	c.cachedCluster.idAlloc = c.s.idAlloc
 	c.cachedCluster.setMeta(&meta)
 
 	// Cache all stores when start the cluster. We don't have
@@ -93,7 +94,7 @@ func (c *raftCluster) Start(meta metapb.Cluster) error {
 		return errors.Trace(err)
 	}
 
-	c.balanceWorker = newBalanceWorker(c, newCapacityBalancer())
+	c.balanceWorker = newBalanceWorker(c.cachedCluster, newCapacityBalancer())
 
 	return nil
 }

--- a/server/cluster_worker.go
+++ b/server/cluster_worker.go
@@ -22,8 +22,11 @@ import (
 )
 
 func (c *raftCluster) handleDefaultBalancer(region *metapb.Region, leader *metapb.Peer) (*pdpb.RegionHeartbeatResponse, error) {
+	// TODO: we must consider max allowed running default balance regions too.
+	// E,g, max peer count is 3, if we have only two store 1, 2 and add 3 later,
+	// if we don't limit, we will allow many regions do ConfChange add peer.
 	balancer := newDefaultBalancer(region, leader)
-	balanceOperator, err := balancer.Balance(c)
+	balanceOperator, err := balancer.Balance(c.cachedCluster)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/server/id.go
+++ b/server/id.go
@@ -26,6 +26,11 @@ const (
 	allocStep = uint64(1000)
 )
 
+// IDAllocator is the allocator to generate unique ID.
+type IDAllocator interface {
+	Alloc() (uint64, error)
+}
+
 type idAllocator struct {
 	mu   sync.Mutex
 	base uint64


### PR DESCRIPTION
Now  Balancer can only depend on ClusterInfo, we can test whole
balancer mechanism independently.

@qiuyesuifeng @disksing @shenli 