### PR TITLE
server: fix panic bug when start cluster failed.

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -71,8 +71,6 @@ func (c *RaftCluster) start(meta metapb.Cluster) error {
 		return nil
 	}
 
-	c.running = true
-
 	c.cachedCluster = newClusterInfo(c.clusterRoot)
 	c.cachedCluster.idAlloc = c.s.idAlloc
 
@@ -91,6 +89,8 @@ func (c *RaftCluster) start(meta metapb.Cluster) error {
 
 	c.balancerWorker = newBalancerWorker(c.cachedCluster, c.s.cfg.BalanceCfg)
 	c.balancerWorker.run()
+
+	c.running = true
 
 	return nil
 }


### PR DESCRIPTION
If we start cluster, but after a while, we cannot connect to etcd,  we will campaign leader and restart inner cluster.
But there is a bug in start function, that is we have not set `c.running` correctly,  a `close of closed channel`  panic may occur.
This PR has fixed it.
