### PR TITLE
Balance refactor step two. 

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -26,5 +26,3 @@ max-balance-count = 16
 max-balance-retry-per-loop = 10
 max-balance-count-per-loop = 3
 max-transfer-wait-count = 3
-leader-score-weight = 0.4
-capacity-score-weight = 0.6

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -335,8 +335,8 @@ func (lb *leaderBalancer) Balance(cluster *clusterInfo) (*score, *balanceOperato
 	}
 
 	regionID := region.GetId()
-	leaderTransferOperator := newTransferLeaderOperator(regionID, leader, newLeader, lb.cfg)
-	return score, newBalanceOperator(region, leaderTransferOperator), nil
+	transferLeaderOperator := newTransferLeaderOperator(regionID, leader, newLeader, lb.cfg)
+	return score, newBalanceOperator(region, transferLeaderOperator), nil
 }
 
 // defaultBalancer is used for default config change, like add/remove peer.

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -30,7 +30,6 @@ var (
 type Balancer interface {
 	// Balance selects one store to do balance.
 	Balance(cluster *clusterInfo) (*score, *balanceOperator, error)
-
 	// ScoreType returns score type.
 	ScoreType() scoreType
 }

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -28,7 +28,10 @@ var (
 
 // Balancer is an interface to select store regions for auto-balance.
 type Balancer interface {
-	Balance(cluster *clusterInfo) (*balanceOperator, error)
+	// Balance selects one store to do balance.
+	Balance(cluster *clusterInfo) (*score, *balanceOperator, error)
+
+	// ScoreType returns score type.
 	ScoreType() scoreType
 }
 
@@ -124,32 +127,28 @@ func (cb *capacityBalancer) ScoreType() scoreType {
 	return cb.st
 }
 
-// selectBalanceRegion tries to select a store leader region to do balance and returns true, but if we cannot find any,
-// we try to find a store follower region and returns false.
-func (cb *capacityBalancer) selectBalanceRegion(cluster *clusterInfo, stores []*storeInfo) (*metapb.Region, *metapb.Peer, *metapb.Peer, bool) {
+// selectBalanceRegion tries to select a store follower region to do balance.
+func (cb *capacityBalancer) selectBalanceRegion(cluster *clusterInfo, stores []*storeInfo) (*metapb.Region, *metapb.Peer, *metapb.Peer) {
 	store := selectFromStore(stores, cluster.getUnknownStores(), cb.filters, cb.st)
 	if store == nil {
 		log.Warn("from store cannot be found to select balance region")
-		return nil, nil, nil, false
+		return nil, nil, nil
 	}
 
-	var (
-		region   *metapb.Region
-		leader   *metapb.Peer
-		follower *metapb.Peer
-	)
-
-	// Random select one leader region from store.
 	storeID := store.store.GetId()
-	region = cluster.regions.randLeaderRegion(storeID)
-	if region == nil {
-		log.Warnf("random leader region is nil, store %d", storeID)
-		region, leader, follower = cluster.regions.randRegion(storeID)
-		return region, leader, follower, false
+	meta := cluster.getMeta()
+	if meta.GetMaxPeerCount() == 1 {
+		region := cluster.regions.randLeaderRegion(storeID)
+		if region == nil {
+			return nil, nil, nil
+		}
+
+		leader := leaderPeer(region, storeID)
+		return region, leader, leader
 	}
 
-	leader = leaderPeer(region, storeID)
-	return region, leader, nil, true
+	// Random select one follower region from store.
+	return cluster.regions.randRegion(storeID)
 }
 
 func (cb *capacityBalancer) selectNewLeaderPeer(cluster *clusterInfo, peers map[uint64]*metapb.Peer) *metapb.Peer {
@@ -204,59 +203,21 @@ func (cb *capacityBalancer) selectRemovePeer(cluster *clusterInfo, peers map[uin
 	return peers[storeID], nil
 }
 
-func (cb *capacityBalancer) doLeaderBalance(cluster *clusterInfo, stores []*storeInfo, region *metapb.Region, leader *metapb.Peer, newPeer *metapb.Peer) (*balanceOperator, error) {
-	if !checkScore(cluster, leader, newPeer, cb.st, cb.cfg) {
-		return nil, nil
-	}
-
-	regionID := region.GetId()
-
-	// If cluster max peer count config is 1, we cannot do leader transfer,
-	// only need to add new peer and remove leader peer.
-	meta := cluster.getMeta()
-	if meta.GetMaxPeerCount() == 1 {
-		addPeerOperator := newAddPeerOperator(regionID, newPeer)
-		removePeerOperator := newRemovePeerOperator(regionID, leader)
-		return newBalanceOperator(region, addPeerOperator, removePeerOperator), nil
-	}
-
-	followerPeers, _ := getFollowerPeers(region, leader)
-	newLeader := cb.selectNewLeaderPeer(cluster, followerPeers)
-	if newLeader == nil {
-		log.Warn("new leader peer cannot be found to do balance, try to do follower peer balance")
-		return nil, nil
-	}
-
-	leaderTransferOperator := newTransferLeaderOperator(regionID, leader, newLeader, cb.cfg)
-	addPeerOperator := newAddPeerOperator(regionID, newPeer)
-	removePeerOperator := newRemovePeerOperator(regionID, leader)
-
-	return newBalanceOperator(region, leaderTransferOperator, addPeerOperator, removePeerOperator), nil
-}
-
-func (cb *capacityBalancer) doFollowerBalance(cluster *clusterInfo, stores []*storeInfo, region *metapb.Region, follower *metapb.Peer, newPeer *metapb.Peer) (*balanceOperator, error) {
-	if !checkScore(cluster, follower, newPeer, cb.st, cb.cfg) {
-		return nil, nil
-	}
-
-	addPeerOperator := newAddPeerOperator(region.GetId(), newPeer)
-	removePeerOperator := newRemovePeerOperator(region.GetId(), follower)
-	return newBalanceOperator(region, addPeerOperator, removePeerOperator), nil
-}
-
-func (cb *capacityBalancer) doBalance(cluster *clusterInfo) (*balanceOperator, error) {
+// Balance tries to select a store region to do balance.
+// The balance type is follower balance.
+func (cb *capacityBalancer) Balance(cluster *clusterInfo) (*score, *balanceOperator, error) {
 	stores := cluster.getStores()
-	region, leader, follower, isLeaderBalance := cb.selectBalanceRegion(cluster, stores)
-	if region == nil || leader == nil {
+	region, leader, peer := cb.selectBalanceRegion(cluster, stores)
+	if region == nil || leader == nil || peer == nil {
 		log.Warn("region cannot be found to do balance")
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// If region peer count is not equal to max peer count, no need to do balance.
 	if len(region.GetPeers()) != int(cluster.getMeta().GetMaxPeerCount()) {
 		log.Warnf("region peer count %d not equals to max peer count %d, no need to do balance",
 			len(region.GetPeers()), cluster.getMeta().GetMaxPeerCount())
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	_, excludedStores := getFollowerPeers(region, leader)
@@ -265,29 +226,22 @@ func (cb *capacityBalancer) doBalance(cluster *clusterInfo) (*balanceOperator, e
 	// Select one store to add new peer.
 	newPeer, err := cb.selectAddPeer(cluster, stores, excludedStores)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
 	if newPeer == nil {
 		log.Warn("new peer cannot be found to do balance")
-		return nil, nil
+		return nil, nil, nil
 	}
 
-	if isLeaderBalance {
-		ops, err := cb.doLeaderBalance(cluster, stores, region, leader, newPeer)
-		return ops, errors.Trace(err)
+	// Check and get diff score.
+	score, ok := checkAndGetDiffScore(cluster, peer, newPeer, cb.st, cb.cfg)
+	if !ok {
+		return nil, nil, nil
 	}
 
-	return cb.doFollowerBalance(cluster, stores, region, follower, newPeer)
-}
-
-// Balance tries to select a store region to do balance.
-// The priority of balance type is:
-// doBalance:
-// 1 do leader balance.
-// 2 do follower balance.
-func (cb *capacityBalancer) Balance(cluster *clusterInfo) (*balanceOperator, error) {
-	op, err := cb.doBalance(cluster)
-	return op, errors.Trace(err)
+	addPeerOperator := newAddPeerOperator(region.GetId(), newPeer)
+	removePeerOperator := newRemovePeerOperator(region.GetId(), peer)
+	return score, newBalanceOperator(region, addPeerOperator, removePeerOperator), nil
 }
 
 type leaderBalancer struct {
@@ -353,41 +307,37 @@ func (lb *leaderBalancer) selectNewLeaderPeer(cluster *clusterInfo, peers map[ui
 	return peers[storeID]
 }
 
-func (lb *leaderBalancer) doBalance(cluster *clusterInfo) (*balanceOperator, error) {
+// Balance tries to select a store region to do balance.
+// The balance type is leader transfer.
+func (lb *leaderBalancer) Balance(cluster *clusterInfo) (*score, *balanceOperator, error) {
 	// If cluster max peer count config is 1, we cannot do leader transfer,
 	meta := cluster.getMeta()
 	if meta.GetMaxPeerCount() == 1 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	stores := cluster.getStores()
 	region, leader, newLeader := lb.selectBalanceRegion(cluster, stores)
 	if region == nil || leader == nil || newLeader == nil {
 		log.Warn("region cannot be found to do leader transfer")
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// If region peer count is not equal to max peer count, no need to do leader transfer.
 	if len(region.GetPeers()) != int(cluster.getMeta().GetMaxPeerCount()) {
 		log.Warnf("region peer count %d not equals to max peer count %d, no need to do leader transfer",
 			len(region.GetPeers()), cluster.getMeta().GetMaxPeerCount())
-		return nil, nil
+		return nil, nil, nil
 	}
 
-	if !checkScore(cluster, leader, newLeader, lb.st, lb.cfg) {
-		return nil, nil
+	score, ok := checkAndGetDiffScore(cluster, leader, newLeader, lb.st, lb.cfg)
+	if !ok {
+		return nil, nil, nil
 	}
 
 	regionID := region.GetId()
 	leaderTransferOperator := newTransferLeaderOperator(regionID, leader, newLeader, lb.cfg)
-	return newBalanceOperator(region, leaderTransferOperator), nil
-}
-
-// Balance tries to select a store region to do balance.
-// The balance type is leader transfer.
-func (lb *leaderBalancer) Balance(cluster *clusterInfo) (*balanceOperator, error) {
-	bop, err := lb.doBalance(cluster)
-	return bop, errors.Trace(err)
+	return score, newBalanceOperator(region, leaderTransferOperator), nil
 }
 
 // defaultBalancer is used for default config change, like add/remove peer.
@@ -452,16 +402,21 @@ func (db *defaultBalancer) removePeer(cluster *clusterInfo) (*balanceOperator, e
 	return newBalanceOperator(db.region, newOnceOperator(removePeerOperator)), nil
 }
 
-func (db *defaultBalancer) Balance(cluster *clusterInfo) (*balanceOperator, error) {
-	clusterMeta := cluster.getMeta()
+func (db *defaultBalancer) Balance(cluster *clusterInfo) (*score, *balanceOperator, error) {
 	peerCount := len(db.region.GetPeers())
+	clusterMeta := cluster.getMeta()
 	maxPeerCount := int(clusterMeta.GetMaxPeerCount())
 
-	if peerCount == maxPeerCount {
-		return nil, nil
-	} else if peerCount < maxPeerCount {
-		return db.addPeer(cluster)
-	} else {
-		return db.removePeer(cluster)
+	var (
+		bop *balanceOperator
+		err error
+	)
+
+	if peerCount < maxPeerCount {
+		bop, err = db.addPeer(cluster)
+	} else if peerCount > maxPeerCount {
+		bop, err = db.removePeer(cluster)
 	}
+
+	return nil, bop, errors.Trace(err)
 }

--- a/server/balancer_worker.go
+++ b/server/balancer_worker.go
@@ -206,24 +206,37 @@ func (bw *balancerWorker) doBalance() error {
 
 		balancerCounter.WithLabelValues("total").Inc()
 
+		scores := make([]*score, 0, len(bw.balancers))
+		bops := make([]*balanceOperator, 0, len(bw.balancers))
+
+		// Find the balance operator candidates.
 		for _, balancer := range bw.balancers {
-			balanceOperator, err := balancer.Balance(bw.cluster)
+			score, balanceOperator, err := balancer.Balance(bw.cluster)
 			if err != nil {
 				balancerCounter.WithLabelValues("failed").Inc()
 				return errors.Trace(err)
 			}
 			if balanceOperator == nil {
-				balancerCounter.WithLabelValues("none").Inc()
 				continue
 			}
 
-			regionID := balanceOperator.getRegionID()
-			if bw.addBalanceOperator(regionID, balanceOperator) {
-				bw.addRegionCache(regionID)
-				balancerCounter.WithLabelValues("successed").Inc()
-				balanceCount++
-				break
-			}
+			scores = append(scores, score)
+			bops = append(bops, balanceOperator)
+		}
+
+		// Calculate the priority of candidates score.
+		idx, score := priorityScore(bw.cfg, scores)
+		if score == nil {
+			balancerCounter.WithLabelValues("none").Inc()
+			continue
+		}
+
+		bop := bops[idx]
+		regionID := bop.getRegionID()
+		if bw.addBalanceOperator(regionID, bop) {
+			bw.addRegionCache(regionID)
+			balancerCounter.WithLabelValues("successed").Inc()
+			balanceCount++
 		}
 	}
 

--- a/server/balancer_worker.go
+++ b/server/balancer_worker.go
@@ -46,7 +46,7 @@ func newBalancerWorker(cluster *clusterInfo, cfg *BalanceConfig) *balancerWorker
 		cfg:              cfg,
 		cluster:          cluster,
 		balanceOperators: make(map[uint64]*balanceOperator),
-		regionCache:      newExpireRegionCache(time.Duration(cfg.BalanceInterval)*time.Second, 2*time.Duration(cfg.BalanceInterval)*time.Second),
+		regionCache:      newExpireRegionCache(time.Duration(cfg.BalanceInterval)*time.Second, 4*time.Duration(cfg.BalanceInterval)*time.Second),
 		historyOperators: newLRUCache(100),
 		events:           newFifoCache(10000),
 		quit:             make(chan struct{}),

--- a/server/balancer_worker_test.go
+++ b/server/balancer_worker_test.go
@@ -46,74 +46,69 @@ func (s *testBalancerWorkerSuite) TestBalancerWorker(c *C) {
 	s.balancerWorker = newBalancerWorker(clusterInfo, s.ts.cfg)
 
 	// The store id will be 1,2,3,4.
-	s.ts.updateStore(c, clusterInfo, 1, 100, 10, 0, 0)
+	s.ts.updateStore(c, clusterInfo, 1, 100, 50, 0, 0)
 	s.ts.updateStore(c, clusterInfo, 2, 100, 20, 0, 0)
 	s.ts.updateStore(c, clusterInfo, 3, 100, 30, 0, 0)
 	s.ts.updateStore(c, clusterInfo, 4, 100, 40, 0, 0)
 
 	// Now we have no region to do balance.
-	ret := s.balancerWorker.doBalance()
-	c.Assert(ret, IsNil)
+	err := s.balancerWorker.doBalance()
+	c.Assert(err, IsNil)
 
 	// Add two peers.
 	s.ts.addRegionPeer(c, clusterInfo, 4, region, leader)
 	s.ts.addRegionPeer(c, clusterInfo, 3, region, leader)
 
-	// Now the region is (1,3,4), the balance operators should be
-	// 1) leader transfer: 1 -> 4
-	// 2) add peer: 2
-	// 3) remove peer: 1
-	ret = s.balancerWorker.doBalance()
-	c.Assert(ret, IsNil)
+	s.ts.cfg.MaxLeaderCount = 1
+
+	// Now the region is (1,3,4), leader is 1, the balance operators should be
+	// leader transfer: 1 -> 3/4
+	err = s.balancerWorker.doBalance()
+	c.Assert(err, IsNil)
 
 	regionID := region.GetId()
 	bop, ok := s.balancerWorker.balanceOperators[regionID]
 	c.Assert(ok, IsTrue)
-	c.Assert(bop.Ops, HasLen, 3)
+	c.Assert(bop.Ops, HasLen, 1)
 
-	op1 := bop.Ops[0].(*transferLeaderOperator)
-	c.Assert(op1.cfg.MaxTransferWaitCount, Equals, defaultMaxTransferWaitCount)
-	c.Assert(op1.OldLeader.GetStoreId(), Equals, uint64(1))
-	c.Assert(op1.NewLeader.GetStoreId(), Equals, uint64(4))
+	op := bop.Ops[0].(*transferLeaderOperator)
+	c.Assert(op.cfg.MaxTransferWaitCount, Equals, defaultMaxTransferWaitCount)
+	c.Assert(op.OldLeader.GetStoreId(), Equals, uint64(1))
+	newLeaderStoreID := op.NewLeader.GetStoreId()
+	c.Assert(newLeaderStoreID, Not(Equals), uint64(1))
 
 	// Now we check the cfg.MaxTransferWaitCount for transferLeaderOperator.
-	op1.cfg.MaxTransferWaitCount = 2
+	s.ts.cfg.MaxTransferWaitCount = 2
 
 	ctx := newOpContext(nil, nil)
-	ok, res, err := op1.Do(ctx, region, leader)
+	ok, res, err := op.Do(ctx, region, leader)
 	c.Assert(err, IsNil)
 	c.Assert(ok, IsFalse)
-	c.Assert(res.GetTransferLeader().GetPeer().GetStoreId(), Equals, uint64(4))
-	c.Assert(op1.Count, Equals, 1)
+	c.Assert(res.GetTransferLeader().GetPeer().GetStoreId(), Equals, newLeaderStoreID)
+	c.Assert(op.Count, Equals, 1)
 
-	ok, res, err = op1.Do(ctx, region, leader)
+	ok, res, err = op.Do(ctx, region, leader)
 	c.Assert(err, IsNil)
 	c.Assert(ok, IsFalse)
 	c.Assert(res, IsNil)
-	c.Assert(op1.Count, Equals, 2)
+	c.Assert(op.Count, Equals, 2)
 
-	ok, res, err = op1.Do(ctx, region, leader)
+	ok, res, err = op.Do(ctx, region, leader)
 	c.Assert(err, NotNil)
 	c.Assert(ok, IsFalse)
 	c.Assert(res, IsNil)
-	c.Assert(op1.Count, Equals, 2)
+	c.Assert(op.Count, Equals, 2)
 
-	op1.cfg.MaxTransferWaitCount = defaultMaxTransferWaitCount
-
-	op2 := bop.Ops[1].(*changePeerOperator)
-	c.Assert(op2.ChangePeer.GetChangeType(), Equals, raftpb.ConfChangeType_AddNode)
-	c.Assert(op2.ChangePeer.GetPeer().GetStoreId(), Equals, uint64(2))
-
-	op3 := bop.Ops[2].(*changePeerOperator)
-	c.Assert(op3.ChangePeer.GetChangeType(), Equals, raftpb.ConfChangeType_RemoveNode)
-	c.Assert(op3.ChangePeer.GetPeer().GetStoreId(), Equals, uint64(1))
-
-	c.Assert(s.balancerWorker.balanceOperators, HasLen, 1)
-	c.Assert(s.balancerWorker.regionCache.count(), Equals, 1)
+	s.ts.cfg.MaxTransferWaitCount = defaultMaxTransferWaitCount
 
 	// Since we have already cached region balance operator, so recall doBalance will do nothing.
-	ret = s.balancerWorker.doBalance()
-	c.Assert(ret, IsNil)
+	s.ts.updateStore(c, clusterInfo, 1, 100, 50, 0, 0)
+	s.ts.updateStore(c, clusterInfo, 2, 100, 90, 0, 0)
+	s.ts.updateStore(c, clusterInfo, 3, 100, 30, 0, 0)
+	s.ts.updateStore(c, clusterInfo, 4, 100, 40, 0, 0)
+
+	err = s.balancerWorker.doBalance()
+	c.Assert(err, IsNil)
 
 	oldBop := bop
 	bop, ok = s.balancerWorker.balanceOperators[regionID]
@@ -126,8 +121,8 @@ func (s *testBalancerWorkerSuite) TestBalancerWorker(c *C) {
 	c.Assert(s.balancerWorker.balanceOperators, HasLen, 0)
 	c.Assert(s.balancerWorker.regionCache.count(), Equals, 1)
 
-	ret = s.balancerWorker.doBalance()
-	c.Assert(ret, IsNil)
+	err = s.balancerWorker.doBalance()
+	c.Assert(err, IsNil)
 	c.Assert(s.balancerWorker.balanceOperators, HasLen, 0)
 
 	// Remove balance expire cache, this time we can get a new balancer now.
@@ -135,22 +130,25 @@ func (s *testBalancerWorkerSuite) TestBalancerWorker(c *C) {
 	c.Assert(s.balancerWorker.balanceOperators, HasLen, 0)
 	c.Assert(s.balancerWorker.regionCache.count(), Equals, 0)
 
-	ret = s.balancerWorker.doBalance()
-	c.Assert(ret, IsNil)
+	err = s.balancerWorker.doBalance()
+	c.Assert(err, IsNil)
 
+	// Now the region is (1,3,4), leader is 3/4, the balance operators should be
+	// 1) add peer: 2
+	// 2) remove peer: 3/4
+	regionID = region.GetId()
 	bop, ok = s.balancerWorker.balanceOperators[regionID]
 	c.Assert(ok, IsTrue)
-	c.Assert(bop.Ops, HasLen, 3)
+	c.Assert(bop.Ops, HasLen, 2)
 
-	op1 = bop.Ops[0].(*transferLeaderOperator)
-	c.Assert(op1.OldLeader.GetStoreId(), Equals, uint64(1))
-	c.Assert(op1.NewLeader.GetStoreId(), Equals, uint64(4))
+	op1 := bop.Ops[0].(*changePeerOperator)
+	c.Assert(op1.ChangePeer.GetChangeType(), Equals, raftpb.ConfChangeType_AddNode)
+	c.Assert(op1.ChangePeer.GetPeer().GetStoreId(), Equals, uint64(2))
 
-	op2 = bop.Ops[1].(*changePeerOperator)
-	c.Assert(op2.ChangePeer.GetChangeType(), Equals, raftpb.ConfChangeType_AddNode)
-	c.Assert(op2.ChangePeer.GetPeer().GetStoreId(), Equals, uint64(2))
+	op2 := bop.Ops[1].(*changePeerOperator)
+	c.Assert(op2.ChangePeer.GetChangeType(), Equals, raftpb.ConfChangeType_RemoveNode)
+	c.Assert(op2.ChangePeer.GetPeer().GetStoreId(), Not(Equals), uint64(2))
 
-	op3 = bop.Ops[2].(*changePeerOperator)
-	c.Assert(op3.ChangePeer.GetChangeType(), Equals, raftpb.ConfChangeType_RemoveNode)
-	c.Assert(op3.ChangePeer.GetPeer().GetStoreId(), Equals, uint64(1))
+	c.Assert(s.balancerWorker.balanceOperators, HasLen, 1)
+	c.Assert(s.balancerWorker.regionCache.count(), Equals, 1)
 }

--- a/server/cache.go
+++ b/server/cache.go
@@ -519,6 +519,8 @@ type StoreStatus struct {
 
 	LeaderRegionCount int `json:"leader_region_count"`
 
+	TotalRegionCount int `json:"total_region_count"`
+
 	Scores []int `json:"scores"`
 }
 
@@ -526,6 +528,7 @@ func (s *StoreStatus) clone() *StoreStatus {
 	return &StoreStatus{
 		Stats:             proto.Clone(s.Stats).(*pdpb.StoreStats),
 		LeaderRegionCount: s.LeaderRegionCount,
+		TotalRegionCount:  s.TotalRegionCount,
 	}
 }
 
@@ -545,11 +548,11 @@ func (s *storeInfo) clone() *storeInfo {
 
 // leaderRatio is the leader region ratio of storage regions.
 func (s *storeInfo) leaderRatio() float64 {
-	if s.stats.Stats.GetRegionCount() == 0 {
+	if s.stats.TotalRegionCount == 0 {
 		return 0
 	}
 
-	return float64(s.stats.LeaderRegionCount) / float64(s.stats.Stats.GetRegionCount())
+	return float64(s.stats.LeaderRegionCount) / float64(s.stats.TotalRegionCount)
 }
 
 // usedRatio is the used capacity ratio of storage capacity.
@@ -617,6 +620,7 @@ func (c *clusterInfo) updateStoreStatus(stats *pdpb.StoreStats) bool {
 	}
 
 	store.stats.LeaderRegionCount = c.regions.leaderRegionCount(storeID)
+	store.stats.TotalRegionCount = c.regions.regionCount()
 	return true
 }
 

--- a/server/cluster_worker.go
+++ b/server/cluster_worker.go
@@ -29,7 +29,7 @@ func (c *RaftCluster) addDefaultBalanceOperator(region *metapb.Region, leader *m
 	}
 
 	balancer := newDefaultBalancer(region, leader, c.s.cfg.BalanceCfg)
-	balanceOperator, err := balancer.Balance(c.cachedCluster)
+	_, balanceOperator, err := balancer.Balance(c.cachedCluster)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/server/config.go
+++ b/server/config.go
@@ -156,12 +156,12 @@ type BalanceConfig struct {
 	// it will never be used as a to store.
 	MaxCapacityUsedRatio float64 `toml:"max-capacity-used-ratio" json:"max-capacity-used-ratio"`
 
-	// For leader count balance.
-	// If the leader region count of one store is greater than this value,
-	// it will be used as a from store to do leader balance.
+	// For leader balance.
+	// If the leader region count of one store is less than this value,
+	// it will never be used as a from store.
 	MaxLeaderCount uint64 `toml:"max-leader-count" json:"max-leader-count"`
 
-	// For snapshot balance filter.
+	// For capacity balance.
 	// If the sending snapshot count of one storage is greater than this value,
 	// it will never be used as a from store.
 	MaxSendingSnapCount uint64 `toml:"max-sending-snap-count" json:"max-sending-snap-count"`

--- a/server/config.go
+++ b/server/config.go
@@ -187,12 +187,6 @@ type BalanceConfig struct {
 
 	// MaxTransferWaitCount is the max heartbeat count to wait leader transfer to finish.
 	MaxTransferWaitCount uint64 `toml:"max-transfer-wait-count" json:"max-transfer-wait-count"`
-
-	// LeaderScoreWeight is the leader score weight to calculate the store score.
-	LeaderScoreWeight float64 `toml:"leader-score-weight" json:"leader-score-weight"`
-
-	// CapacityScoreWeight is the capacity score weight to calculate the store score.
-	CapacityScoreWeight float64 `toml:"capacity-score-weight" json:"capacity-score-weight"`
 }
 
 func newBalanceConfig() *BalanceConfig {
@@ -211,8 +205,6 @@ const (
 	defaultMaxBalanceRetryPerLoop = uint64(10)
 	defaultMaxBalanceCountPerLoop = uint64(3)
 	defaultMaxTransferWaitCount   = uint64(3)
-	defaultLeaderScoreWeight      = float64(0.4)
-	defaultCapacityScoreWeight    = float64(0.6)
 )
 
 func (c *BalanceConfig) adjust() {
@@ -258,14 +250,6 @@ func (c *BalanceConfig) adjust() {
 
 	if c.MaxTransferWaitCount == 0 {
 		c.MaxTransferWaitCount = defaultMaxTransferWaitCount
-	}
-
-	if c.LeaderScoreWeight == 0 {
-		c.LeaderScoreWeight = defaultLeaderScoreWeight
-	}
-
-	if c.CapacityScoreWeight == 0 {
-		c.CapacityScoreWeight = defaultCapacityScoreWeight
 	}
 }
 

--- a/server/score.go
+++ b/server/score.go
@@ -18,6 +18,48 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 )
 
+type score struct {
+	first     int
+	second    int
+	diff      int
+	threshold int
+	st        string
+}
+
+func priorityScore(cfg *BalanceConfig, scores []*score) (int, *score) {
+	var (
+		maxPriority int
+		idx         int
+		resultScore *score
+	)
+
+	for i, score := range scores {
+		priority := score.diff
+		if score.threshold != -1 {
+			// If the score diff is close to threshold value, we should add the priority weight.
+			if abs(score.threshold-score.first) <= int(100*cfg.MaxDiffScoreFraction) {
+				priority += 10
+			}
+		}
+
+		if priority > maxPriority {
+			idx = i
+			resultScore = score
+		}
+	}
+
+	return idx, resultScore
+}
+
+func scoreThreshold(cfg *BalanceConfig, st scoreType) int {
+	switch st {
+	case capacityScore:
+		return int(cfg.MaxCapacityUsedRatio * 100)
+	default:
+		return -1
+	}
+}
+
 type scoreType byte
 
 const (
@@ -75,12 +117,12 @@ func newScorer(st scoreType) Scorer {
 	return nil
 }
 
-func checkScore(cluster *clusterInfo, oldPeer *metapb.Peer, newPeer *metapb.Peer, st scoreType, cfg *BalanceConfig) bool {
+func checkAndGetDiffScore(cluster *clusterInfo, oldPeer *metapb.Peer, newPeer *metapb.Peer, st scoreType, cfg *BalanceConfig) (*score, bool) {
 	oldStore := cluster.getStore(oldPeer.GetStoreId())
 	newStore := cluster.getStore(newPeer.GetStoreId())
 	if oldStore == nil || newStore == nil {
 		log.Debugf("check score failed - old peer: %v, new peer: %v", oldPeer, newPeer)
-		return false
+		return nil, false
 	}
 
 	// TODO: we should check the diff score of pre-balance `from store` and post balance `to store`.
@@ -93,8 +135,16 @@ func checkScore(cluster *clusterInfo, oldPeer *metapb.Peer, newPeer *metapb.Peer
 	if diffScore <= int(float64(oldStoreScore)*cfg.MaxDiffScoreFraction) {
 		log.Debugf("check score failed - diff score is too small - score type: %v, old peer: %v, new peer: %v, old store score: %d, new store score: %d, diif score: %d",
 			st, oldPeer, newPeer, oldStoreScore, newStoreScore, diffScore)
-		return false
+		return nil, false
 	}
 
-	return true
+	score := &score{
+		first:     oldStoreScore,
+		second:    newStoreScore,
+		diff:      diffScore,
+		threshold: scoreThreshold(cfg, st),
+		st:        st.String(),
+	}
+
+	return score, true
 }

--- a/server/score.go
+++ b/server/score.go
@@ -25,7 +25,7 @@ type score struct {
 	to        int
 	diff      int
 	threshold int
-	st        string
+	st        scoreType
 }
 
 func priorityScore(cfg *BalanceConfig, scores []*score) (int, *score) {
@@ -145,7 +145,7 @@ func checkAndGetDiffScore(cluster *clusterInfo, oldPeer *metapb.Peer, newPeer *m
 		to:        newStoreScore,
 		diff:      diffScore,
 		threshold: scoreThreshold(cfg, st),
-		st:        st.String(),
+		st:        st,
 	}
 
 	return score, true

--- a/server/score.go
+++ b/server/score.go
@@ -19,8 +19,8 @@ import (
 )
 
 type score struct {
-	first     int
-	second    int
+	from      int
+	to        int
 	diff      int
 	threshold int
 	st        string
@@ -37,7 +37,7 @@ func priorityScore(cfg *BalanceConfig, scores []*score) (int, *score) {
 		priority := score.diff
 		if score.threshold != -1 {
 			// If the score diff is close to threshold value, we should add the priority weight.
-			if abs(score.threshold-score.first) <= int(100*cfg.MaxDiffScoreFraction) {
+			if score.threshold-score.from <= int(100*cfg.MaxDiffScoreFraction) {
 				priority += 10
 			}
 		}
@@ -139,8 +139,8 @@ func checkAndGetDiffScore(cluster *clusterInfo, oldPeer *metapb.Peer, newPeer *m
 	}
 
 	score := &score{
-		first:     oldStoreScore,
-		second:    newStoreScore,
+		from:      oldStoreScore,
+		to:        newStoreScore,
 		diff:      diffScore,
 		threshold: scoreThreshold(cfg, st),
 		st:        st.String(),

--- a/server/score.go
+++ b/server/score.go
@@ -36,7 +36,7 @@ func priorityScore(cfg *BalanceConfig, scores []*score) (int, *score) {
 	for i, score := range scores {
 		priority := score.diff
 		if score.threshold != -1 {
-			// If the score diff is close to threshold value, we should add the priority weight.
+			// If the from store score is close to threshold value, we should add the priority weight.
 			if score.threshold-score.from <= int(100*cfg.MaxDiffScoreFraction) {
 				priority += 10
 			}

--- a/server/score.go
+++ b/server/score.go
@@ -18,6 +18,8 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 )
 
+const noThreshold = -1
+
 type score struct {
 	from      int
 	to        int
@@ -35,7 +37,7 @@ func priorityScore(cfg *BalanceConfig, scores []*score) (int, *score) {
 
 	for i, score := range scores {
 		priority := score.diff
-		if score.threshold != -1 {
+		if score.threshold != noThreshold {
 			// If the from store score is close to threshold value, we should add the priority weight.
 			if score.threshold-score.from <= int(100*cfg.MaxDiffScoreFraction) {
 				priority += 10
@@ -56,7 +58,7 @@ func scoreThreshold(cfg *BalanceConfig, st scoreType) int {
 	case capacityScore:
 		return int(cfg.MaxCapacityUsedRatio * 100)
 	default:
-		return -1
+		return noThreshold
 	}
 }
 

--- a/server/util.go
+++ b/server/util.go
@@ -157,3 +157,11 @@ func mergeMap(m1 map[uint64]struct{}, m2 map[uint64]struct{}) map[uint64]struct{
 
 	return data
 }
+
+func abs(a int) int {
+	if a < 0 {
+		return -a
+	}
+
+	return a
+}

--- a/server/util.go
+++ b/server/util.go
@@ -157,11 +157,3 @@ func mergeMap(m1 map[uint64]struct{}, m2 map[uint64]struct{}) map[uint64]struct{
 
 	return data
 }
-
-func abs(a int) int {
-	if a < 0 {
-		return -a
-	}
-
-	return a
-}


### PR DESCRIPTION
In #195 , we have mentioned that the refactor balance including following steps:
1）separate leader count and capacity balancer.
2）find a new algorithm to decide the priority of balance strategy dynamically.

This PR is for 2) step, the balance strategy is dynamical.
In this implement, we will calculate the capacity and leader score of stores first, then try to find the  best balance candidate. 
Now we only consider the diff score of `from store` and `to store` and the threshold score conditions.
The balance refactor framework is finished, later we should add more balance rules to make the strategy better.

/cc @siddontang @huachaohuang @zhangjinpeng1987 @shenli @disksing 
