### PR TITLE
leader: check client in GetLeader().

### DIFF
--- a/server/api/member_test.go
+++ b/server/api/member_test.go
@@ -127,8 +127,8 @@ func (s *testMemberAPISuite) TestMemberDelete(c *C) {
 		{
 			// delete it again
 			name:    server.Name(),
-			checker: Equals,
-			status:  http.StatusNotFound,
+			checker: Not(Equals),
+			status:  http.StatusOK,
 		},
 	}
 

--- a/server/leader.go
+++ b/server/leader.go
@@ -103,8 +103,8 @@ func getLeader(c *clientv3.Client, leaderPath string) (*pdpb.Leader, error) {
 
 // GetLeader gets pd cluster leader.
 func (s *Server) GetLeader() (*pdpb.Leader, error) {
-	if s.client == nil {
-		return nil, errors.New("server is not ready")
+	if s.isClosed() {
+		return nil, errors.New("server is closed")
 	}
 	return getLeader(s.client, s.getLeaderPath())
 }

--- a/server/leader.go
+++ b/server/leader.go
@@ -103,6 +103,9 @@ func getLeader(c *clientv3.Client, leaderPath string) (*pdpb.Leader, error) {
 
 // GetLeader gets pd cluster leader.
 func (s *Server) GetLeader() (*pdpb.Leader, error) {
+	if s.client == nil {
+		return nil, errors.New("server is not ready")
+	}
 	return getLeader(s.client, s.getLeaderPath())
 }
 

--- a/server/leader_test.go
+++ b/server/leader_test.go
@@ -1,0 +1,87 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"sync"
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+)
+
+var _ = Suite(&testGetLeaderSuite{})
+
+type testGetLeaderSuite struct {
+	svr  *Server
+	wg   sync.WaitGroup
+	done chan bool
+}
+
+func (s *testGetLeaderSuite) SetUpSuite(c *C) {
+	cfg := NewTestSingleConfig()
+
+	// Send requests before server has started.
+	s.wg.Add(1)
+	s.done = make(chan bool)
+	go s.sendRequest(c, cfg.ClientUrls)
+	time.Sleep(100 * time.Millisecond)
+
+	svr, err := NewServer(cfg)
+	c.Assert(err, IsNil)
+	go svr.Run()
+
+	s.svr = svr
+}
+
+func (s *testGetLeaderSuite) TearDownSuite(c *C) {
+	s.svr.Close()
+	cleanServer(s.svr.cfg)
+}
+
+func (s *testGetLeaderSuite) TestGetLeader(c *C) {
+	mustWaitLeader(c, []*Server{s.svr})
+
+	leader, err := s.svr.GetLeader()
+	c.Assert(err, IsNil)
+	c.Assert(leader, NotNil)
+
+	s.done <- true
+	s.wg.Wait()
+}
+
+func (s *testGetLeaderSuite) sendRequest(c *C, addr string) {
+	defer s.wg.Done()
+
+	req := &pdpb.Request{
+		CmdType: pdpb.CommandType_AllocId,
+		AllocId: &pdpb.AllocIdRequest{},
+	}
+
+	for {
+		select {
+		case <-s.done:
+			return
+		default:
+			// We don't need to check the response and errror,
+			// just make sure the server will not panic.
+			conn, err := rpcConnect(addr)
+			if err == nil {
+				rpcCall(conn, 0, req)
+				conn.Close()
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/server/leader_test.go
+++ b/server/leader_test.go
@@ -74,7 +74,7 @@ func (s *testGetLeaderSuite) sendRequest(c *C, addr string) {
 		case <-s.done:
 			return
 		default:
-			// We don't need to check the response and errror,
+			// We don't need to check the response and error,
 			// just make sure the server will not panic.
 			conn, err := rpcConnect(addr)
 			if err == nil {

--- a/server/server.go
+++ b/server/server.go
@@ -96,7 +96,7 @@ func CreateServer(cfg *Config) (*Server, error) {
 		cfg:           cfg,
 		isLeaderValue: 0,
 		conns:         make(map[*conn]struct{}),
-		closed:        0,
+		closed:        1,
 		rootPath:      path.Join(pdRootPath, strconv.FormatUint(cfg.ClusterID, 10)),
 	}
 
@@ -155,6 +155,8 @@ func (s *Server) StartEtcd(apiHandler http.Handler) error {
 	s.client = client
 	s.id = uint64(etcd.Server.ID())
 
+	// Server has started.
+	atomic.StoreInt64(&s.closed, 0)
 	return nil
 }
 


### PR DESCRIPTION
PD will panic if it try to `GetLeader()` before `s.client` is ready in startup.