### PR TITLE
Cleanup GetRaftCluster() and fix API errors.

### DIFF
--- a/pd-client/client_test.go
+++ b/pd-client/client_test.go
@@ -197,8 +197,7 @@ func (s *testClientSuite) TestGetStore(c *C) {
 	c.Assert(n, DeepEquals, store)
 
 	// Get a removed store should return error.
-	cluster, err := s.srv.GetRaftCluster()
-	c.Assert(err, IsNil)
+	cluster := s.srv.GetRaftCluster()
 	c.Assert(cluster, NotNil)
 	err = cluster.RemoveStore(store.GetId())
 	c.Assert(err, IsNil)

--- a/server/api/balancer.go
+++ b/server/api/balancer.go
@@ -38,13 +38,9 @@ func newBalancerHandler(svr *server.Server, rd *render.Render) *balancerHandler 
 }
 
 func (h *balancerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	cluster, err := h.svr.GetRaftCluster()
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
-		return
-	}
+	cluster := h.svr.GetRaftCluster()
 	if cluster == nil {
-		h.rd.JSON(w, http.StatusOK, nil)
+		h.rd.JSON(w, http.StatusInternalServerError, errNotBootstrapped.Error())
 		return
 	}
 
@@ -74,13 +70,9 @@ func newHistoryOperatorHandler(svr *server.Server, rd *render.Render) *historyOp
 }
 
 func (h *historyOperatorHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	cluster, err := h.svr.GetRaftCluster()
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
-		return
-	}
+	cluster := h.svr.GetRaftCluster()
 	if cluster == nil {
-		h.rd.JSON(w, http.StatusOK, nil)
+		h.rd.JSON(w, http.StatusInternalServerError, errNotBootstrapped.Error())
 		return
 	}
 

--- a/server/api/cluster.go
+++ b/server/api/cluster.go
@@ -33,13 +33,9 @@ func newClusterHandler(svr *server.Server, rd *render.Render) *clusterHandler {
 }
 
 func (h *clusterHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	cluster, err := h.svr.GetRaftCluster()
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
-		return
-	}
+	cluster := h.svr.GetRaftCluster()
 	if cluster == nil {
-		h.rd.JSON(w, http.StatusOK, nil)
+		h.rd.JSON(w, http.StatusInternalServerError, errNotBootstrapped.Error())
 		return
 	}
 

--- a/server/api/config.go
+++ b/server/api/config.go
@@ -40,7 +40,7 @@ func (h *confHandler) Post(w http.ResponseWriter, r *http.Request) {
 	config := &server.BalanceConfig{}
 	err := fromBody(r, config)
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 

--- a/server/api/event.go
+++ b/server/api/event.go
@@ -39,13 +39,9 @@ func newFeedHandler(svr *server.Server, rd *render.Render) *feedHandler {
 }
 
 func (h *feedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	cluster, err := h.svr.GetRaftCluster()
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
-		return
-	}
+	cluster := h.svr.GetRaftCluster()
 	if cluster == nil {
-		h.rd.JSON(w, http.StatusOK, nil)
+		h.rd.JSON(w, http.StatusInternalServerError, errNotBootstrapped.Error())
 		return
 	}
 
@@ -57,7 +53,7 @@ func (h *feedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	offset, err := strconv.ParseUint(offsetStr, 10, 64)
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -78,13 +74,9 @@ func newEventsHandler(svr *server.Server, rd *render.Render) *eventsHandler {
 }
 
 func (h *eventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	cluster, err := h.svr.GetRaftCluster()
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
-		return
-	}
+	cluster := h.svr.GetRaftCluster()
 	if cluster == nil {
-		h.rd.JSON(w, http.StatusOK, nil)
+		h.rd.JSON(w, http.StatusInternalServerError, errNotBootstrapped.Error())
 		return
 	}
 
@@ -133,11 +125,7 @@ func (h *wsHandler) fetchEventFeed() {
 	for {
 		time.Sleep(1 * time.Second)
 
-		cluster, err := h.svr.GetRaftCluster()
-		if err != nil {
-			log.Error(err)
-			continue
-		}
+		cluster := h.svr.GetRaftCluster()
 		if cluster == nil {
 			continue
 		}

--- a/server/api/event.go
+++ b/server/api/event.go
@@ -123,7 +123,7 @@ func (h *wsHandler) fanout() {
 
 func (h *wsHandler) fetchEventFeed() {
 	for {
-		time.Sleep(1 * time.Second)
+		time.Sleep(time.Second)
 
 		cluster := h.svr.GetRaftCluster()
 		if cluster == nil {

--- a/server/api/member.go
+++ b/server/api/member.go
@@ -51,7 +51,7 @@ func (h *memberListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	listResp, err := client.MemberList(ctx)
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -92,7 +92,7 @@ func (h *memberDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	defer cancel()
 	listResp, err := client.MemberList(ctx)
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	for _, m := range listResp.Members {
@@ -111,7 +111,7 @@ func (h *memberDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	defer cancel()
 	_, err = client.MemberRemove(ctx, id)
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	h.rd.JSON(w, http.StatusOK, fmt.Sprintf("removed, pd: %s", name))
@@ -137,7 +137,7 @@ func newLeaderHandler(svr *server.Server, rd *render.Render) *leaderHandler {
 func (h *leaderHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	leader, err := h.svr.GetLeader()
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -46,13 +46,9 @@ func newRegionHandler(svr *server.Server, rd *render.Render) *regionHandler {
 }
 
 func (h *regionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	cluster, err := h.svr.GetRaftCluster()
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
-		return
-	}
+	cluster := h.svr.GetRaftCluster()
 	if cluster == nil {
-		h.rd.JSON(w, http.StatusOK, nil)
+		h.rd.JSON(w, http.StatusInternalServerError, errNotBootstrapped.Error())
 		return
 	}
 
@@ -60,7 +56,7 @@ func (h *regionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	regionIDStr := vars["id"]
 	regionID, err := strconv.ParseUint(regionIDStr, 10, 64)
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -85,13 +81,9 @@ func newRegionsHandler(svr *server.Server, rd *render.Render) *regionsHandler {
 }
 
 func (h *regionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	cluster, err := h.svr.GetRaftCluster()
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
-		return
-	}
+	cluster := h.svr.GetRaftCluster()
 	if cluster == nil {
-		h.rd.JSON(w, http.StatusOK, nil)
+		h.rd.JSON(w, http.StatusInternalServerError, errNotBootstrapped.Error())
 		return
 	}
 

--- a/server/api/server.go
+++ b/server/api/server.go
@@ -14,6 +14,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -22,6 +23,10 @@ import (
 )
 
 const apiPrefix = "/pd"
+
+var (
+	errNotBootstrapped = errors.New("cluster is not bootstrapped")
+)
 
 // NewHandler creates a HTTP handler for API.
 func NewHandler(svr *server.Server) http.Handler {

--- a/server/api/store.go
+++ b/server/api/store.go
@@ -46,13 +46,9 @@ func newStoreHandler(svr *server.Server, rd *render.Render) *storeHandler {
 }
 
 func (h *storeHandler) Get(w http.ResponseWriter, r *http.Request) {
-	cluster, err := h.svr.GetRaftCluster()
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
-		return
-	}
+	cluster := h.svr.GetRaftCluster()
 	if cluster == nil {
-		h.rd.JSON(w, http.StatusOK, nil)
+		h.rd.JSON(w, http.StatusInternalServerError, errNotBootstrapped.Error())
 		return
 	}
 
@@ -60,13 +56,13 @@ func (h *storeHandler) Get(w http.ResponseWriter, r *http.Request) {
 	storeIDStr := vars["id"]
 	storeID, err := strconv.ParseUint(storeIDStr, 10, 64)
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
 	store, status, err := cluster.GetStore(storeID)
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -80,13 +76,9 @@ func (h *storeHandler) Get(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *storeHandler) Delete(w http.ResponseWriter, r *http.Request) {
-	cluster, err := h.svr.GetRaftCluster()
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
-		return
-	}
+	cluster := h.svr.GetRaftCluster()
 	if cluster == nil {
-		h.rd.JSON(w, http.StatusOK, nil)
+		h.rd.JSON(w, http.StatusInternalServerError, errNotBootstrapped.Error())
 		return
 	}
 
@@ -119,13 +111,9 @@ func newStoresHandler(svr *server.Server, rd *render.Render) *storesHandler {
 }
 
 func (h *storesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	cluster, err := h.svr.GetRaftCluster()
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err)
-		return
-	}
+	cluster := h.svr.GetRaftCluster()
 	if cluster == nil {
-		h.rd.JSON(w, http.StatusOK, nil)
+		h.rd.JSON(w, http.StatusInternalServerError, errNotBootstrapped.Error())
 		return
 	}
 
@@ -138,7 +126,7 @@ func (h *storesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for _, s := range stores {
 		store, status, err := cluster.GetStore(s.GetId())
 		if err != nil {
-			h.rd.JSON(w, http.StatusInternalServerError, err)
+			h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 

--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -54,8 +54,8 @@ func (s *testClusterCacheSuite) TestCache(c *C) {
 	_, err = s.svr.bootstrapCluster(req.Bootstrap)
 	c.Assert(err, IsNil)
 
-	cluster, err := s.svr.GetRaftCluster()
-	c.Assert(err, IsNil)
+	cluster := s.svr.GetRaftCluster()
+	c.Assert(cluster, NotNil)
 
 	stats := &pdpb.StoreStats{
 		StoreId:            store1.GetId(),
@@ -203,8 +203,7 @@ func (s *testClusterCacheSuite) TestCache(c *C) {
 		store2.GetId(): store2,
 	}
 
-	cluster, err = s.svr.GetRaftCluster()
-	c.Assert(err, IsNil)
+	cluster = s.svr.GetRaftCluster()
 	c.Assert(cluster, IsNil)
 
 	allStores := s.svr.cluster.GetStores()

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -128,12 +128,13 @@ func (s *Server) getClusterRootPath() string {
 }
 
 // GetRaftCluster gets raft cluster.
-func (s *Server) GetRaftCluster() (*RaftCluster, error) {
+// If cluster has not been bootstrapped, return nil.
+func (s *Server) GetRaftCluster() *RaftCluster {
 	if s.cluster.isRunning() {
-		return s.cluster, nil
+		return s.cluster
 	}
 
-	return nil, nil
+	return nil
 }
 
 func (s *Server) createRaftCluster() error {

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -229,8 +229,7 @@ func (s *testClusterBaseSuite) getRegion(c *C, conn net.Conn, clusterID uint64, 
 }
 
 func (s *testClusterBaseSuite) getRaftCluster(c *C) *RaftCluster {
-	cluster, err := s.svr.GetRaftCluster()
-	c.Assert(err, IsNil)
+	cluster := s.svr.GetRaftCluster()
 	c.Assert(cluster, NotNil)
 	return cluster
 }

--- a/server/cluster_worker_test.go
+++ b/server/cluster_worker_test.go
@@ -150,8 +150,8 @@ func (s *testClusterWorkerSuite) newMockRaftStore(c *C, metaStore *metapb.Store)
 		peers:    make(map[uint64]*metapb.Peer),
 	}
 
-	cluster, err := s.svr.GetRaftCluster()
-	c.Assert(err, IsNil)
+	cluster := s.svr.GetRaftCluster()
+	c.Assert(cluster, NotNil)
 
 	err = cluster.putStore(metaStore)
 	c.Assert(err, IsNil)
@@ -197,10 +197,10 @@ func (s *testClusterWorkerSuite) SetUpTest(c *C) {
 	s.newMockRaftStore(c, nil)
 	s.newMockRaftStore(c, nil)
 
-	cluster, err := s.svr.GetRaftCluster()
-	c.Assert(err, IsNil)
+	cluster := s.svr.GetRaftCluster()
+	c.Assert(cluster, NotNil)
 
-	err = cluster.putConfig(&metapb.Cluster{
+	err := cluster.putConfig(&metapb.Cluster{
 		Id:           s.clusterID,
 		MaxPeerCount: 5,
 	})
@@ -215,8 +215,8 @@ func (s *testClusterWorkerSuite) TearDownTest(c *C) {
 }
 
 func (s *testClusterWorkerSuite) checkRegionPeerCount(c *C, regionKey []byte, expectCount int) *metapb.Region {
-	cluster, err := s.svr.GetRaftCluster()
-	c.Assert(err, IsNil)
+	cluster := s.svr.GetRaftCluster()
+	c.Assert(cluster, NotNil)
 
 	region, _ := cluster.getRegion(regionKey)
 	c.Assert(region.Peers, HasLen, expectCount)
@@ -356,12 +356,12 @@ func checkSearchRegions(c *C, cluster *RaftCluster, keys ...[]byte) {
 }
 
 func (s *testClusterWorkerSuite) TestHeartbeatSplit(c *C) {
-	cluster, err := s.svr.GetRaftCluster()
-	c.Assert(err, IsNil)
+	cluster := s.svr.GetRaftCluster()
+	c.Assert(cluster, NotNil)
 
 	meta := cluster.GetConfig()
 	meta.MaxPeerCount = 1
-	err = cluster.putConfig(meta)
+	err := cluster.putConfig(meta)
 	c.Assert(err, IsNil)
 
 	leaderPD := mustGetLeader(c, s.client, s.svr.getLeaderPath())
@@ -417,8 +417,9 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit(c *C) {
 }
 
 func (s *testClusterWorkerSuite) TestHeartbeatSplit2(c *C) {
-	cluster, err := s.svr.GetRaftCluster()
-	c.Assert(err, IsNil)
+	cluster := s.svr.GetRaftCluster()
+	c.Assert(cluster, NotNil)
+
 	r1, _ := cluster.getRegion([]byte("a"))
 	leaderPd := mustGetLeader(c, s.client, s.svr.getLeaderPath())
 	conn, err := rpcConnect(leaderPd.GetAddr())
@@ -452,8 +453,8 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit2(c *C) {
 }
 
 func (s *testClusterWorkerSuite) TestHeartbeatChangePeer(c *C) {
-	cluster, err := s.svr.GetRaftCluster()
-	c.Assert(err, IsNil)
+	cluster := s.svr.GetRaftCluster()
+	c.Assert(cluster, NotNil)
 
 	meta := cluster.GetConfig()
 	c.Assert(meta.GetMaxPeerCount(), Equals, uint32(5))
@@ -513,12 +514,12 @@ func (s *testClusterWorkerSuite) TestHeartbeatChangePeer(c *C) {
 }
 
 func (s *testClusterWorkerSuite) TestHeartbeatSplitAddPeer(c *C) {
-	cluster, err := s.svr.GetRaftCluster()
-	c.Assert(err, IsNil)
+	cluster := s.svr.GetRaftCluster()
+	c.Assert(cluster, NotNil)
 
 	meta := cluster.GetConfig()
 	meta.MaxPeerCount = 2
-	err = cluster.putConfig(meta)
+	err := cluster.putConfig(meta)
 	c.Assert(err, IsNil)
 
 	leaderPD := mustGetLeader(c, s.client, s.svr.getLeaderPath())
@@ -551,8 +552,8 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplitAddPeer(c *C) {
 }
 
 func (s *testClusterWorkerSuite) TestStoreHeartbeat(c *C) {
-	cluster, err := s.svr.GetRaftCluster()
-	c.Assert(err, IsNil)
+	cluster := s.svr.GetRaftCluster()
+	c.Assert(cluster, NotNil)
 
 	stores := cluster.GetStores()
 	c.Assert(stores, HasLen, 5)
@@ -579,8 +580,8 @@ func (s *testClusterWorkerSuite) TestStoreHeartbeat(c *C) {
 }
 
 func (s *testClusterWorkerSuite) TestReportSplit(c *C) {
-	cluster, err := s.svr.GetRaftCluster()
-	c.Assert(err, IsNil)
+	cluster := s.svr.GetRaftCluster()
+	c.Assert(cluster, NotNil)
 
 	stores := cluster.GetStores()
 	c.Assert(stores, HasLen, 5)

--- a/server/command.go
+++ b/server/command.go
@@ -67,10 +67,7 @@ func (c *conn) handleIsBootstrapped(req *pdpb.Request) (*pdpb.Response, error) {
 		return nil, errors.Errorf("invalid is bootstrapped command, but %v", req)
 	}
 
-	cluster, err := c.s.GetRaftCluster()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	cluster := c.s.GetRaftCluster()
 
 	resp := &pdpb.IsBootstrappedResponse{
 		Bootstrapped: proto.Bool(cluster != nil),
@@ -87,10 +84,7 @@ func (c *conn) handleBootstrap(req *pdpb.Request) (*pdpb.Response, error) {
 		return nil, errors.Errorf("invalid bootstrap command, but %v", req)
 	}
 
-	cluster, err := c.s.GetRaftCluster()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	cluster := c.s.GetRaftCluster()
 	if cluster != nil {
 		return newBootstrappedError(), nil
 	}
@@ -99,10 +93,7 @@ func (c *conn) handleBootstrap(req *pdpb.Request) (*pdpb.Response, error) {
 }
 
 func (c *conn) getRaftCluster() (*RaftCluster, error) {
-	cluster, err := c.s.GetRaftCluster()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	cluster := c.s.GetRaftCluster()
 	if cluster == nil {
 		return nil, errors.Trace(errClusterNotBootstrapped)
 	}


### PR DESCRIPTION
1. `GetRaftCluster()` actually never return error.
2. Errors should not be rendered into JSON directly, that will output nothing...