### PR TITLE
server/tso: prevent the same millisecond

### DIFF
--- a/server/tso.go
+++ b/server/tso.go
@@ -89,7 +89,7 @@ func (s *Server) syncTimestamp() error {
 
 	for {
 		now = time.Now()
-		if wait := last.Sub(now); wait > 0 {
+		if wait := last.Sub(now) + time.Millisecond; wait > 0 {
 			log.Warnf("wait %v to guarantee valid generated timestamp", wait)
 			time.Sleep(wait)
 			continue
@@ -121,7 +121,7 @@ func (s *Server) updateTimestamp() error {
 		log.Warnf("clock offset: %v, prev: %v, now: %v", since, prev, now)
 	}
 	// Avoid the same physical time stamp
-	if since <= 0 {
+	if since <= time.Millisecond {
 		log.Warnf("invalid physical timestamp, prev: %v, now: %v, re-update later", prev, now)
 		return nil
 	}
@@ -156,7 +156,7 @@ func (s *Server) getRespTS(count uint32) (pdpb.Timestamp, error) {
 			continue
 		}
 
-		resp.Physical = int64(current.physical.UnixNano()) / 1e6
+		resp.Physical = current.physical.UnixNano() / int64(time.Millisecond)
 		resp.Logical = atomic.AddInt64(&current.logical, int64(count))
 		if resp.Logical >= maxLogical {
 			log.Errorf("logical part outside of max logical interval %v, please check ntp time, retry count %d", resp, i)

--- a/server/tso.go
+++ b/server/tso.go
@@ -26,9 +26,9 @@ import (
 
 const (
 	// update timestamp every updateTimestampStep.
-	updateTimestampStep = 50 * time.Millisecond
-	syncTimestampGuard  = time.Millisecond
-	maxLogical          = int64(1 << 18)
+	updateTimestampStep  = 50 * time.Millisecond
+	updateTimestampGuard = time.Millisecond
+	maxLogical           = int64(1 << 18)
 )
 
 var (
@@ -90,7 +90,7 @@ func (s *Server) syncTimestamp() error {
 
 	for {
 		now = time.Now()
-		if wait := last.Sub(now) + syncTimestampGuard; wait > 0 {
+		if wait := last.Sub(now) + updateTimestampGuard; wait > 0 {
 			log.Warnf("wait %v to guarantee valid generated timestamp", wait)
 			time.Sleep(wait)
 			continue
@@ -122,7 +122,7 @@ func (s *Server) updateTimestamp() error {
 		log.Warnf("clock offset: %v, prev: %v, now: %v", since, prev, now)
 	}
 	// Avoid the same physical time stamp
-	if since <= time.Millisecond {
+	if since <= updateTimestampGuard {
 		log.Warnf("invalid physical timestamp, prev: %v, now: %v, re-update later", prev, now)
 		return nil
 	}

--- a/server/tso.go
+++ b/server/tso.go
@@ -27,6 +27,7 @@ import (
 const (
 	// update timestamp every updateTimestampStep.
 	updateTimestampStep = 50 * time.Millisecond
+	syncTimestampGuard  = time.Millisecond
 	maxLogical          = int64(1 << 18)
 )
 
@@ -89,7 +90,7 @@ func (s *Server) syncTimestamp() error {
 
 	for {
 		now = time.Now()
-		if wait := last.Sub(now) + time.Millisecond; wait > 0 {
+		if wait := last.Sub(now) + syncTimestampGuard; wait > 0 {
 			log.Warnf("wait %v to guarantee valid generated timestamp", wait)
 			time.Sleep(wait)
 			continue


### PR DESCRIPTION
If the previous leader has used the millisecond of the last saved
timestamp, the new leader may use that millisecond too.

So we wait one more millisecond, make sure that the previous and
the new leader will never use the same millisecond.