### PR TITLE
pd-client: no need to watch leader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ endif
 	mv vendor _vendor/vendor
 
 clean:
-    # clean unix socket
+	# clean unix socket
 	find . -type s -exec rm {} \;
 
 .PHONY: update clean

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 GO=GO15VENDOREXPERIMENT="1" go
 
-PACKAGES  := $$(go list ./...| grep -vE 'vendor')
+PACKAGES := $$(go list ./...| grep -vE 'vendor')
+
+GOFILTER := grep -vE 'vendor|render.Delims|bindata_assetfs|testutil'
+GOCHECKER := $(GOFILTER) | awk '{ print } END { if (NR > 0) { exit 1 } }'
 
 LDFLAGS += -X "github.com/pingcap/pd/server.PDBuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
 LDFLAGS += -X "github.com/pingcap/pd/server.PDGitHash=$(shell git rev-parse HEAD)"
@@ -21,12 +24,12 @@ build:
 	$(GO) build -ldflags '$(LDFLAGS)' -o bin/pd-server cmd/pd-server/main.go
 	rm -rf vendor
 
-install: 
+install:
 	rm -rf vendor && ln -s _vendor/vendor vendor
 	$(GO) install ./...
 	rm -rf vendor
 
-test: 
+test:
 	rm -rf vendor && ln -s _vendor/vendor vendor
 	$(GO) test --race $(PACKAGES)
 	rm -rf vendor
@@ -34,10 +37,13 @@ test:
 check:
 	go get github.com/golang/lint/golint
 
-	go tool vet . 2>&1 | grep -vE 'vendor|render.Delims|bindata_assetfs' | awk '{print} END{if(NR>0) {exit 1}}'
-	go tool vet --shadow . 2>&1 | grep -vE 'vendor|bindata_assetfs' | awk '{print} END{if(NR>0) {exit 1}}'
-	golint ./... 2>&1 | grep -vE 'vendor|bindata_assetfs' | awk '{print} END{if(NR>0) {exit 1}}'
-	gofmt -s -l . 2>&1 | grep -vE 'vendor|bindata_assetfs' | awk '{print} END{if(NR>0) {exit 1}}'
+	@echo "vet"
+	@ go tool vet . 2>&1 | $(GOCHECKER)
+	@ go tool vet --shadow . 2>&1 | $(GOCHECKER)
+	@echo "golint"
+	@ golint ./... 2>&1 | $(GOCHECKER)
+	@echo "gofmt"
+	@ gofmt -s -l . 2>&1 | $(GOCHECKER)
 
 update:
 	which glide >/dev/null || curl https://glide.sh/get | sh
@@ -55,7 +61,7 @@ endif
 	mv vendor _vendor/vendor
 
 clean:
-	# clean unix socket
+    # clean unix socket
 	find . -type s -exec rm {} \;
 
 .PHONY: update clean

--- a/pd-client/client.go
+++ b/pd-client/client.go
@@ -14,24 +14,10 @@
 package pd
 
 import (
-	"path"
-	"strconv"
-	"sync"
-	"time"
-
-	"github.com/coreos/etcd/clientv3"
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
-	"golang.org/x/net/context"
-)
-
-const (
-	pdRootPath        = "/pd"
-	requestTimeout    = 10 * time.Second
-	connectTimeout    = 30 * time.Second
-	maxRetryGetLeader = 100
 )
 
 // Client is a PD (Placement Driver) client.
@@ -54,67 +40,19 @@ type Client interface {
 }
 
 type client struct {
-	clusterID   uint64
-	etcdClient  *clientv3.Client
-	workerMutex sync.RWMutex
-	worker      *rpcWorker
-	wg          sync.WaitGroup
-	quit        chan struct{}
-}
-
-func getLeaderPath(clusterID uint64) string {
-	return path.Join(pdRootPath, strconv.FormatUint(clusterID, 10), "leader")
+	worker *rpcWorker
 }
 
 // NewClient creates a PD client.
-func NewClient(etcdAddrs []string, clusterID uint64) (Client, error) {
-	log.Infof("[pd] create etcd client with endpoints %v", etcdAddrs)
-	etcdClient, err := clientv3.New(clientv3.Config{
-		Endpoints:   etcdAddrs,
-		DialTimeout: connectTimeout,
-	})
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	leaderPath := getLeaderPath(clusterID)
-
-	var (
-		leaderAddr string
-		revision   int64
-	)
-
-	for i := 0; i < maxRetryGetLeader; i++ {
-		leaderAddr, revision, err = getLeader(etcdClient, leaderPath)
-		if err == nil {
-			break
-		}
-
-		time.Sleep(50 * time.Millisecond)
-	}
-
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
+func NewClient(pdAddrs []string, clusterID uint64) (Client, error) {
+	log.Infof("[pd] create pd client with endpoints %v", pdAddrs)
 	client := &client{
-		clusterID:  clusterID,
-		etcdClient: etcdClient,
-		worker:     newRPCWorker(leaderAddr, clusterID),
-		quit:       make(chan struct{}),
+		worker: newRPCWorker(pdAddrs, clusterID),
 	}
-
-	client.wg.Add(1)
-	go client.watchLeader(leaderPath, revision)
-
 	return client, nil
 }
 
 func (c *client) Close() {
-	c.etcdClient.Close()
-
-	close(c.quit)
-	// Must wait watchLeader done.
-	c.wg.Wait()
 	c.worker.stop(errors.New("[pd] pd-client closing"))
 }
 
@@ -122,9 +60,7 @@ func (c *client) GetTS() (int64, int64, error) {
 	req := &tsoRequest{
 		done: make(chan error, 1),
 	}
-	c.workerMutex.RLock()
 	c.worker.requests <- req
-	c.workerMutex.RUnlock()
 	err := <-req.done
 	return req.physical, req.logical, err
 }
@@ -136,9 +72,7 @@ func (c *client) GetRegion(key []byte) (*metapb.Region, *metapb.Peer, error) {
 		},
 		done: make(chan error, 1),
 	}
-	c.workerMutex.RLock()
 	c.worker.requests <- req
-	c.workerMutex.RUnlock()
 	err := <-req.done
 	if err != nil {
 		return nil, nil, errors.Trace(err)
@@ -153,9 +87,7 @@ func (c *client) GetStore(storeID uint64) (*metapb.Store, error) {
 		},
 		done: make(chan error, 1),
 	}
-	c.workerMutex.RLock()
 	c.worker.requests <- req
-	c.workerMutex.RUnlock()
 	err := <-req.done
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -168,70 +100,4 @@ func (c *client) GetStore(storeID uint64) (*metapb.Store, error) {
 		return nil, nil
 	}
 	return store, nil
-}
-
-// Use var here is for test changing.
-// TODO: refactor this after etcd fixes https://github.com/coreos/etcd/issues/5985
-var defaultWatchLeaderTimeout = 30 * time.Second
-
-func (c *client) watchLeader(leaderPath string, revision int64) {
-	defer c.wg.Done()
-
-	for {
-		log.Infof("[pd] start watch pd leader on path %v, revision %v", leaderPath, revision)
-		ctx, cancel := context.WithTimeout(c.etcdClient.Ctx(), defaultWatchLeaderTimeout)
-		rch := c.etcdClient.Watch(ctx, leaderPath, clientv3.WithRev(revision))
-
-		for resp := range rch {
-			if resp.Canceled {
-				log.Warn("[pd] leader watcher canceled")
-				break
-			}
-
-			// We don't watch any changed, no need to check leader again.
-			if len(resp.Events) == 0 {
-				break
-			}
-
-			leaderAddr, rev, err := getLeader(c.etcdClient, leaderPath)
-			if err != nil {
-				log.Warn(err)
-				break
-			}
-
-			log.Infof("[pd] found new pd-server leader addr: %v", leaderAddr)
-			c.workerMutex.Lock()
-			c.worker.stop(errors.New("[pd] leader change"))
-			c.worker = newRPCWorker(leaderAddr, c.clusterID)
-			c.workerMutex.Unlock()
-			revision = rev
-		}
-
-		cancel()
-
-		select {
-		case <-c.quit:
-			return
-		default:
-		}
-	}
-}
-
-func getLeader(etcdClient *clientv3.Client, path string) (string, int64, error) {
-	kv := clientv3.NewKV(etcdClient)
-	ctx, cancel := context.WithTimeout(etcdClient.Ctx(), requestTimeout)
-	resp, err := kv.Get(ctx, path)
-	cancel()
-	if err != nil {
-		return "", 0, errors.Trace(err)
-	}
-	if len(resp.Kvs) != 1 {
-		return "", 0, errors.Errorf("invalid getLeader resp: %v", resp)
-	}
-
-	var leader pdpb.Leader
-	if err = leader.Unmarshal(resp.Kvs[0].Value); err != nil {
-		return "", 0, errors.Trace(err)
-	}
-	return leader.GetAddr(), resp.Header.Revision, nil
 }

--- a/pd-client/client_test.go
+++ b/pd-client/client_test.go
@@ -80,7 +80,7 @@ type testClientSuite struct {
 func (s *testClientSuite) SetUpSuite(c *C) {
 	s.srv, s.cleanup = newServer(c, clusterID)
 
-	mustWaitLeader(c, []*server.Server{s.srv})
+	mustWaitLeader(c, map[string]*server.Server{s.srv.GetAddr(): s.srv})
 	bootstrapServer(c, s.srv.GetAddr())
 
 	var err error
@@ -112,7 +112,7 @@ func newServer(c *C, clusterID uint64) (*server.Server, cleanupFunc) {
 	return s, cleanup
 }
 
-func mustWaitLeader(c *C, svrs []*server.Server) *server.Server {
+func mustWaitLeader(c *C, svrs map[string]*server.Server) *server.Server {
 	for i := 0; i < 500; i++ {
 		for _, s := range svrs {
 			if s.IsLeader() {

--- a/pd-client/client_test.go
+++ b/pd-client/client_test.go
@@ -21,9 +21,8 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
-	"github.com/pingcap/kvproto/pkg/msgpb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
-	"github.com/pingcap/kvproto/pkg/util"
+	"github.com/pingcap/pd/pkg/testutil"
 	"github.com/pingcap/pd/server"
 	"github.com/twinj/uuid"
 )
@@ -138,18 +137,7 @@ func bootstrapServer(c *C, addr string) {
 			Region: region,
 		},
 	}
-	msg := &msgpb.Message{
-		MsgType: msgpb.MessageType_PdReq,
-		PdReq:   req,
-	}
-
-	conn, err := rpcConnect(addr)
-	c.Assert(err, IsNil)
-	err = util.WriteMessage(conn, 0, msg)
-	c.Assert(err, IsNil)
-
-	_, err = util.ReadMessage(conn, msg)
-	c.Assert(err, IsNil)
+	testutil.MustRPCRequest(c, addr, req)
 }
 
 func heartbeatRegion(c *C, addr string) {
@@ -164,18 +152,7 @@ func heartbeatRegion(c *C, addr string) {
 			Leader: peer,
 		},
 	}
-	msg := &msgpb.Message{
-		MsgType: msgpb.MessageType_PdReq,
-		PdReq:   req,
-	}
-
-	conn, err := rpcConnect(addr)
-	c.Assert(err, IsNil)
-	err = util.WriteMessage(conn, 0, msg)
-	c.Assert(err, IsNil)
-
-	_, err = util.ReadMessage(conn, msg)
-	c.Assert(err, IsNil)
+	testutil.MustRPCRequest(c, addr, req)
 }
 
 func (s *testClientSuite) TestTSO(c *C) {

--- a/pd-client/conn.go
+++ b/pd-client/conn.go
@@ -43,7 +43,7 @@ type conn struct {
 	net.Conn
 	wg         sync.WaitGroup
 	quit       chan struct{}
-	C          chan *conn
+	ConnChan   chan *conn
 	ReadWriter *bufio.ReadWriter
 }
 
@@ -53,7 +53,7 @@ func newConn(c net.Conn) *conn {
 	return &conn{
 		Conn:       c,
 		quit:       make(chan struct{}),
-		C:          make(chan *conn),
+		ConnChan:   make(chan *conn),
 		ReadWriter: bufio.NewReadWriter(reader, writer),
 	}
 }
@@ -101,7 +101,7 @@ func (c *conn) connectLeader(urls []string, interval time.Duration) {
 		case <-ticker.C:
 			conn, err := rpcConnectLeader(urls)
 			if err == nil {
-				c.C <- newConn(conn)
+				c.ConnChan <- newConn(conn)
 				return
 			}
 			log.Warn(err)

--- a/pd-client/conn.go
+++ b/pd-client/conn.go
@@ -53,7 +53,7 @@ func newConn(c net.Conn) *conn {
 	return &conn{
 		Conn:       c,
 		quit:       make(chan struct{}),
-		ConnChan:   make(chan *conn),
+		ConnChan:   make(chan *conn, 1),
 		ReadWriter: bufio.NewReadWriter(reader, writer),
 	}
 }

--- a/pd-client/conn.go
+++ b/pd-client/conn.go
@@ -1,0 +1,144 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pd
+
+import (
+	"bufio"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/ngaut/deadline"
+	"github.com/ngaut/log"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/pd/pkg/apiutil"
+	"github.com/pingcap/pd/pkg/rpcutil"
+)
+
+const (
+	requestPDTimeout   = time.Second
+	connectPDTimeout   = time.Second * 3
+	reconnectPDTimeout = time.Second * 60
+)
+
+const (
+	readBufferSize  = 8 * 1024
+	writeBufferSize = 8 * 1024
+)
+
+type conn struct {
+	net.Conn
+	wg         sync.WaitGroup
+	quit       chan struct{}
+	C          chan *conn
+	ReadWriter *bufio.ReadWriter
+}
+
+func newConn(c net.Conn) *conn {
+	reader := bufio.NewReaderSize(deadline.NewDeadlineReader(c, requestPDTimeout), readBufferSize)
+	writer := bufio.NewWriterSize(deadline.NewDeadlineWriter(c, requestPDTimeout), writeBufferSize)
+	return &conn{
+		Conn:       c,
+		quit:       make(chan struct{}),
+		C:          make(chan *conn),
+		ReadWriter: bufio.NewReadWriter(reader, writer),
+	}
+}
+
+func mustNewConn(urls []string, quit chan struct{}) *conn {
+	for {
+		conn, err := rpcConnectLeader(urls)
+		if err == nil {
+			return newConn(conn)
+		}
+		log.Warn(err)
+
+		conn, err = rpcConnect(urls)
+		if err == nil {
+			c := newConn(conn)
+			c.wg.Add(1)
+			go c.connectLeader(urls, reconnectPDTimeout)
+			return c
+		}
+		log.Warn(err)
+
+		select {
+		case <-time.After(connectPDTimeout):
+			break
+		case <-quit:
+			return nil
+		}
+	}
+}
+
+func (c *conn) Close() {
+	c.Conn.Close()
+	close(c.quit)
+	c.wg.Wait()
+}
+
+func (c *conn) connectLeader(urls []string, interval time.Duration) {
+	defer c.wg.Done()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			conn, err := rpcConnectLeader(urls)
+			if err == nil {
+				c.C <- newConn(conn)
+				return
+			}
+			log.Warn(err)
+		case <-c.quit:
+			return
+		}
+	}
+}
+
+func getLeader(urls []string) (*pdpb.Leader, error) {
+	for _, u := range urls {
+		client, err := apiutil.NewClient(u, connectPDTimeout)
+		if err != nil {
+			continue
+		}
+		leader, err := client.GetLeader()
+		if err != nil {
+			continue
+		}
+		return leader, nil
+	}
+	return nil, errors.Errorf("failed to get leader from %v", urls)
+}
+
+func rpcConnect(urls []string) (net.Conn, error) {
+	s := strings.Join(urls, ",")
+	return rpcutil.ConnectUrls(s, connectPDTimeout)
+}
+
+func rpcConnectLeader(urls []string) (net.Conn, error) {
+	leader, err := getLeader(urls)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	conn, err := rpcutil.ConnectUrls(leader.GetAddr(), connectPDTimeout)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return conn, nil
+}

--- a/pd-client/leader_change_test.go
+++ b/pd-client/leader_change_test.go
@@ -144,4 +144,5 @@ func mustConnectLeader(c *C, urls []string, leaderAddr string) {
 	// Make sure it will not block forever.
 	conn.wg.Add(1)
 	go conn.connectLeader(urls, time.Second)
+	time.Sleep(time.Second * 3)
 }

--- a/pd-client/leader_change_test.go
+++ b/pd-client/leader_change_test.go
@@ -139,4 +139,9 @@ func mustConnectLeader(c *C, urls []string, leaderAddr string) {
 	case <-time.After(time.Second * 10):
 		c.Fatal("failed to connect to leader")
 	}
+
+	// Create another goroutine and return to close the connection.
+	// Make sure it will not block forever.
+	conn.wg.Add(1)
+	go conn.connectLeader(urls, time.Second)
 }

--- a/pd-client/leader_change_test.go
+++ b/pd-client/leader_change_test.go
@@ -63,8 +63,7 @@ func (s *testLeaderChangeSuite) TestLeaderChange(c *C) {
 		endpoints = append(endpoints, svr.GetEndpoints()...)
 	}
 
-	// wait etcds start ok.
-	time.Sleep(5 * time.Second)
+	mustWaitLeader(c, svrs)
 
 	defer func() {
 		for _, svr := range svrs {
@@ -134,7 +133,7 @@ func mustConnectLeader(c *C, urls []string, leaderAddr string) {
 	go conn.connectLeader(urls, time.Second)
 
 	select {
-	case leaderConn := <-conn.C:
+	case leaderConn := <-conn.ConnChan:
 		addr := leaderConn.RemoteAddr()
 		c.Assert(addr.Network()+"://"+addr.String(), Equals, leaderAddr)
 	case <-time.After(time.Second * 10):

--- a/pd-client/rpc_worker.go
+++ b/pd-client/rpc_worker.go
@@ -130,7 +130,7 @@ RECONNECT:
 		case <-w.quit:
 			conn.Close()
 			return
-		case leaderConn := <-conn.C:
+		case leaderConn := <-conn.ConnChan:
 			conn.Close()
 			conn = leaderConn
 			log.Infof("[pd] reconnected to leader %v", conn.RemoteAddr())

--- a/pd-client/rpc_worker.go
+++ b/pd-client/rpc_worker.go
@@ -15,33 +15,18 @@ package pd
 
 import (
 	"bufio"
-	"net"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/ngaut/deadline"
 	"github.com/ngaut/log"
 	"github.com/pingcap/kvproto/pkg/msgpb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/kvproto/pkg/util"
-	"github.com/pingcap/pd/pkg/apiutil"
 	"github.com/pingcap/pd/pkg/metrics"
-	"github.com/pingcap/pd/pkg/rpcutil"
 	"github.com/twinj/uuid"
-)
-
-const (
-	requestPDTimeout   = time.Second
-	connectPDTimeout   = time.Second * 3
-	reconnectPDTimeout = time.Second * 60
-)
-
-const (
-	readBufferSize  = 8 * 1024
-	writeBufferSize = 8 * 1024
 )
 
 const maxPipelineRequest = 10000
@@ -74,7 +59,7 @@ type clusterConfigRequest struct {
 }
 
 type rpcWorker struct {
-	addrs     []string
+	urls      []string
 	clusterID uint64
 	requests  chan interface{}
 	wg        sync.WaitGroup
@@ -83,7 +68,7 @@ type rpcWorker struct {
 
 func newRPCWorker(addrs []string, clusterID uint64) *rpcWorker {
 	w := &rpcWorker{
-		addrs:     addrs,
+		urls:      addrsToUrls(addrs),
 		clusterID: clusterID,
 		requests:  make(chan interface{}, maxPipelineRequest),
 		quit:      make(chan struct{}),
@@ -116,28 +101,13 @@ func (w *rpcWorker) stop(err error) {
 func (w *rpcWorker) work() {
 	defer w.wg.Done()
 
-	// Add default schema "http://" to addrs.
-	urls := make([]string, 0, len(w.addrs))
-	for _, addr := range w.addrs {
-		if strings.Contains(addr, "://") {
-			urls = append(urls, addr)
-		} else {
-			urls = append(urls, "http://"+addr)
-		}
-	}
-
 RECONNECT:
-	conn, isLeader := w.connectUrls(urls)
+	log.Infof("[pd] connect to pd server %v", w.urls)
+	conn := mustNewConn(w.urls, w.quit)
 	if conn == nil {
-		return
+		return // Closed.
 	}
-	readwriter := newReadWriter(conn)
 	log.Infof("[pd] connected to %v", conn.RemoteAddr())
-
-	// We can't connect to the leader now, try to reconnect later.
-	if !isLeader {
-		time.AfterFunc(reconnectPDTimeout, func() { conn.Close() })
-	}
 
 	for {
 		var pending []interface{}
@@ -153,39 +123,17 @@ RECONNECT:
 					break POP_ALL
 				}
 			}
-			if ok := w.handleRequests(pending, readwriter); !ok {
+			if ok := w.handleRequests(pending, conn.ReadWriter); !ok {
 				conn.Close()
 				goto RECONNECT
 			}
 		case <-w.quit:
 			conn.Close()
 			return
-		}
-	}
-}
-
-// connectUrls tries to connect to the leader first.
-// If it fails, it will try to connect to any urls.
-func (w *rpcWorker) connectUrls(urls []string) (net.Conn, bool) {
-	log.Infof("[pd] connect to pd server %v", urls)
-	for {
-		conn, err := rpcConnectLeader(urls)
-		if err == nil {
-			return conn, true
-		}
-		log.Warn(err)
-
-		conn, err = rpcConnect(urls)
-		if err == nil {
-			return conn, false
-		}
-		log.Warn(err)
-
-		select {
-		case <-time.After(connectPDTimeout):
-			break
-		case <-w.quit:
-			return nil, false
+		case leaderConn := <-conn.C:
+			conn.Close()
+			conn = leaderConn
+			log.Infof("[pd] reconnected to leader %v", conn.RemoteAddr())
 		}
 	}
 }
@@ -392,40 +340,15 @@ func (w *rpcWorker) checkResponse(resp *pdpb.Response) error {
 	return nil
 }
 
-func getLeader(urls []string) (*pdpb.Leader, error) {
-	for _, u := range urls {
-		client, err := apiutil.NewClient(u, connectPDTimeout)
-		if err != nil {
-			continue
+func addrsToUrls(addrs []string) []string {
+	// Add default schema "http://" to addrs.
+	urls := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		if strings.Contains(addr, "://") {
+			urls = append(urls, addr)
+		} else {
+			urls = append(urls, "http://"+addr)
 		}
-		leader, err := client.GetLeader()
-		if err != nil {
-			continue
-		}
-		return leader, nil
 	}
-	return nil, errors.Errorf("failed to get leader from %v", urls)
-}
-
-func rpcConnect(urls []string) (net.Conn, error) {
-	s := strings.Join(urls, ",")
-	return rpcutil.ConnectUrls(s, connectPDTimeout)
-}
-
-func rpcConnectLeader(urls []string) (net.Conn, error) {
-	leader, err := getLeader(urls)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	conn, err := rpcutil.ConnectUrls(leader.GetAddr(), connectPDTimeout)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return conn, nil
-}
-
-func newReadWriter(conn net.Conn) *bufio.ReadWriter {
-	reader := bufio.NewReaderSize(deadline.NewDeadlineReader(conn, requestPDTimeout), readBufferSize)
-	writer := bufio.NewWriterSize(deadline.NewDeadlineWriter(conn, requestPDTimeout), writeBufferSize)
-	return bufio.NewReadWriter(reader, writer)
+	return urls
 }

--- a/pd-client/rpc_worker.go
+++ b/pd-client/rpc_worker.go
@@ -132,6 +132,7 @@ RECONNECT:
 		return
 	}
 	readwriter := newReadWriter(conn)
+	log.Infof("[pd] connected to %v", conn.RemoteAddr())
 
 	// We can't connect to the leader now, try to reconnect later.
 	if !isLeader {

--- a/pkg/apiutil/apiutil.go
+++ b/pkg/apiutil/apiutil.go
@@ -1,0 +1,58 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiutil
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/juju/errors"
+)
+
+// ReadJSON reads a JSON data from r and then close it.
+func ReadJSON(r io.ReadCloser, data interface{}) error {
+	defer r.Close()
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	err = json.Unmarshal(b, data)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+// NewHTTPClient returns a HTTP client according to the scheme.
+func NewHTTPClient(scheme string, timeout time.Duration) *http.Client {
+	tr := &http.Transport{}
+	if scheme == "unix" || scheme == "unixs" {
+		tr.Dial = unixDial
+	}
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: tr,
+	}
+}
+
+func unixDial(_, addr string) (net.Conn, error) {
+	return net.Dial("unix", addr)
+}

--- a/pkg/apiutil/client.go
+++ b/pkg/apiutil/client.go
@@ -1,0 +1,70 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiutil
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+)
+
+const (
+	apiPrefix = "/pd/api/v1"
+)
+
+// Client is a client to access PD APIs.
+type Client struct {
+	hc  *http.Client
+	url string
+}
+
+// NewClient returns a client to access PD APIs.
+func NewClient(addr string, timeout time.Duration) (*Client, error) {
+	u, err := url.Parse(addr)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	u.Path = apiPrefix
+
+	scheme := u.Scheme
+	if u.Scheme == "unix" || u.Scheme == "unixs" {
+		u.Scheme = "http"
+	}
+
+	client := &Client{
+		hc:  NewHTTPClient(scheme, timeout),
+		url: u.String(),
+	}
+	return client, nil
+}
+
+// GetLeader returns the PD leader info.
+func (c *Client) GetLeader() (*pdpb.Leader, error) {
+	leaderURL := c.url + "/leader"
+	resp, err := c.hc.Get(leaderURL)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("GET %s: %s", leaderURL, resp.Status)
+	}
+	leader := &pdpb.Leader{}
+	if err := ReadJSON(resp.Body, leader); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return leader, nil
+}

--- a/pkg/rpcutil/connect.go
+++ b/pkg/rpcutil/connect.go
@@ -1,0 +1,68 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcutil
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/juju/errors"
+)
+
+const (
+	rpcPrefix = "/pd/rpc"
+)
+
+// connectURL returns a rpc connection to the url.
+func connectURL(u url.URL, timeout time.Duration) (net.Conn, error) {
+	req, err := http.NewRequest("GET", rpcPrefix, nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var conn net.Conn
+	switch u.Scheme {
+	case "unix", "unixs":
+		conn, err = net.DialTimeout("unix", u.Host, timeout)
+	default:
+		conn, err = net.DialTimeout("tcp", u.Host, timeout)
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if err = req.Write(conn); err != nil {
+		conn.Close()
+		return nil, errors.Trace(err)
+	}
+
+	return conn, nil
+}
+
+// ConnectUrls returns a rpc connection to any one of the urls.
+func ConnectUrls(urls string, timeout time.Duration) (net.Conn, error) {
+	us, err := ParseUrls(urls)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, u := range us {
+		conn, err := connectURL(u, timeout)
+		if err == nil {
+			return conn, nil
+		}
+	}
+	return nil, errors.Errorf("failed to connect to %s", urls)
+}

--- a/pkg/rpcutil/rpcutil.go
+++ b/pkg/rpcutil/rpcutil.go
@@ -1,0 +1,68 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcutil
+
+import (
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/pingcap/kvproto/pkg/msgpb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/kvproto/pkg/util"
+)
+
+// ParseUrls parses a string into multiple urls.
+func ParseUrls(s string) ([]url.URL, error) {
+	items := strings.Split(s, ",")
+	urls := make([]url.URL, 0, len(items))
+	for _, item := range items {
+		u, err := url.Parse(item)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		urls = append(urls, *u)
+	}
+	return urls, nil
+}
+
+// Call sends the request to conn and wait for the response.
+func Call(conn net.Conn, reqID uint64, request *pdpb.Request) (*pdpb.Response, error) {
+	req := &msgpb.Message{
+		MsgType: msgpb.MessageType_PdReq,
+		PdReq:   request,
+	}
+	if err := util.WriteMessage(conn, reqID, req); err != nil {
+		return nil, errors.Trace(err)
+	}
+	resp := &msgpb.Message{}
+	respID, err := util.ReadMessage(conn, resp)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if respID != reqID {
+		return nil, errors.Errorf("message id mismatch: reqID %d respID %d", reqID, respID)
+	}
+	return resp.GetPdResp(), nil
+}
+
+// Request connects to urls, then sends the request and wait for the response.
+func Request(urls string, reqID uint64, request *pdpb.Request) (*pdpb.Response, error) {
+	conn, err := ConnectUrls(urls, 0)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return Call(conn, reqID, request)
+}

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -1,0 +1,36 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"net"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/pd/pkg/rpcutil"
+)
+
+func MustRPCCall(c *C, conn net.Conn, request *pdpb.Request) *pdpb.Response {
+	resp, err := rpcutil.Call(conn, 0, request)
+	c.Assert(err, IsNil)
+	c.Assert(resp, NotNil)
+	return resp
+}
+
+func MustRPCRequest(c *C, urls string, request *pdpb.Request) *pdpb.Response {
+	resp, err := rpcutil.Request(urls, 0, request)
+	c.Assert(err, IsNil)
+	c.Assert(resp, NotNil)
+	return resp
+}

--- a/server/tso_test.go
+++ b/server/tso_test.go
@@ -128,37 +128,3 @@ func (s *testTsoSuite) TestTso(c *C) {
 
 	wg.Wait()
 }
-
-func (s *testTsoSuite) TestSyncTimestamp(c *C) {
-	svr := s.svr
-	mustGetLeader(c, svr.client, svr.getLeaderPath())
-
-	var prevTS int64
-	for i := 0; i < 10; i++ {
-		prev := svr.ts.Load().(*atomicObject).physical
-		prevMS := prev.UnixNano() / int64(time.Millisecond)
-		lastMS := svr.lastSavedTime.UnixNano() / int64(time.Millisecond)
-		if prevMS != lastMS {
-			current := &atomicObject{
-				physical: svr.lastSavedTime,
-			}
-			svr.ts.Store(current)
-		}
-
-		ts, err := svr.getRespTS(1)
-		c.Assert(err, IsNil)
-		newTS := ts.Physical*int64(time.Millisecond) + ts.Logical
-		c.Assert(newTS, Greater, prevTS)
-		prevTS = newTS
-
-		err = svr.resignLeader()
-		c.Assert(err, IsNil)
-		mustGetLeader(c, svr.client, svr.getLeaderPath())
-
-		ts, err = svr.getRespTS(1)
-		c.Assert(err, IsNil)
-		newTS = ts.Physical*int64(time.Millisecond) + ts.Logical
-		c.Assert(newTS, Greater, prevTS)
-		prevTS = newTS
-	}
-}


### PR DESCRIPTION
Since PD server can proxy requests to the leader,
PD client don't need to watch the leader any more.

Now PD client first try to connect to the leader,
if it fails, it will connect to any other PD servers temporarily,
and retry to connect to the leader later.

**Update**:
When we can't connect to the leader, we will connect to any
other servers temporarily. Meanwhile, we delegate a
goroutine to keep trying to connect to the leader. Once the
delegated goroutine connected to the leader, it sends the
connection to the channel, and we can use the leader
connection to replace the old one.

Reference Issues: #293 