### PR TITLE
server/balancer_worker: check in progress operator

### DIFF
--- a/server/balancer_worker.go
+++ b/server/balancer_worker.go
@@ -100,11 +100,15 @@ func (bw *balancerWorker) addBalanceOperator(regionID uint64, op *balanceOperato
 	bw.Lock()
 	defer bw.Unlock()
 
-	// adminOP can replace any operators.
-	if op.Type != adminOP {
-		// Replace the old operator if the new op has higher priority.
-		oldOp, ok := bw.balanceOperators[regionID]
-		if ok && op.Type <= oldOp.Type {
+	oldOp, ok := bw.balanceOperators[regionID]
+	if ok {
+		if oldOp.Index != 0 {
+			// Old operator is still in progress, don't replace it.
+			return false
+		}
+		if op.Type != adminOP && op.Type <= oldOp.Type {
+			// New operator is not an admin operator, and its priority
+			// is not higher than the old one.
 			return false
 		}
 	}

--- a/server/cluster_worker_test.go
+++ b/server/cluster_worker_test.go
@@ -667,8 +667,22 @@ func (s *testClusterWorkerSuite) TestBalanceOperatorPriority(c *C) {
 	// replicaOP finishes immediately, so the op is nil here.
 	c.Assert(op, IsNil)
 
-	// Add an adminOP.
+	// Add an in progress balanceOP.
+	addPeer := s.newPeer(c, 999, 0)
+	addPeerOperator := newAddPeerOperator(region.GetId(), addPeer)
+	bop = newBalanceOperator(region, balanceOP, addPeerOperator, removePeerOperator)
+	bop.Index = 1
+	ok = bw.addBalanceOperator(region.GetId(), bop)
+	c.Assert(ok, IsTrue)
+
+	// New adminOP will not replace an in progress balanceOP.
 	aop := newBalanceOperator(region, adminOP, removePeerOperator)
+	ok = bw.addBalanceOperator(region.GetId(), aop)
+	c.Assert(ok, IsFalse)
+	bw.removeBalanceOperator(region.GetId())
+
+	// Add an adminOP.
+	aop = newBalanceOperator(region, adminOP, removePeerOperator)
 	ok = bw.addBalanceOperator(region.GetId(), aop)
 	c.Assert(ok, IsTrue)
 	// Add an adminOP again is OK.


### PR DESCRIPTION
When an operator is in progress, we should not replace it.

For example, we have a region with 3 peers (A,B,C).  The balancer add
an operator to add a peer D and replace peer A.  Then, the region adds
the peer D and reports to PD that it has 4 peers (A,B,C,D). Now the
replica balancer will take over to remove a peer, and it may remove
peer D, which is not reasonable.

Reference Issues: [TiKV #1084](https://github.com/pingcap/tikv/issues/1084)