### PR TITLE
server: use etcd election for PD leader election

### DIFF
--- a/server/api/redirector.go
+++ b/server/api/redirector.go
@@ -27,6 +27,7 @@ const (
 )
 
 const (
+	errServerIsClosed      = "server is closed"
 	errNoLeaderFound       = "no leader found"
 	errRedirectFailed      = "redirect failed"
 	errRedirectToNotLeader = "redirect to not leader"
@@ -41,6 +42,11 @@ func newRedirector(s *server.Server) *redirector {
 }
 
 func (h *redirector) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	if h.s.IsClosed() {
+		http.Error(w, errServerIsClosed, http.StatusInternalServerError)
+		return
+	}
+
 	if h.s.IsLeader() {
 		next(w, r)
 		return

--- a/server/api/redirector_test.go
+++ b/server/api/redirector_test.go
@@ -121,7 +121,7 @@ func (s *testRedirectorSuite) TestNotLeader(c *C) {
 }
 
 func mustRequest(c *C, s *server.Server) *http.Response {
-	unixAddr := []string{s.GetAddr(), apiPrefix, "/api/v1/version"}
+	unixAddr := []string{s.GetAddr(), apiPrefix, "/api/v1/leader"}
 	httpAddr := mustUnixAddrToHTTPAddr(c, strings.Join(unixAddr, ""))
 	client := newUnixSocketClient()
 	resp, err := client.Get(httpAddr)

--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -41,7 +41,7 @@ func (s *testClusterCacheSuite) TearDownSuite(c *C) {
 }
 
 func (s *testClusterCacheSuite) TestCache(c *C) {
-	leaderPd := mustGetLeader(c, s.client, s.svr.getLeaderPath())
+	leaderPd := mustGetLeader(c, s.svr)
 
 	conn, err := rpcConnect(leaderPd.GetAddr())
 	c.Assert(err, IsNil)

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -426,7 +426,7 @@ func (c *RaftCluster) saveStore(store *metapb.Store) error {
 
 	storePath := makeStoreKey(c.clusterRoot, store.GetId())
 
-	resp, err := c.s.leaderTxn().Then(clientv3.OpPut(storePath, string(storeValue))).Commit()
+	resp, err := c.s.txn().Then(clientv3.OpPut(storePath, string(storeValue))).Commit()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -613,7 +613,7 @@ func (c *RaftCluster) putConfig(meta *metapb.Cluster) error {
 		return errors.Trace(err)
 	}
 
-	resp, err := c.s.leaderTxn().Then(clientv3.OpPut(c.clusterRoot, string(metaValue))).Commit()
+	resp, err := c.s.txn().Then(clientv3.OpPut(c.clusterRoot, string(metaValue))).Commit()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -114,7 +114,7 @@ func (s *testClusterBaseSuite) newRegion(c *C, regionID uint64, startKey []byte,
 }
 
 func (s *testClusterSuite) TestBootstrap(c *C) {
-	leader := mustGetLeader(c, s.client, s.svr.getLeaderPath())
+	leader := mustGetLeader(c, s.svr)
 
 	conn, err := rpcConnect(leader.GetAddr())
 	c.Assert(err, IsNil)
@@ -266,7 +266,7 @@ func (s *testClusterBaseSuite) getClusterConfig(c *C, conn net.Conn, clusterID u
 }
 
 func (s *testClusterSuite) TestGetPutConfig(c *C) {
-	leader := mustGetLeader(c, s.client, s.svr.getLeaderPath())
+	leader := mustGetLeader(c, s.svr)
 
 	conn, err := rpcConnect(leader.GetAddr())
 	c.Assert(err, IsNil)
@@ -492,7 +492,7 @@ func (s *testClusterSuite) TestClosedChannel(c *C) {
 	defer cleanup()
 	go svr.Run()
 
-	leader := mustGetLeader(c, svr.client, svr.getLeaderPath())
+	leader := mustGetLeader(c, svr)
 
 	conn, err := rpcConnect(leader.GetAddr())
 	c.Assert(err, IsNil)

--- a/server/cluster_worker_test.go
+++ b/server/cluster_worker_test.go
@@ -364,7 +364,7 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit(c *C) {
 	err := cluster.putConfig(meta)
 	c.Assert(err, IsNil)
 
-	leaderPD := mustGetLeader(c, s.client, s.svr.getLeaderPath())
+	leaderPD := mustGetLeader(c, s.svr)
 	conn, err := rpcConnect(leaderPD.GetAddr())
 	c.Assert(err, IsNil)
 	defer conn.Close()
@@ -421,7 +421,7 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit2(c *C) {
 	c.Assert(cluster, NotNil)
 
 	r1, _ := cluster.getRegion([]byte("a"))
-	leaderPd := mustGetLeader(c, s.client, s.svr.getLeaderPath())
+	leaderPd := mustGetLeader(c, s.svr)
 	conn, err := rpcConnect(leaderPd.GetAddr())
 	c.Assert(err, IsNil)
 	defer conn.Close()
@@ -464,7 +464,7 @@ func (s *testClusterWorkerSuite) TestHeartbeatChangePeer(c *C) {
 	region, _ := cluster.getRegion(regionKey)
 	c.Assert(region.Peers, HasLen, 1)
 
-	leaderPd := mustGetLeader(c, s.client, s.svr.getLeaderPath())
+	leaderPd := mustGetLeader(c, s.svr)
 
 	conn, err := rpcConnect(leaderPd.GetAddr())
 	c.Assert(err, IsNil)
@@ -522,7 +522,7 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplitAddPeer(c *C) {
 	err := cluster.putConfig(meta)
 	c.Assert(err, IsNil)
 
-	leaderPD := mustGetLeader(c, s.client, s.svr.getLeaderPath())
+	leaderPD := mustGetLeader(c, s.svr)
 	conn, err := rpcConnect(leaderPD.GetAddr())
 	c.Assert(err, IsNil)
 	defer conn.Close()
@@ -558,7 +558,7 @@ func (s *testClusterWorkerSuite) TestStoreHeartbeat(c *C) {
 	stores := cluster.GetStores()
 	c.Assert(stores, HasLen, 5)
 
-	leaderPd := mustGetLeader(c, s.client, s.svr.getLeaderPath())
+	leaderPd := mustGetLeader(c, s.svr)
 	conn, err := rpcConnect(leaderPd.GetAddr())
 	c.Assert(err, IsNil)
 	defer conn.Close()
@@ -586,7 +586,7 @@ func (s *testClusterWorkerSuite) TestReportSplit(c *C) {
 	stores := cluster.GetStores()
 	c.Assert(stores, HasLen, 5)
 
-	leaderPd := mustGetLeader(c, s.client, s.svr.getLeaderPath())
+	leaderPd := mustGetLeader(c, s.svr)
 	conn, err := rpcConnect(leaderPd.GetAddr())
 	c.Assert(err, IsNil)
 	defer conn.Close()
@@ -626,7 +626,7 @@ func (s *testClusterWorkerSuite) TestBalanceOperatorPriority(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	leaderPd := mustGetLeader(c, s.client, s.svr.getLeaderPath())
+	leaderPd := mustGetLeader(c, s.svr)
 	conn, err := rpcConnect(leaderPd.GetAddr())
 	c.Assert(err, IsNil)
 	defer conn.Close()

--- a/server/command.go
+++ b/server/command.go
@@ -219,7 +219,7 @@ func (c *conn) handleRegionHeartbeat(req *pdpb.Request) (*pdpb.Response, error) 
 
 	// TODO: we can update in etcd asynchronously later.
 	if len(ops) > 0 {
-		resp, err := c.s.leaderTxn().Then(ops...).Commit()
+		resp, err := c.s.txn().Then(ops...).Commit()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -75,15 +75,13 @@ func (s *testConnSuite) TestReconnect(c *C) {
 	newLeader.Close()
 	time.Sleep(time.Second)
 
-	// Request will fail with no leader.
+	// Request will fail with no majority.
 	for i := 0; i < 2; i++ {
 		svr := followers[i]
 		if svr != newLeader {
 			resp := mustRequest(c, svr)
 			err := resp.GetHeader().GetError()
 			c.Assert(err, NotNil)
-			c.Logf("Response error: %v", err)
-			c.Assert(svr.IsLeader(), IsFalse)
 		}
 	}
 }

--- a/server/id.go
+++ b/server/id.go
@@ -84,7 +84,7 @@ func (alloc *idAllocator) generate() (uint64, error) {
 
 	end += allocStep
 	value = uint64ToBytes(end)
-	resp, err := alloc.s.leaderTxn(cmp).Then(clientv3.OpPut(key, string(value))).Commit()
+	resp, err := alloc.s.txn().If(cmp).Then(clientv3.OpPut(key, string(value))).Commit()
 	if err != nil {
 		return 0, errors.Trace(err)
 	}

--- a/server/id_test.go
+++ b/server/id_test.go
@@ -44,7 +44,7 @@ func (s *testAllocIDSuite) TearDownSuite(c *C) {
 }
 
 func (s *testAllocIDSuite) TestID(c *C) {
-	mustGetLeader(c, s.client, s.svr.getLeaderPath())
+	mustGetLeader(c, s.svr)
 
 	var last uint64
 	for i := uint64(0); i < allocStep; i++ {
@@ -80,7 +80,7 @@ func (s *testAllocIDSuite) TestID(c *C) {
 }
 
 func (s *testAllocIDSuite) TestCommand(c *C) {
-	leader := mustGetLeader(c, s.client, s.svr.getLeaderPath())
+	leader := mustGetLeader(c, s.svr)
 
 	conn, err := rpcConnect(leader.GetAddr())
 	c.Assert(err, IsNil)

--- a/server/join_test.go
+++ b/server/join_test.go
@@ -108,8 +108,11 @@ func startPdWith(cfg *Config) (*Server, error) {
 		default:
 		}
 
+		go svr.Run()
+
+		// Let the server runs before returning it to prevent data race.
+		time.Sleep(time.Second)
 		svrCh <- svr
-		svr.Run()
 	}()
 
 	timer := time.NewTimer(30 * time.Second)

--- a/server/leader.go
+++ b/server/leader.go
@@ -64,6 +64,7 @@ func (s *Server) leaderLoop() {
 			continue
 		}
 
+		log.Infof("campaign leader ok: %v", s.Name())
 		s.leaderRound(lessor)
 	}
 }

--- a/server/leader.go
+++ b/server/leader.go
@@ -130,5 +130,5 @@ func (s *Server) txn() clientv3.Txn {
 	if lessor != nil {
 		return lessor.Txn()
 	}
-	return newNotLeaderTxn(s.client)
+	return newNotLeaderTxn()
 }

--- a/server/leader.go
+++ b/server/leader.go
@@ -16,234 +16,117 @@ package server
 import (
 	"os"
 	"path"
-	"sync/atomic"
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/mvcc/mvccpb"
-	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/pingcap/kvproto/pkg/pdpb"
-	"golang.org/x/net/context"
 )
 
-// IsLeader returns whether server is leader or not.
+const (
+	campaignInterval = time.Millisecond * 100
+)
+
+// IsLeader returns whether this server is the leader or not.
 func (s *Server) IsLeader() bool {
-	return atomic.LoadInt64(&s.isLeaderValue) == 1
+	return s.getLessor() != nil
 }
 
-func (s *Server) enableLeader(b bool) {
-	value := int64(0)
-	if b {
-		value = 1
-	}
-
-	atomic.StoreInt64(&s.isLeaderValue, value)
-
-	// Reset connections and cluster.
-	s.closeAllConnections()
-	s.cluster.stop()
+// GetLeader returns the leader for the current election.
+func (s *Server) GetLeader() (*pdpb.Leader, error) {
+	return GetLeader(s.client, s.leaderPath())
 }
 
-func (s *Server) getLeaderPath() string {
+func (s *Server) leaderPath() string {
 	return path.Join(s.rootPath, "leader")
 }
 
 func (s *Server) leaderLoop() {
 	defer s.wg.Done()
 
-	for {
-		if s.isClosed() {
-			log.Infof("server is closed, return leader loop")
-			return
-		}
-
-		leader, err := s.GetLeader()
-		if err != nil {
-			log.Errorf("get leader err %v", err)
-			time.Sleep(200 * time.Millisecond)
-			continue
-		}
-		if leader != nil {
-			if s.isSameLeader(leader) {
-				// oh, we are already leader, we may meet something wrong
-				// in previous campaignLeader. we can resign and campaign again.
-				log.Warnf("leader is still %s, resign and campaign again", leader)
-				if err = s.resignLeader(); err != nil {
-					log.Errorf("resign leader err %s", err)
-					time.Sleep(200 * time.Millisecond)
-					continue
-				}
-			} else {
-				log.Infof("leader is %s, watch it", leader)
-				s.watchLeader()
-				log.Info("leader changed, try to campaign leader")
-			}
-		}
-
-		if err = s.campaignLeader(); err != nil {
-			log.Errorf("campaign leader err %s", errors.ErrorStack(err))
-		}
-	}
-}
-
-// getLeader gets server leader from etcd.
-func getLeader(c *clientv3.Client, leaderPath string) (*pdpb.Leader, error) {
-	leader := &pdpb.Leader{}
-	ok, err := getProtoMsg(c, leaderPath, leader)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if !ok {
-		return nil, nil
-	}
-
-	return leader, nil
-}
-
-// GetLeader gets pd cluster leader.
-func (s *Server) GetLeader() (*pdpb.Leader, error) {
-	if s.isClosed() {
-		return nil, errors.New("server is closed")
-	}
-	return getLeader(s.client, s.getLeaderPath())
-}
-
-func (s *Server) isSameLeader(leader *pdpb.Leader) bool {
-	return leader.GetAddr() == s.GetAddr() && leader.GetPid() == int64(os.Getpid())
-}
-
-func (s *Server) marshalLeader() string {
 	leader := &pdpb.Leader{
 		Addr: s.GetAddr(),
 		Pid:  int64(os.Getpid()),
 	}
 
-	data, err := leader.Marshal()
-	if err != nil {
-		// can't fail, so panic here.
-		log.Fatalf("marshal leader %s err %v", leader, err)
-	}
+	for !s.IsClosed() {
+		time.Sleep(campaignInterval)
 
-	return string(data)
+		lessor, err := NewLessor(s.client, int(s.cfg.LeaderLease), s.leaderPath())
+		if err != nil {
+			log.Errorf("failed to create lessor: %v", err)
+			continue
+		}
+
+		err = lessor.Campaign(leader)
+		if err != nil {
+			log.Errorf("failed to campaign leader: %v", err)
+			continue
+		}
+
+		s.leaderRound(lessor)
+	}
 }
 
-func (s *Server) campaignLeader() error {
-	log.Debugf("begin to campaign leader %s", s.Name())
+func (s *Server) leaderRound(lessor *Lessor) {
+	s.becomeLeader(lessor)
+	defer s.resignLeader()
 
-	lessor := clientv3.NewLease(s.client)
-	defer lessor.Close()
-
-	start := time.Now()
-	ctx, cancel := context.WithTimeout(s.client.Ctx(), requestTimeout)
-	leaseResp, err := lessor.Grant(ctx, s.cfg.LeaderLease)
-	cancel()
-
-	if cost := time.Now().Sub(start); cost > slowRequestTime {
-		log.Warnf("lessor grants too slow, cost %s", cost)
+	if err := s.createRaftCluster(); err != nil {
+		log.Error(err)
+		return
 	}
 
-	if err != nil {
-		return errors.Trace(err)
+	if err := s.syncTimestamp(); err != nil {
+		log.Error(err)
+		return
 	}
 
-	leaderKey := s.getLeaderPath()
-	// The leader key must not exist, so the CreateRevision is 0.
-	resp, err := s.txn().
-		If(clientv3.Compare(clientv3.CreateRevision(leaderKey), "=", 0)).
-		Then(clientv3.OpPut(leaderKey, s.leaderValue, clientv3.WithLease(clientv3.LeaseID(leaseResp.ID)))).
-		Commit()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if !resp.Succeeded {
-		return errors.New("campaign leader failed, other server may campaign ok")
-	}
-
-	log.Debugf("campaign leader ok %s", s.Name())
-	s.enableLeader(true)
-	defer s.enableLeader(false)
-
-	// Try to create raft cluster.
-	err = s.createRaftCluster()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// Make the leader keepalived.
-	ch, err := lessor.KeepAlive(s.client.Ctx(), clientv3.LeaseID(leaseResp.ID))
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	log.Debug("sync timestamp for tso")
-	if err = s.syncTimestamp(); err != nil {
-		return errors.Trace(err)
-	}
-
-	tsTicker := time.NewTicker(updateTimestampStep)
-	defer tsTicker.Stop()
+	ticker := time.NewTicker(updateTimestampStep)
+	defer ticker.Stop()
 
 	for {
 		select {
-		case _, ok := <-ch:
-			if !ok {
-				log.Info("keep alive channel is closed")
-				return nil
-			}
-		case <-tsTicker.C:
-			if err = s.updateTimestamp(); err != nil {
-				return errors.Trace(err)
-			}
-		case <-s.client.Ctx().Done():
-			return errors.New("server closed")
-		}
-	}
-}
-
-func (s *Server) watchLeader() {
-	watcher := clientv3.NewWatcher(s.client)
-	defer watcher.Close()
-
-	ctx := s.client.Ctx()
-	for {
-		rch := watcher.Watch(ctx, s.getLeaderPath())
-		for wresp := range rch {
-			if wresp.Canceled {
+		case <-ticker.C:
+			if err := s.updateTimestamp(); err != nil {
+				log.Error(err)
 				return
 			}
-
-			for _, ev := range wresp.Events {
-				if ev.Type == mvccpb.DELETE {
-					log.Info("leader is deleted")
-					return
-				}
-			}
-		}
-
-		select {
-		case <-ctx.Done():
-			// server closed, return
+		case <-lessor.Done():
 			return
-		default:
 		}
 	}
 }
 
-func (s *Server) resignLeader() error {
-	// delete leader itself and let others start a new election again.
-	leaderKey := s.getLeaderPath()
-	resp, err := s.leaderTxn().Then(clientv3.OpDelete(leaderKey)).Commit()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if !resp.Succeeded {
-		return errors.New("resign leader failed, we are not leader already")
-	}
+func (s *Server) becomeLeader(lessor *Lessor) {
+	s.lessor.Store(lessor)
+	s.closeAllConnections()
+}
 
+func (s *Server) resignLeader() {
+	lessor := s.getLessor()
+	if lessor != nil {
+		lessor.Close()
+	}
+	s.lessor.Store((*Lessor)(nil))
+	s.closeAllConnections()
+	s.cluster.stop()
+}
+
+func (s *Server) getLessor() *Lessor {
+	lessor := s.lessor.Load()
+	if lessor != nil {
+		return lessor.(*Lessor)
+	}
 	return nil
 }
 
-func (s *Server) leaderCmp() clientv3.Cmp {
-	return clientv3.Compare(clientv3.Value(s.getLeaderPath()), "=", s.leaderValue)
+// txn returns an etcd transaction wrapper. It guarantees that the
+// transaction will be executed only when this server is the leader.
+func (s *Server) txn() clientv3.Txn {
+	lessor := s.getLessor()
+	if lessor != nil {
+		return lessor.Txn()
+	}
+	return newNotLeaderTxn(s.client)
 }

--- a/server/lessor.go
+++ b/server/lessor.go
@@ -15,7 +15,7 @@ package server
 
 import (
 	"github.com/coreos/etcd/clientv3"
-	concurv3 "github.com/coreos/etcd/clientv3/concurrency"
+	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/juju/errors"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"golang.org/x/net/context"
@@ -27,19 +27,19 @@ var (
 
 // Lessor is a wrapper for leader election.
 type Lessor struct {
-	session  *concurv3.Session
-	election *concurv3.Election
+	session  *concurrency.Session
+	election *concurrency.Election
 	compare  clientv3.Cmp
 }
 
 // NewLessor returns a new Lessor.
 func NewLessor(client *clientv3.Client, ttl int, prefix string) (*Lessor, error) {
-	session, err := concurv3.NewSession(client, concurv3.WithTTL(ttl))
+	session, err := concurrency.NewSession(client, concurrency.WithTTL(ttl))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	election := concurv3.NewElection(session, prefix)
+	election := concurrency.NewElection(session, prefix)
 
 	lessor := &Lessor{
 		session:  session,

--- a/server/lessor.go
+++ b/server/lessor.go
@@ -1,0 +1,119 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+
+	"github.com/coreos/etcd/clientv3"
+	concurv3 "github.com/coreos/etcd/clientv3/concurrency"
+	"github.com/juju/errors"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+)
+
+var (
+	errNoLeader = errors.New("no leader elected")
+)
+
+// Lessor is a wrapper for leader election.
+type Lessor struct {
+	session  *concurv3.Session
+	election *concurv3.Election
+	compare  clientv3.Cmp
+}
+
+// NewLessor returns a new Lessor.
+func NewLessor(client *clientv3.Client, ttl int, prefix string) (*Lessor, error) {
+	session, err := concurv3.NewSession(client, concurv3.WithTTL(ttl))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	election := concurv3.NewElection(session, prefix)
+
+	lessor := &Lessor{
+		session:  session,
+		election: election,
+	}
+	return lessor, nil
+}
+
+// Close closes the lessor.
+func (l *Lessor) Close() {
+	l.Resign()
+	l.session.Close()
+}
+
+func (l *Lessor) withTimeout() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(l.session.Client().Ctx(), requestTimeout)
+}
+
+// Campaign blocks until it is elected, or an error occurs.
+// It puts the leader as eligible for the election.
+func (l *Lessor) Campaign(leader *pdpb.Leader) error {
+	ctx, cancel := l.withTimeout()
+	defer cancel()
+
+	value, err := leader.Marshal()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	err = l.election.Campaign(ctx, string(value))
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	l.compare = clientv3.Compare(clientv3.Value(l.election.Key()), "=", string(value))
+	return nil
+}
+
+// Resign resigns the leadership.
+func (l *Lessor) Resign() error {
+	ctx, cancel := l.withTimeout()
+	defer cancel()
+	return l.election.Resign(ctx)
+}
+
+// Done returns a channel that closes when the lease is invalid.
+func (l *Lessor) Done() <-chan struct{} {
+	return l.session.Done()
+}
+
+// Txn returns a transaction wrapper. It guarantees that the
+// transaction will be executed only when the lease is valid.
+func (l *Lessor) Txn() clientv3.Txn {
+	txn := newSlowLogTxn(l.session.Client())
+	return txn.If(l.compare)
+}
+
+// GetLeader returns the leader for the current election.
+func GetLeader(client *clientv3.Client, prefix string) (*pdpb.Leader, error) {
+	ctx, cancel := context.WithTimeout(client.Ctx(), requestTimeout)
+	defer cancel()
+
+	resp, err := client.Get(ctx, prefix, clientv3.WithFirstCreate()...)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(resp.Kvs) == 0 {
+		return nil, errors.Trace(errNoLeader)
+	}
+
+	leader := &pdpb.Leader{}
+	if err := leader.Unmarshal(resp.Kvs[0].Value); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return leader, nil
+}

--- a/server/lessor_test.go
+++ b/server/lessor_test.go
@@ -85,13 +85,15 @@ func (s *testLessorSuite) TestLessor(c *C) {
 		id := int(leader.GetPid())
 		c.Assert(lessors[id], Equals, lessor)
 
-		_, err = lessor.Txn().Then(clientv3.OpPut("hello", "world")).Commit()
+		op := clientv3.OpPut("hello", "world")
+
+		_, err = lessor.Txn().Then(op).Commit()
 		c.Assert(err, IsNil)
 
 		lessor.Close()
 		delete(lessors, id)
 
-		_, err = lessor.Txn().Then(clientv3.OpPut("hello", "world")).Commit()
+		_, err = lessor.Txn().Then(op).Commit()
 		c.Assert(err, NotNil)
 		c.Assert(errors.Cause(err), Equals, errTxnFailed)
 	}

--- a/server/lessor_test.go
+++ b/server/lessor_test.go
@@ -1,0 +1,98 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/embed"
+	"github.com/juju/errors"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+)
+
+var _ = Suite(&testLessorSuite{})
+
+type testLessorSuite struct {
+	etcd   *embed.Etcd
+	client *clientv3.Client
+}
+
+func (s *testLessorSuite) SetUpSuite(c *C) {
+	cfg, err := NewTestSingleConfig().genEmbedEtcdConfig()
+	c.Assert(err, IsNil)
+
+	etcd, err := embed.StartEtcd(cfg)
+	c.Assert(err, IsNil)
+
+	endpoints := []string{cfg.LCUrls[0].String()}
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints: endpoints,
+	})
+	c.Assert(err, IsNil)
+
+	<-etcd.Server.ReadyNotify()
+
+	s.etcd = etcd
+	s.client = client
+}
+
+func (s *testLessorSuite) TearDownSuite(c *C) {
+	s.etcd.Close()
+	s.client.Close()
+}
+
+const (
+	leaderPrefix = "/pd/leader"
+)
+
+func (s *testLessorSuite) TestLessor(c *C) {
+	ch := make(chan *Lessor)
+	lessors := make(map[int]*Lessor)
+
+	for i := 0; i < 3; i++ {
+		lessor, err := NewLessor(s.client, 3, leaderPrefix)
+		c.Assert(err, IsNil)
+
+		go func(id int, lessor *Lessor) {
+			leader := &pdpb.Leader{
+				Pid: int64(id),
+			}
+			err := lessor.Campaign(leader)
+			c.Assert(err, IsNil)
+			ch <- lessor
+		}(i, lessor)
+
+		lessors[i] = lessor
+	}
+
+	for len(lessors) != 0 {
+		lessor := <-ch
+
+		leader, err := GetLeader(s.client, leaderPrefix)
+		c.Assert(err, IsNil)
+
+		id := int(leader.GetPid())
+		c.Assert(lessors[id], Equals, lessor)
+
+		_, err = lessor.Txn().Then(clientv3.OpPut("hello", "world")).Commit()
+		c.Assert(err, IsNil)
+
+		lessor.Close()
+		delete(lessors, id)
+
+		_, err = lessor.Txn().Then(clientv3.OpPut("hello", "world")).Commit()
+		c.Assert(err, NotNil)
+		c.Assert(errors.Cause(err), Equals, errTxnFailed)
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -21,13 +21,44 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/etcd/clientv3"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 )
 
 func TestServer(t *testing.T) {
 	TestingT(t)
+}
+
+// We can put more test utilities below.
+
+const (
+	maxWaitCount = 50
+	waitInterval = time.Millisecond * 200
+)
+
+func mustGetLeader(c *C, s *Server) *pdpb.Leader {
+	for i := 0; i < maxWaitCount; i++ {
+		leader, err := s.GetLeader()
+		if err == nil {
+			return leader
+		}
+		time.Sleep(waitInterval)
+	}
+	c.Fatal()
+	return nil
+}
+
+func mustGetLeaderServer(c *C, servers map[string]*Server) *Server {
+	for i := 0; i < maxWaitCount; i++ {
+		for _, s := range servers {
+			if s.IsLeader() {
+				return s
+			}
+		}
+		time.Sleep(waitInterval)
+	}
+	c.Fatal()
+	return nil
 }
 
 type cleanupFunc func()
@@ -118,16 +149,7 @@ func mustRPCCall(c *C, conn net.Conn, req *pdpb.Request) *pdpb.Response {
 var _ = Suite(&testLeaderServerSuite{})
 
 type testLeaderServerSuite struct {
-	svrs       map[string]*Server
-	leaderPath string
-}
-
-func mustGetEtcdClient(c *C, svrs map[string]*Server) *clientv3.Client {
-	for _, svr := range svrs {
-		return svr.GetClient()
-	}
-	c.Fatal("etcd client none available")
-	return nil
+	svrs map[string]*Server
 }
 
 func (s *testLeaderServerSuite) SetUpSuite(c *C) {
@@ -149,7 +171,6 @@ func (s *testLeaderServerSuite) SetUpSuite(c *C) {
 	for i := 0; i < 3; i++ {
 		svr := <-ch
 		s.svrs[svr.GetAddr()] = svr
-		s.leaderPath = svr.getLeaderPath()
 	}
 }
 
@@ -165,24 +186,10 @@ func (s *testLeaderServerSuite) TestLeader(c *C) {
 		go svr.Run()
 	}
 
-	leader1 := mustGetLeader(c, mustGetEtcdClient(c, s.svrs), s.leaderPath)
-	svr, ok := s.svrs[leader1.GetAddr()]
-	c.Assert(ok, IsTrue)
-	svr.Close()
-	delete(s.svrs, leader1.GetAddr())
+	leader := mustGetLeaderServer(c, s.svrs)
+	leader.Close()
+	delete(s.svrs, leader.GetAddr())
 
-	client := mustGetEtcdClient(c, s.svrs)
-
-	// wait leader changes
-	for i := 0; i < 50; i++ {
-		leader, _ := getLeader(client, s.leaderPath)
-		if leader != nil && leader.GetAddr() != leader1.GetAddr() {
-			break
-		}
-
-		time.Sleep(500 * time.Millisecond)
-	}
-
-	leader2 := mustGetLeader(c, client, s.leaderPath)
-	c.Assert(leader1.GetAddr(), Not(Equals), leader2.GetAddr())
+	newLeader := mustGetLeaderServer(c, s.svrs)
+	c.Assert(leader.GetAddr(), Not(Equals), newLeader.GetAddr())
 }

--- a/server/tso.go
+++ b/server/tso.go
@@ -67,7 +67,7 @@ func (s *Server) saveTimestamp(now time.Time) error {
 	data := uint64ToBytes(uint64(now.UnixNano()))
 	key := s.getTimestampPath()
 
-	resp, err := s.leaderTxn().Then(clientv3.OpPut(key, string(data))).Commit()
+	resp, err := s.txn().Then(clientv3.OpPut(key, string(data))).Commit()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/server/tso_test.go
+++ b/server/tso_test.go
@@ -82,22 +82,8 @@ func (s *testTsoSuite) testGetTimestamp(c *C, conn net.Conn, n int) pdpb.Timesta
 	return res
 }
 
-func mustGetLeader(c *C, client *clientv3.Client, leaderPath string) *pdpb.Leader {
-	for i := 0; i < 20; i++ {
-		leader, err := getLeader(client, leaderPath)
-		c.Assert(err, IsNil)
-		if leader != nil {
-			return leader
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-
-	c.Fatal("get leader error")
-	return nil
-}
-
 func (s *testTsoSuite) TestTso(c *C) {
-	leader := mustGetLeader(c, s.client, s.svr.getLeaderPath())
+	leader := mustGetLeader(c, s.svr)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {

--- a/server/txn.go
+++ b/server/txn.go
@@ -1,0 +1,115 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/juju/errors"
+	"github.com/ngaut/log"
+)
+
+const (
+	requestTimeout  = time.Second * 10
+	slowRequestTime = time.Second * 1
+)
+
+const (
+	successLabel = "success"
+	failureLabel = "failure"
+)
+
+var (
+	errNotLeader = errors.New("server is not leader")
+	errTxnFailed = errors.New("transaction precondition is not satisfied")
+)
+
+type slowLogTxn struct {
+	client  *clientv3.Client
+	compare []clientv3.Cmp
+	success []clientv3.Op
+	failure []clientv3.Op
+}
+
+func newSlowLogTxn(client *clientv3.Client) clientv3.Txn {
+	return &slowLogTxn{client: client}
+}
+
+func (t *slowLogTxn) If(cs ...clientv3.Cmp) clientv3.Txn {
+	t.compare = append(t.compare, cs...)
+	return t
+}
+
+func (t *slowLogTxn) Then(ops ...clientv3.Op) clientv3.Txn {
+	t.success = append(t.success, ops...)
+	return t
+}
+
+func (t *slowLogTxn) Else(ops ...clientv3.Op) clientv3.Txn {
+	t.failure = append(t.failure, ops...)
+	return t
+}
+
+func (t *slowLogTxn) Commit() (*clientv3.TxnResponse, error) {
+	ctx, cancel := context.WithTimeout(t.client.Ctx(), requestTimeout)
+	defer cancel()
+
+	txn := t.client.Txn(ctx)
+	if len(t.compare) > 0 {
+		txn = txn.If(t.compare...)
+	}
+	if len(t.success) > 0 {
+		txn = txn.Then(t.success...)
+	}
+	if len(t.failure) > 0 {
+		txn = txn.Else(t.failure...)
+	}
+
+	start := time.Now()
+	resp, err := txn.Commit()
+	cost := time.Since(start)
+	if cost > slowRequestTime {
+		log.Warnf("txn runs too slow: cost %v err %v", cost, err)
+	}
+
+	label := successLabel
+	if err != nil {
+		label = failureLabel
+	}
+	txnCounter.WithLabelValues(label).Inc()
+	txnDuration.WithLabelValues(label).Observe(cost.Seconds())
+
+	if err != nil {
+		return nil, errors.Trace(err)
+	} else if !resp.Succeeded {
+		return nil, errors.Trace(errTxnFailed)
+	}
+	return resp, nil
+}
+
+type notLeaderTxn struct {
+	clientv3.Txn
+}
+
+func newNotLeaderTxn(client *clientv3.Client) clientv3.Txn {
+	return &notLeaderTxn{
+		Txn: client.Txn(client.Ctx()),
+	}
+}
+
+func (t *notLeaderTxn) Commit() (*clientv3.TxnResponse, error) {
+	return nil, errNotLeader
+}

--- a/server/txn.go
+++ b/server/txn.go
@@ -14,12 +14,12 @@
 package server
 
 import (
-	"context"
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
+	"golang.org/x/net/context"
 )
 
 const (

--- a/server/txn.go
+++ b/server/txn.go
@@ -100,15 +100,15 @@ func (t *slowLogTxn) Commit() (*clientv3.TxnResponse, error) {
 	return resp, nil
 }
 
-type notLeaderTxn struct {
-	clientv3.Txn
-}
+type notLeaderTxn struct{}
 
-func newNotLeaderTxn(client *clientv3.Client) clientv3.Txn {
-	return &notLeaderTxn{
-		Txn: client.Txn(client.Ctx()),
-	}
-}
+func newNotLeaderTxn() clientv3.Txn { return &notLeaderTxn{} }
+
+func (t *notLeaderTxn) If(cs ...clientv3.Cmp) clientv3.Txn { return t }
+
+func (t *notLeaderTxn) Then(ops ...clientv3.Op) clientv3.Txn { return t }
+
+func (t *notLeaderTxn) Else(ops ...clientv3.Op) clientv3.Txn { return t }
 
 func (t *notLeaderTxn) Commit() (*clientv3.TxnResponse, error) {
 	return nil, errNotLeader


### PR DESCRIPTION
Here's a brief introduction about how etcd session and election work.

When a session is created, it requests a lease with a ttl, and keeps
alive it automatically.

Then we use the session to create an election under a prefix. When we
campaign with a leader value, the election will save the leader value
under the prefix with the session id. For example, if the prefix is
`/pd/1/leader`, and the session id is 123, then the leader value will be
saved at `/pd/1/leader/123`.  Notice that, multiple elections may save
values under the same prefix concurrently. After the leader value has
been saved, the election will wait until any values created before it
have been deleted. That is, the first created value under the same
prefix is the current leader.

We need to pay attention to one thing. No matter an election becomes
leader or not, it will save its leader value under the prefix. The
benefit is that if one election exits, the other will become leader
immediately because its leader value has already been saved.