### PR TITLE
server: add regionTree

### DIFF
--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -76,7 +76,7 @@ func (s *testClusterCacheSuite) TestCache(c *C) {
 	cacheStore := cluster.cachedCluster.getStore(store1.GetId())
 	c.Assert(cacheStore.store, DeepEquals, store1)
 	c.Assert(cluster.cachedCluster.regions.regions, HasLen, 1)
-	c.Assert(cluster.cachedCluster.regions.searchRegions.Len(), Equals, 1)
+	c.Assert(cluster.cachedCluster.regions.searchRegions.length(), Equals, 1)
 	c.Assert(cluster.cachedCluster.regions.leaders.storeRegions, HasLen, 0)
 	c.Assert(cluster.cachedCluster.regions.leaders.regionStores, HasLen, 0)
 
@@ -116,7 +116,7 @@ func (s *testClusterCacheSuite) TestCache(c *C) {
 
 	cacheRegions := cluster.cachedCluster.regions
 	c.Assert(cacheRegions.regions, HasLen, 1)
-	c.Assert(cacheRegions.searchRegions.Len(), Equals, 1)
+	c.Assert(cacheRegions.searchRegions.length(), Equals, 1)
 	c.Assert(cacheRegions.leaders.storeRegions, HasLen, 0)
 	c.Assert(cacheRegions.leaders.regionStores, HasLen, 0)
 

--- a/server/cluster_worker_test.go
+++ b/server/cluster_worker_test.go
@@ -342,15 +342,10 @@ func mustGetRegion(c *C, cluster *RaftCluster, key []byte, expect *metapb.Region
 
 func checkSearchRegions(c *C, cluster *RaftCluster, keys ...[]byte) {
 	cacheRegions := cluster.cachedCluster.regions
-	c.Assert(cacheRegions.searchRegions.Len(), Equals, len(keys))
+	c.Assert(cacheRegions.searchRegions.length(), Equals, len(keys))
 
 	for _, key := range keys {
-		mockRegion := &metapb.Region{StartKey: key}
-		item := &searchKeyItem{
-			region: mockRegion,
-		}
-
-		getItem := cacheRegions.searchRegions.Get(item)
+		getItem := cacheRegions.searchRegions.search(key)
 		c.Assert(getItem, NotNil)
 	}
 }

--- a/server/region.go
+++ b/server/region.go
@@ -1,0 +1,110 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"log"
+
+	"github.com/google/btree"
+	"github.com/pingcap/kvproto/pkg/metapb"
+)
+
+var _ btree.Item = &regionItem{}
+
+type regionItem struct {
+	region *metapb.Region
+}
+
+// Less returns true if the region start key is greater than the other.
+// So we will sort the region with start key reversely.
+func (r *regionItem) Less(other btree.Item) bool {
+	left := r.region.GetStartKey()
+	right := other.(*regionItem).region.GetStartKey()
+	return bytes.Compare(left, right) > 0
+}
+
+func (r *regionItem) Contains(key []byte) bool {
+	start, end := r.region.GetStartKey(), r.region.GetEndKey()
+	return bytes.Compare(key, start) >= 0 && (len(end) == 0 || bytes.Compare(key, end) < 0)
+}
+
+const (
+	defaultBTreeDegree = 64
+)
+
+type regionTree struct {
+	tree *btree.BTree
+}
+
+func newRegionTree() *regionTree {
+	return &regionTree{
+		tree: btree.New(defaultBTreeDegree),
+	}
+}
+
+func (t *regionTree) length() int {
+	return t.tree.Len()
+}
+
+func (t *regionTree) insert(region *metapb.Region) {
+	item := &regionItem{
+		region: region,
+	}
+
+	oldItem := t.tree.ReplaceOrInsert(item)
+	if oldItem != nil {
+		log.Panicf("insert existed region: %v", region)
+	}
+}
+
+func (t *regionTree) update(region *metapb.Region) {
+	item := &regionItem{
+		region: region,
+	}
+
+	oldItem := t.tree.ReplaceOrInsert(item)
+	if oldItem == nil {
+		log.Panicf("update non exist region: %v", region)
+	}
+}
+
+func (t *regionTree) remove(region *metapb.Region) {
+	item := &regionItem{
+		region: region,
+	}
+
+	oldItem := t.tree.Delete(item)
+	if oldItem == nil {
+		log.Panicf("remove non exist region: %v", region)
+	}
+}
+
+func (t *regionTree) search(regionKey []byte) *metapb.Region {
+	item := &regionItem{
+		region: &metapb.Region{StartKey: regionKey},
+	}
+
+	var result *regionItem
+	t.tree.AscendGreaterOrEqual(item, func(i btree.Item) bool {
+		result = i.(*regionItem)
+		return false
+	})
+
+	if result == nil || !result.Contains(regionKey) {
+		return nil
+	}
+
+	return result.region
+}

--- a/server/region_test.go
+++ b/server/region_test.go
@@ -1,0 +1,80 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/metapb"
+)
+
+var _ = Suite(&testRegionSuite{})
+
+type testRegionSuite struct{}
+
+func (s *testRegionSuite) TestRegionItem(c *C) {
+	item := newRegionItem([]byte("b"), []byte{})
+
+	c.Assert(item.Less(newRegionItem([]byte("a"), []byte{})), IsTrue)
+	c.Assert(item.Less(newRegionItem([]byte("b"), []byte{})), IsFalse)
+	c.Assert(item.Less(newRegionItem([]byte("c"), []byte{})), IsFalse)
+
+	c.Assert(item.Contains([]byte("a")), IsFalse)
+	c.Assert(item.Contains([]byte("b")), IsTrue)
+	c.Assert(item.Contains([]byte("c")), IsTrue)
+
+	item = newRegionItem([]byte("b"), []byte("d"))
+	c.Assert(item.Contains([]byte("a")), IsFalse)
+	c.Assert(item.Contains([]byte("b")), IsTrue)
+	c.Assert(item.Contains([]byte("c")), IsTrue)
+	c.Assert(item.Contains([]byte("d")), IsFalse)
+}
+
+func (s *testRegionSuite) TestRegionTree(c *C) {
+	tree := newRegionTree()
+
+	c.Assert(tree.search([]byte("a")), IsNil)
+
+	regionA := newRegionItem([]byte("a"), []byte("b")).region
+	regionC := newRegionItem([]byte("c"), []byte("d")).region
+	regionD := newRegionItem([]byte("d"), []byte{}).region
+
+	tree.insert(regionA)
+	tree.insert(regionC)
+
+	c.Assert(tree.search([]byte{}), IsNil)
+	c.Assert(tree.search([]byte("a")), Equals, regionA)
+	c.Assert(tree.search([]byte("b")), IsNil)
+	c.Assert(tree.search([]byte("c")), Equals, regionC)
+	c.Assert(tree.search([]byte("d")), IsNil)
+	c.Assert(tree.search([]byte("e")), IsNil)
+
+	tree.remove(regionC)
+	tree.insert(regionD)
+
+	c.Assert(tree.search([]byte{}), IsNil)
+	c.Assert(tree.search([]byte("a")), Equals, regionA)
+	c.Assert(tree.search([]byte("b")), IsNil)
+	c.Assert(tree.search([]byte("c")), IsNil)
+	c.Assert(tree.search([]byte("d")), Equals, regionD)
+	c.Assert(tree.search([]byte("e")), Equals, regionD)
+}
+
+func newRegionItem(start, end []byte) *regionItem {
+	return &regionItem{
+		region: &metapb.Region{
+			StartKey: start,
+			EndKey:   end,
+		},
+	}
+}


### PR DESCRIPTION
My intent is to optimize the cache, but it's messed up, and may break a lot of code.
So I will do some pull requests to cleanup the code first.

This PR separates region search related code to the `regionTree`.