### PR TITLE
server: separate store info and add uptime

### DIFF
--- a/pkg/timeutil/duration.go
+++ b/pkg/timeutil/duration.go
@@ -1,0 +1,52 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timeutil
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/errors"
+)
+
+// Duration is a wrapper of time.Duration for TOML and JSON.
+type Duration struct {
+	time.Duration
+}
+
+// NewDuration creates a Duration from time.Duration.
+func NewDuration(duration time.Duration) Duration {
+	return Duration{Duration: duration}
+}
+
+// MarshalJSON returns the duration as a JSON string.
+func (d *Duration) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, d.String())), nil
+}
+
+// UnmarshalJSON parses a JSON string into the duration.
+func (d *Duration) UnmarshalJSON(text []byte) error {
+	duration, err := time.ParseDuration(string(text))
+	if err == nil {
+		d.Duration = duration
+	}
+	return errors.Trace(err)
+}
+
+// UnmarshalText parses a TOML string into the duration.
+func (d *Duration) UnmarshalText(text []byte) error {
+	var err error
+	d.Duration, err = time.ParseDuration(string(text))
+	return errors.Trace(err)
+}

--- a/pkg/timeutil/duration.go
+++ b/pkg/timeutil/duration.go
@@ -15,6 +15,7 @@ package timeutil
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/juju/errors"
@@ -37,11 +38,16 @@ func (d *Duration) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON parses a JSON string into the duration.
 func (d *Duration) UnmarshalJSON(text []byte) error {
-	duration, err := time.ParseDuration(string(text))
-	if err == nil {
-		d.Duration = duration
+	s, err := strconv.Unquote(string(text))
+	if err != nil {
+		return errors.Trace(err)
 	}
-	return errors.Trace(err)
+	duration, err := time.ParseDuration(s)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	d.Duration = duration
+	return nil
 }
 
 // UnmarshalText parses a TOML string into the duration.

--- a/pkg/timeutil/duration_test.go
+++ b/pkg/timeutil/duration_test.go
@@ -1,0 +1,49 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timeutil
+
+import (
+	"encoding/json"
+
+	"github.com/BurntSushi/toml"
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testDurationSuite{})
+
+type testDurationSuite struct{}
+
+type example struct {
+	Interval Duration `json:"interval" toml:"interval"`
+}
+
+func (s *testDurationSuite) TestJSON(c *C) {
+	example := &example{}
+
+	text := []byte(`{"interval":"1h1m1s"}`)
+	c.Assert(json.Unmarshal(text, example), IsNil)
+	c.Assert(example.Interval.Seconds(), Equals, float64(60*60+60+1))
+
+	b, err := json.Marshal(example)
+	c.Assert(err, IsNil)
+	c.Assert(string(b), Equals, string(text))
+}
+
+func (s *testDurationSuite) TestTOML(c *C) {
+	example := &example{}
+
+	text := []byte(`interval = "1h1m1s"`)
+	c.Assert(toml.Unmarshal(text, example), IsNil)
+	c.Assert(example.Interval.Seconds(), Equals, float64(60*60+60+1))
+}

--- a/pkg/timeutil/timeutil_test.go
+++ b/pkg/timeutil/timeutil_test.go
@@ -1,0 +1,22 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timeutil
+
+import (
+	"testing"
+
+	. "github.com/pingcap/check"
+)
+
+func Test(t *testing.T) { TestingT(t) }

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -411,10 +411,10 @@ func (rb *replicaBalancer) collectDownPeers(cluster *clusterInfo) []*metapb.Peer
 		if store == nil {
 			continue
 		}
-		if stats.GetDownSeconds() >= rb.cfg.MaxPeerDownDuration.Seconds() {
+		if stats.GetDownSeconds() >= uint64(rb.cfg.MaxPeerDownDuration.Seconds()) {
 			// Peer has been down for too long.
 			downPeers = append(downPeers, peer)
-		} else if store.downSeconds() >= rb.cfg.MaxStoreDownDuration.Seconds() {
+		} else if store.downTime() >= rb.cfg.MaxStoreDownDuration.Duration {
 			// Both peer and store are down, we should do balance.
 			downPeers = append(downPeers, peer)
 		}
@@ -429,7 +429,7 @@ func (rb *replicaBalancer) collectTombstonePeers(cluster *clusterInfo) []*metapb
 		if store == nil {
 			continue
 		}
-		if !store.isUpState() {
+		if !store.isUp() {
 			tombPeers = append(tombPeers, peer)
 		}
 	}

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -106,7 +106,7 @@ func (s *testBalancerSuite) updateStoreState(c *C, clusterInfo *clusterInfo, sto
 	storeInfo := clusterInfo.getStore(storeID)
 	storeInfo.store.State = state
 	clusterInfo.addStore(storeInfo.store)
-	ok := clusterInfo.updateStoreStatus(storeInfo.stats.Stats)
+	ok := clusterInfo.updateStoreStatus(storeInfo.stats.StoreStats)
 	c.Assert(ok, IsTrue)
 }
 

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -531,21 +531,16 @@ func (c *RaftCluster) collectMetrics() {
 		case metapb.StoreState_Tombstone:
 			storeTombstoneCount++
 		}
-		if s.store.GetState() == metapb.StoreState_Tombstone {
+		if s.isTombstone() {
 			continue
 		}
-		if s.downSeconds() >= c.balancerWorker.cfg.MaxStoreDownDuration.Seconds() {
+		if s.downTime() >= c.balancerWorker.cfg.MaxStoreDownDuration.Duration {
 			storeDownCount++
 		}
 
 		// Store stats.
-		stats := s.stats.Stats
-		if stats == nil {
-			continue
-		}
-
-		storageSize += stats.GetCapacity() - stats.GetAvailable()
-		storageCapacity += stats.GetCapacity()
+		storageSize += s.stats.GetUsedSize()
+		storageCapacity += s.stats.GetCapacity()
 		if regionTotalCount < s.stats.TotalRegionCount {
 			regionTotalCount = s.stats.TotalRegionCount
 		}

--- a/server/cluster_worker_test.go
+++ b/server/cluster_worker_test.go
@@ -571,7 +571,7 @@ func (s *testClusterWorkerSuite) TestStoreHeartbeat(c *C) {
 	c.Assert(resp, NotNil)
 
 	store := cluster.cachedCluster.getStore(storeID)
-	c.Assert(stats, DeepEquals, store.stats.Stats)
+	c.Assert(stats, DeepEquals, store.stats.StoreStats)
 }
 
 func (s *testClusterWorkerSuite) TestReportSplit(c *C) {

--- a/server/filter.go
+++ b/server/filter.go
@@ -53,14 +53,10 @@ func newStateFilter(cfg *BalanceConfig) *stateFilter {
 }
 
 func (sf *stateFilter) filterBadStore(store *storeInfo) bool {
-	if !store.isUpState() {
+	if !store.isUp() {
 		return true
 	}
-	if store.stats.Stats == nil {
-		// The store is in unknown state.
-		return true
-	}
-	if store.downSeconds() >= sf.cfg.MaxStoreDownDuration.Seconds() {
+	if store.downTime() >= sf.cfg.MaxStoreDownDuration.Duration {
 		// The store is considered to be down.
 		return true
 	}
@@ -100,11 +96,11 @@ func newSnapCountFilter(cfg *BalanceConfig) *snapCountFilter {
 }
 
 func (sf *snapCountFilter) FilterFromStore(store *storeInfo, args ...interface{}) bool {
-	return uint64(store.stats.Stats.GetSendingSnapCount()) > sf.cfg.MaxSendingSnapCount
+	return uint64(store.stats.GetSendingSnapCount()) > sf.cfg.MaxSendingSnapCount
 }
 
 func (sf *snapCountFilter) FilterToStore(store *storeInfo, args ...interface{}) bool {
-	return uint64(store.stats.Stats.GetReceivingSnapCount()) > sf.cfg.MaxReceivingSnapCount
+	return uint64(store.stats.GetReceivingSnapCount()) > sf.cfg.MaxReceivingSnapCount
 }
 
 type leaderCountFilter struct {

--- a/server/store.go
+++ b/server/store.go
@@ -1,0 +1,120 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+)
+
+// storeInfo contains information about a store.
+type storeInfo struct {
+	store *metapb.Store
+	stats *StoreStatus
+}
+
+func newStoreInfo(store *metapb.Store) *storeInfo {
+	return &storeInfo{
+		store: store,
+		stats: newStoreStatus(),
+	}
+}
+
+func (s *storeInfo) clone() *storeInfo {
+	return &storeInfo{
+		store: proto.Clone(s.store).(*metapb.Store),
+		stats: s.stats.clone(),
+	}
+}
+
+func (s *storeInfo) isUp() bool {
+	return s.store.GetState() == metapb.StoreState_Up
+}
+
+func (s *storeInfo) isOffline() bool {
+	return s.store.GetState() == metapb.StoreState_Offline
+}
+
+func (s *storeInfo) isTombstone() bool {
+	return s.store.GetState() == metapb.StoreState_Tombstone
+}
+
+func (s *storeInfo) downTime() time.Duration {
+	return time.Since(s.stats.LastHeartbeatTS)
+}
+
+func (s *storeInfo) usedRatio() float64 {
+	if s.stats.GetCapacity() == 0 {
+		return 0
+	}
+	return float64(s.stats.GetUsedSize()) / float64(s.stats.GetCapacity())
+}
+
+func (s *storeInfo) leaderRatio() float64 {
+	if s.stats.TotalRegionCount == 0 {
+		return 0
+	}
+	return float64(s.stats.LeaderRegionCount) / float64(s.stats.TotalRegionCount)
+}
+
+// StoreStatus contains information about a store's status.
+type StoreStatus struct {
+	*pdpb.StoreStats
+
+	StartTS           time.Time `json:"start_ts"`
+	LastHeartbeatTS   time.Time `json:"last_heartbeat_ts"`
+	TotalRegionCount  int       `json:"total_region_count"`
+	LeaderRegionCount int       `json:"leader_region_count"`
+}
+
+func newStoreStatus() *StoreStatus {
+	return &StoreStatus{
+		StoreStats: &pdpb.StoreStats{},
+		StartTS:    time.Now(),
+	}
+}
+
+func (s *StoreStatus) clone() *StoreStatus {
+	return &StoreStatus{
+		StoreStats:        proto.Clone(s.StoreStats).(*pdpb.StoreStats),
+		StartTS:           s.StartTS,
+		LastHeartbeatTS:   s.LastHeartbeatTS,
+		TotalRegionCount:  s.TotalRegionCount,
+		LeaderRegionCount: s.LeaderRegionCount,
+	}
+}
+
+func (s *StoreStatus) update(stats *pdpb.StoreStats, totalRegionCount, leaderRegionCount int) {
+	s.StoreStats = stats
+	s.LastHeartbeatTS = time.Now()
+	s.TotalRegionCount = totalRegionCount
+	s.LeaderRegionCount = leaderRegionCount
+}
+
+// GetUptime returns the uptime of the store.
+func (s *StoreStatus) GetUptime() time.Duration {
+	uptime := s.LastHeartbeatTS.Sub(s.StartTS)
+	if uptime > 0 {
+		return uptime
+	}
+	return 0
+}
+
+// GetUsedSize returns the used storage size.
+func (s *StoreStatus) GetUsedSize() uint64 {
+	return s.GetCapacity() - s.GetAvailable()
+}


### PR DESCRIPTION
This PR separates the `storeInfo` from the cache to cleanup code of the cache.
A `StartTS` is added to the `StoreStatus` to indicate when the store is started and how long the store has been up.

Close Issue: #339 