### PR TITLE
server: add regionInfo

### DIFF
--- a/server/balancer.go
+++ b/server/balancer.go
@@ -237,13 +237,7 @@ func (lb *leaderBalancer) selectBalanceRegion(cluster *clusterInfo, stores []*st
 	}
 
 	// Random select one leader region from store.
-<<<<<<< HEAD
-	storeID := store.GetId()
-	region := cluster.regions.randLeaderRegion(storeID)
-=======
-	storeID := store.store.GetId()
-	region := cluster.randLeaderRegion(storeID)
->>>>>>> server: add regionInfo
+	region := cluster.randLeaderRegion(store.GetId())
 	if region == nil {
 		return nil, nil
 	}

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/pingcap/kvproto/pkg/metapb"
-	"github.com/pingcap/kvproto/pkg/pdpb"
 )
 
 var (
@@ -127,26 +126,21 @@ func (cb *capacityBalancer) ScoreType() scoreType {
 	return cb.st
 }
 
-func (cb *capacityBalancer) selectBalanceRegion(cluster *clusterInfo, stores []*storeInfo) (*metapb.Region, *metapb.Peer, *metapb.Peer) {
+func (cb *capacityBalancer) selectBalanceRegion(cluster *clusterInfo, stores []*storeInfo) (*regionInfo, *metapb.Peer) {
 	store := selectFromStore(stores, nil, cb.filters, cb.st)
 	if store == nil {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	storeID := store.GetId()
-	meta := cluster.getMeta()
-	if meta.GetMaxPeerCount() == 1 {
-		region := cluster.regions.randLeaderRegion(storeID)
-		if region == nil {
-			return nil, nil, nil
-		}
-
-		leader := leaderPeer(region, storeID)
-		return region, leader, leader
+	region := cluster.randFollowerRegion(storeID)
+	if region == nil {
+		region = cluster.randLeaderRegion(storeID)
 	}
-
-	// Random select one follower region from store.
-	return cluster.regions.randRegion(storeID)
+	if region == nil {
+		return nil, nil
+	}
+	return region, region.GetStorePeer(storeID)
 }
 
 func (cb *capacityBalancer) selectAddPeer(cluster *clusterInfo, stores []*storeInfo, excluded map[uint64]struct{}) (*metapb.Peer, error) {
@@ -187,8 +181,8 @@ func (cb *capacityBalancer) selectRemovePeer(cluster *clusterInfo, peers map[uin
 // The balance type is follower balance.
 func (cb *capacityBalancer) Balance(cluster *clusterInfo) (*score, *balanceOperator, error) {
 	stores := cluster.getStores()
-	region, leader, peer := cb.selectBalanceRegion(cluster, stores)
-	if region == nil || leader == nil || peer == nil {
+	region, peer := cb.selectBalanceRegion(cluster, stores)
+	if region == nil || peer == nil {
 		return nil, nil, nil
 	}
 
@@ -198,8 +192,7 @@ func (cb *capacityBalancer) Balance(cluster *clusterInfo) (*score, *balanceOpera
 	}
 
 	// Select one store to add new peer.
-	excluded := getExcludedStores(region)
-	newPeer, err := cb.selectAddPeer(cluster, stores, excluded)
+	newPeer, err := cb.selectAddPeer(cluster, stores, region.GetStoreIds())
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -237,31 +230,30 @@ func (lb *leaderBalancer) ScoreType() scoreType {
 }
 
 // selectBalanceRegion tries to select a store leader region to do balance.
-func (lb *leaderBalancer) selectBalanceRegion(cluster *clusterInfo, stores []*storeInfo) (*metapb.Region, *metapb.Peer, *metapb.Peer) {
+func (lb *leaderBalancer) selectBalanceRegion(cluster *clusterInfo, stores []*storeInfo) (*regionInfo, *metapb.Peer) {
 	store := selectFromStore(stores, nil, lb.filters, lb.st)
 	if store == nil {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	// Random select one leader region from store.
+<<<<<<< HEAD
 	storeID := store.GetId()
 	region := cluster.regions.randLeaderRegion(storeID)
+=======
+	storeID := store.store.GetId()
+	region := cluster.randLeaderRegion(storeID)
+>>>>>>> server: add regionInfo
 	if region == nil {
-		return nil, nil, nil
+		return nil, nil
 	}
 
-	leader := leaderPeer(region, storeID)
-	if leader == nil {
-		return nil, nil, nil
-	}
-
-	followers := getFollowerPeers(region, leader)
-	newLeader := lb.selectNewLeaderPeer(cluster, followers)
+	newLeader := lb.selectNewLeaderPeer(cluster, region.GetFollowers())
 	if newLeader == nil {
-		return nil, nil, nil
+		return nil, nil
 	}
 
-	return region, leader, newLeader
+	return region, newLeader
 }
 
 func (lb *leaderBalancer) selectNewLeaderPeer(cluster *clusterInfo, peers map[uint64]*metapb.Peer) *metapb.Peer {
@@ -289,8 +281,8 @@ func (lb *leaderBalancer) Balance(cluster *clusterInfo) (*score, *balanceOperato
 	}
 
 	stores := cluster.getStores()
-	region, leader, newLeader := lb.selectBalanceRegion(cluster, stores)
-	if region == nil || leader == nil || newLeader == nil {
+	region, newLeader := lb.selectBalanceRegion(cluster, stores)
+	if region == nil || newLeader == nil {
 		return nil, nil, nil
 	}
 
@@ -299,39 +291,34 @@ func (lb *leaderBalancer) Balance(cluster *clusterInfo) (*score, *balanceOperato
 		return nil, nil, nil
 	}
 
-	score, ok := checkAndGetDiffScore(cluster, leader, newLeader, lb.st, lb.cfg)
+	score, ok := checkAndGetDiffScore(cluster, region.Leader, newLeader, lb.st, lb.cfg)
 	if !ok {
 		return nil, nil, nil
 	}
 
 	regionID := region.GetId()
-	transferLeaderOperator := newTransferLeaderOperator(regionID, leader, newLeader, lb.cfg)
+	transferLeaderOperator := newTransferLeaderOperator(regionID, region.Leader, newLeader, lb.cfg)
 	return score, newBalanceOperator(region, balanceOP, transferLeaderOperator), nil
 }
 
 // replicaBalancer is used to balance active replica count.
 type replicaBalancer struct {
 	*capacityBalancer
-	cfg       *BalanceConfig
-	region    *metapb.Region
-	leader    *metapb.Peer
-	downPeers []*pdpb.PeerStats
+	cfg    *BalanceConfig
+	region *regionInfo
 }
 
-func newReplicaBalancer(region *metapb.Region, leader *metapb.Peer, downPeers []*pdpb.PeerStats, cfg *BalanceConfig) *replicaBalancer {
+func newReplicaBalancer(region *regionInfo, cfg *BalanceConfig) *replicaBalancer {
 	return &replicaBalancer{
 		cfg:              cfg,
 		region:           region,
-		leader:           leader,
-		downPeers:        downPeers,
 		capacityBalancer: newCapacityBalancer(cfg),
 	}
 }
 
 func (rb *replicaBalancer) addPeer(cluster *clusterInfo) (*balanceOperator, error) {
 	stores := cluster.getStores()
-	excluded := getExcludedStores(rb.region)
-	peer, err := rb.selectAddPeer(cluster, stores, excluded)
+	peer, err := rb.selectAddPeer(cluster, stores, rb.region.GetStoreIds())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -350,8 +337,7 @@ func (rb *replicaBalancer) removePeer(cluster *clusterInfo, badPeers []*metapb.P
 		peer = badPeers[0]
 	} else {
 		var err error
-		followers := getFollowerPeers(rb.region, rb.leader)
-		peer, err = rb.selectRemovePeer(cluster, followers)
+		peer, err = rb.selectRemovePeer(cluster, rb.region.GetFollowers())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -386,8 +372,8 @@ func (rb *replicaBalancer) collectBadPeers(cluster *clusterInfo) []*metapb.Peer 
 }
 
 func (rb *replicaBalancer) collectDownPeers(cluster *clusterInfo) []*metapb.Peer {
-	downPeers := make([]*metapb.Peer, 0, len(rb.downPeers))
-	for _, stats := range rb.downPeers {
+	downPeers := make([]*metapb.Peer, 0, len(rb.region.DownPeers))
+	for _, stats := range rb.region.DownPeers {
 		peer := stats.GetPeer()
 		if peer == nil {
 			continue

--- a/server/balancer_worker.go
+++ b/server/balancer_worker.go
@@ -19,8 +19,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
-	"github.com/pingcap/kvproto/pkg/metapb"
-	"github.com/pingcap/kvproto/pkg/pdpb"
 )
 
 type balancerWorker struct {
@@ -252,8 +250,8 @@ func (bw *balancerWorker) doBalance() error {
 	return nil
 }
 
-func (bw *balancerWorker) checkReplicas(region *metapb.Region, leader *metapb.Peer, downPeers []*pdpb.PeerStats) error {
-	bc := newReplicaBalancer(region, leader, downPeers, bw.cfg)
+func (bw *balancerWorker) checkReplicas(region *regionInfo) error {
+	bc := newReplicaBalancer(region, bw.cfg)
 	_, op, err := bc.Balance(bw.cluster)
 	if err != nil {
 		return errors.Trace(err)

--- a/server/balancer_worker_test.go
+++ b/server/balancer_worker_test.go
@@ -39,9 +39,8 @@ func (s *testBalancerWorkerSuite) TestBalancerWorker(c *C) {
 	clusterInfo := s.ts.newClusterInfo(c)
 	c.Assert(clusterInfo, NotNil)
 
-	region, leader := clusterInfo.regions.getRegion([]byte("a"))
+	region := clusterInfo.searchRegion([]byte("a"))
 	c.Assert(region.GetPeers(), HasLen, 1)
-	c.Assert(leader, NotNil)
 
 	s.balancerWorker = newBalancerWorker(clusterInfo, s.ts.cfg)
 
@@ -56,8 +55,8 @@ func (s *testBalancerWorkerSuite) TestBalancerWorker(c *C) {
 	c.Assert(err, IsNil)
 
 	// Add two peers.
-	s.ts.addRegionPeer(c, clusterInfo, 4, region, leader)
-	s.ts.addRegionPeer(c, clusterInfo, 3, region, leader)
+	s.ts.addRegionPeer(c, clusterInfo, 4, region)
+	s.ts.addRegionPeer(c, clusterInfo, 3, region)
 
 	s.ts.cfg.MaxLeaderCount = 1
 
@@ -81,19 +80,19 @@ func (s *testBalancerWorkerSuite) TestBalancerWorker(c *C) {
 	s.ts.cfg.MaxTransferWaitCount = 2
 
 	ctx := newOpContext(nil, nil)
-	ok, res, err := op.Do(ctx, region, leader)
+	ok, res, err := op.Do(ctx, region)
 	c.Assert(err, IsNil)
 	c.Assert(ok, IsFalse)
 	c.Assert(res.GetTransferLeader().GetPeer().GetStoreId(), Equals, newLeaderStoreID)
 	c.Assert(op.Count, Equals, 1)
 
-	ok, res, err = op.Do(ctx, region, leader)
+	ok, res, err = op.Do(ctx, region)
 	c.Assert(err, IsNil)
 	c.Assert(ok, IsFalse)
 	c.Assert(res, IsNil)
 	c.Assert(op.Count, Equals, 2)
 
-	ok, res, err = op.Do(ctx, region, leader)
+	ok, res, err = op.Do(ctx, region)
 	c.Assert(err, NotNil)
 	c.Assert(ok, IsFalse)
 	c.Assert(res, IsNil)

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -362,6 +362,11 @@ func (c *RaftCluster) GetRegionByID(regionID uint64) (*metapb.Region, *metapb.Pe
 	return c.cachedCluster.regions.getRegionByID(regionID)
 }
 
+// GetRegion returns the region from cluster.
+func (c *RaftCluster) GetRegion(regionID uint64) *regionInfo {
+	return c.cachedCluster.getRegion(regionID)
+}
+
 // GetRegions gets regions from cluster.
 func (c *RaftCluster) GetRegions() []*metapb.Region {
 	return c.cachedCluster.regions.getRegions()
@@ -624,7 +629,7 @@ func (c *RaftCluster) putConfig(meta *metapb.Cluster) error {
 // NewAddPeerOperator creates an operator to add a peer to the region.
 // If storeID is 0, it will be chosen according to the balance rules.
 func (c *RaftCluster) NewAddPeerOperator(regionID uint64, storeID uint64) (Operator, error) {
-	region, _ := c.GetRegionByID(regionID)
+	region := c.GetRegion(regionID)
 	if region == nil {
 		return nil, errRegionNotFound(regionID)
 	}
@@ -637,8 +642,7 @@ func (c *RaftCluster) NewAddPeerOperator(regionID uint64, storeID uint64) (Opera
 	cluster := c.cachedCluster
 	if storeID == 0 {
 		cb := newCapacityBalancer(&c.s.cfg.BalanceCfg)
-		excluded := getExcludedStores(region)
-		peer, err = cb.selectAddPeer(cluster, cluster.getStores(), excluded)
+		peer, err = cb.selectAddPeer(cluster, cluster.getStores(), region.GetStoreIds())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -677,7 +681,7 @@ func (c *RaftCluster) NewRemovePeerOperator(regionID uint64, peerID uint64) (Ope
 
 // SetAdminOperator sets the balance operator of the region.
 func (c *RaftCluster) SetAdminOperator(regionID uint64, ops []Operator) error {
-	region, _ := c.GetRegionByID(regionID)
+	region := c.GetRegion(regionID)
 	if region == nil {
 		return errRegionNotFound(regionID)
 	}

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -363,7 +363,7 @@ func (c *RaftCluster) GetRegionByID(regionID uint64) (*metapb.Region, *metapb.Pe
 }
 
 // GetRegion returns the region from cluster.
-func (c *RaftCluster) GetRegion(regionID uint64) *regionInfo {
+func (c *RaftCluster) getRegionByID(regionID uint64) *regionInfo {
 	return c.cachedCluster.getRegion(regionID)
 }
 
@@ -629,7 +629,7 @@ func (c *RaftCluster) putConfig(meta *metapb.Cluster) error {
 // NewAddPeerOperator creates an operator to add a peer to the region.
 // If storeID is 0, it will be chosen according to the balance rules.
 func (c *RaftCluster) NewAddPeerOperator(regionID uint64, storeID uint64) (Operator, error) {
-	region := c.GetRegion(regionID)
+	region := c.getRegionByID(regionID)
 	if region == nil {
 		return nil, errRegionNotFound(regionID)
 	}
@@ -681,7 +681,7 @@ func (c *RaftCluster) NewRemovePeerOperator(regionID uint64, peerID uint64) (Ope
 
 // SetAdminOperator sets the balance operator of the region.
 func (c *RaftCluster) SetAdminOperator(regionID uint64, ops []Operator) error {
-	region := c.GetRegion(regionID)
+	region := c.getRegionByID(regionID)
 	if region == nil {
 		return errRegionNotFound(regionID)
 	}

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -454,7 +454,8 @@ func (s *testClusterSuite) testCheckStores(c *C, conn net.Conn, clusterID uint64
 	// Add a region peer to store.
 	leader := &metapb.Peer{StoreId: store.GetId()}
 	region := s.newRegion(c, 0, []byte{'a'}, []byte{'b'}, []*metapb.Peer{leader}, nil)
-	_, err := cluster.handleRegionHeartbeat(region, leader, nil)
+	regionInfo := newRegionInfo(region, leader)
+	_, err := cluster.handleRegionHeartbeat(regionInfo)
 	c.Assert(err, IsNil)
 	c.Assert(cluster.cachedCluster.regions.getStoreRegionCount(store.GetId()), Equals, 1)
 
@@ -476,7 +477,7 @@ func (s *testClusterSuite) testCheckStores(c *C, conn net.Conn, clusterID uint64
 	// Clear store's region peers.
 	leader.StoreId = 0
 	region.Peers = []*metapb.Peer{leader}
-	_, err = cluster.handleRegionHeartbeat(region, leader, nil)
+	_, err = cluster.handleRegionHeartbeat(regionInfo)
 	c.Assert(err, IsNil)
 	c.Assert(cluster.cachedCluster.regions.getStoreRegionCount(store.GetId()), Equals, 0)
 

--- a/server/cluster_worker_test.go
+++ b/server/cluster_worker_test.go
@@ -636,7 +636,8 @@ func (s *testClusterWorkerSuite) TestBalanceOperatorPriority(c *C) {
 
 	// Add a balanceOP.
 	removePeerOperator := newRemovePeerOperator(region.GetId(), leader)
-	bop := newBalanceOperator(region, balanceOP, removePeerOperator)
+	regionInfo := newRegionInfo(region, leader)
+	bop := newBalanceOperator(regionInfo, balanceOP, removePeerOperator)
 	ok := bw.addBalanceOperator(region.GetId(), bop)
 	c.Assert(ok, IsTrue)
 	// Add a balanceOP again will fail.
@@ -665,19 +666,19 @@ func (s *testClusterWorkerSuite) TestBalanceOperatorPriority(c *C) {
 	// Add an in progress balanceOP.
 	addPeer := s.newPeer(c, 999, 0)
 	addPeerOperator := newAddPeerOperator(region.GetId(), addPeer)
-	bop = newBalanceOperator(region, balanceOP, addPeerOperator, removePeerOperator)
+	bop = newBalanceOperator(regionInfo, balanceOP, addPeerOperator, removePeerOperator)
 	bop.Index = 1
 	ok = bw.addBalanceOperator(region.GetId(), bop)
 	c.Assert(ok, IsTrue)
 
 	// New adminOP will not replace an in progress balanceOP.
-	aop := newBalanceOperator(region, adminOP, removePeerOperator)
+	aop := newBalanceOperator(regionInfo, adminOP, removePeerOperator)
 	ok = bw.addBalanceOperator(region.GetId(), aop)
 	c.Assert(ok, IsFalse)
 	bw.removeBalanceOperator(region.GetId())
 
 	// Add an adminOP.
-	aop = newBalanceOperator(region, adminOP, removePeerOperator)
+	aop = newBalanceOperator(regionInfo, adminOP, removePeerOperator)
 	ok = bw.addBalanceOperator(region.GetId(), aop)
 	c.Assert(ok, IsTrue)
 	// Add an adminOP again is OK.


### PR DESCRIPTION
Wrap region information into regionInfo. regionInfo will be cached after
optimizing the cache, so that we can access different information
about a region more easily.

This commit is tedious and breaks a lot of trivial code.