### PR TITLE
api/member, server/join: use client.Ctx()

### DIFF
--- a/server/api/member.go
+++ b/server/api/member.go
@@ -45,9 +45,9 @@ func newMemberListHandler(svr *server.Server, rd *render.Render) *memberListHand
 }
 
 func (h *memberListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultDialTimeout)
-	defer cancel()
 	client := h.svr.GetClient()
+	ctx, cancel := context.WithTimeout(client.Ctx(), defaultDialTimeout)
+	defer cancel()
 
 	listResp, err := client.MemberList(ctx)
 	if err != nil {
@@ -88,7 +88,7 @@ func (h *memberDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	// step 1. get etcd id
 	var id uint64
 	name := (mux.Vars(r))["name"]
-	ctx, cancel := context.WithTimeout(context.Background(), defaultDialTimeout)
+	ctx, cancel := context.WithTimeout(client.Ctx(), defaultDialTimeout)
 	defer cancel()
 	listResp, err := client.MemberList(ctx)
 	if err != nil {
@@ -107,7 +107,7 @@ func (h *memberDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// step 2. remove member by id
-	ctx, cancel = context.WithTimeout(context.Background(), defaultDialTimeout)
+	ctx, cancel = context.WithTimeout(client.Ctx(), defaultDialTimeout)
 	defer cancel()
 	_, err = client.MemberRemove(ctx, id)
 	if err != nil {

--- a/server/join.go
+++ b/server/join.go
@@ -39,14 +39,14 @@ func genClientV3Config(cfg *Config) clientv3.Config {
 }
 
 func memberAdd(client *clientv3.Client, urls []string) (*clientv3.MemberAddResponse, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultDialTimeout)
+	ctx, cancel := context.WithTimeout(client.Ctx(), defaultDialTimeout)
 	defer cancel()
 
 	return client.MemberAdd(ctx, urls)
 }
 
 func memberList(client *clientv3.Client) (*clientv3.MemberListResponse, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultDialTimeout)
+	ctx, cancel := context.WithTimeout(client.Ctx(), defaultDialTimeout)
 	defer cancel()
 
 	return client.MemberList(ctx)


### PR DESCRIPTION
Derive Context from `client.Ctx()` instead of `Background`.

PTAL @siddontang @huachaohuang 