### PR TITLE
server/cache: reorganize the cache

### DIFF
--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -76,7 +76,7 @@ func (s *testBalancerSuite) newClusterInfo(c *C) *clusterInfo {
 	c.Assert(err, IsNil)
 
 	region := s.newRegion(c, id, []byte{}, []byte{}, []*metapb.Peer{peer}, nil)
-	clusterInfo.addRegion(newRegionInfo(region, peer))
+	clusterInfo.setRegion(newRegionInfo(region, peer))
 
 	stores := clusterInfo.getStores()
 	c.Assert(stores, HasLen, 4)
@@ -117,7 +117,7 @@ func (s *testBalancerSuite) addRegionPeer(c *C, clusterInfo *clusterInfo, storeI
 
 	addRegionPeer(c, region.Region, peer)
 
-	clusterInfo.updateRegion(region)
+	clusterInfo.setRegion(region)
 }
 
 func (s *testBalancerSuite) TestCapacityBalancer(c *C) {
@@ -251,7 +251,7 @@ func (s *testBalancerSuite) TestCapacityBalancer(c *C) {
 	// Set region peers to one peer.
 	peers := region.GetPeers()
 	region.Peers = []*metapb.Peer{leader}
-	clusterInfo.updateRegion(region)
+	clusterInfo.setRegion(region)
 
 	cb = newCapacityBalancer(testCfg)
 	_, bop, err = cb.Balance(clusterInfo)
@@ -281,7 +281,7 @@ func (s *testBalancerSuite) TestCapacityBalancer(c *C) {
 	clusterInfo.setMeta(oldMeta)
 
 	region.Peers = peers
-	clusterInfo.updateRegion(region)
+	clusterInfo.setRegion(region)
 }
 
 // TODO: Refactor these tests, they are quite ugly now.
@@ -455,7 +455,7 @@ func (s *testBalancerSuite) TestReplicaBalancerWithDownPeers(c *C) {
 
 	// Now we have enough active replicas, we can remove the down peer in store 4.
 	addRegionPeer(c, region.Region, op.ChangePeer.GetPeer())
-	clusterInfo.updateRegion(region)
+	clusterInfo.setRegion(region)
 
 	rb = newReplicaBalancer(region, s.cfg)
 	_, bop, err = rb.Balance(clusterInfo)

--- a/server/cache.go
+++ b/server/cache.go
@@ -14,12 +14,12 @@
 package server
 
 import (
-	"log"
 	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/juju/errors"
+	"github.com/ngaut/log"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 )

--- a/server/cache.go
+++ b/server/cache.go
@@ -36,6 +36,12 @@ var (
 	errRegionIsStale = func(region *metapb.Region, origin *metapb.Region) error {
 		return errors.Errorf("region is stale: region %v origin %v", region, origin)
 	}
+	errRegionNotFound = func(regionID uint64) error {
+		return errors.Errorf("region not found: %v", regionID)
+	}
+	errRegionIsStale = func(region *metapb.Region, origin *metapb.Region) error {
+		return errors.Errorf("region is stale: region %v origin %v", region, origin)
+	}
 )
 
 func checkStaleRegion(origin *metapb.Region, region *metapb.Region) error {

--- a/server/cache.go
+++ b/server/cache.go
@@ -14,12 +14,11 @@
 package server
 
 import (
-	"bytes"
-	"math/rand"
+	"log"
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -74,7 +73,7 @@ func (s *storesInfo) getStore(storeID uint64) *storeInfo {
 }
 
 func (s *storesInfo) setStore(store *storeInfo) {
-	s.stores[store.GetId()] = store
+	s.stores[store.GetId()] = store.clone()
 }
 
 func (s *storesInfo) getStores() []*storeInfo {
@@ -97,394 +96,153 @@ func (s *storesInfo) getStoreCount() int {
 	return len(s.stores)
 }
 
-func containPeer(region *metapb.Region, peer *metapb.Peer) bool {
-	for _, p := range region.GetPeers() {
-		if p.GetId() == peer.GetId() {
-			return true
-		}
-	}
-
-	return false
-}
-
-func leaderPeer(region *metapb.Region, storeID uint64) *metapb.Peer {
-	for _, peer := range region.GetPeers() {
-		if peer.GetStoreId() == storeID {
-			return peer
-		}
-	}
-
-	return nil
-}
-
-func cloneRegion(r *metapb.Region) *metapb.Region {
-	return proto.Clone(r).(*metapb.Region)
-}
-
-type leaders struct {
-	// store id -> region id -> struct{}
-	storeRegions map[uint64]map[uint64]struct{}
-	// region id -> store id
-	regionStores map[uint64]uint64
-}
-
-func (l *leaders) remove(regionID uint64) {
-	storeID, ok := l.regionStores[regionID]
-	if !ok {
-		return
-	}
-
-	l.removeStoreRegion(storeID, regionID)
-	delete(l.regionStores, regionID)
-}
-
-func (l *leaders) removeStoreRegion(regionID uint64, storeID uint64) {
-	storeRegions, ok := l.storeRegions[storeID]
-	if ok {
-		delete(storeRegions, regionID)
-		if len(storeRegions) == 0 {
-			delete(l.storeRegions, storeID)
-		}
-	}
-}
-
-func (l *leaders) update(regionID uint64, storeID uint64) {
-	storeRegions, ok := l.storeRegions[storeID]
-	if !ok {
-		storeRegions = make(map[uint64]struct{})
-		l.storeRegions[storeID] = storeRegions
-	}
-	storeRegions[regionID] = struct{}{}
-
-	if lastStoreID, ok := l.regionStores[regionID]; ok && lastStoreID != storeID {
-		l.removeStoreRegion(regionID, lastStoreID)
-	}
-
-	l.regionStores[regionID] = storeID
-}
-
-// regionsInfo is regions cache info.
 type regionsInfo struct {
-	sync.RWMutex
-
-	// region id -> RegionInfo
-	regions map[uint64]*metapb.Region
-	// search key -> region id
-	searchRegions *regionTree
-	// store id -> region count
-	storeRegionCount map[uint64]uint64
-
-	leaders *leaders
+	tree      *regionTree
+	regions   map[uint64]*regionInfo
+	leaders   map[uint64]map[uint64]*regionInfo
+	followers map[uint64]map[uint64]*regionInfo
 }
 
 func newRegionsInfo() *regionsInfo {
 	return &regionsInfo{
-		regions:          make(map[uint64]*metapb.Region),
-		searchRegions:    newRegionTree(),
-		storeRegionCount: make(map[uint64]uint64),
-		leaders: &leaders{
-			storeRegions: make(map[uint64]map[uint64]struct{}),
-			regionStores: make(map[uint64]uint64),
-		},
+		tree:      newRegionTree(),
+		regions:   make(map[uint64]*regionInfo),
+		leaders:   make(map[uint64]map[uint64]*regionInfo),
+		followers: make(map[uint64]map[uint64]*regionInfo),
 	}
 }
 
-// getRegion gets the region and leader peer by regionKey.
-func (r *regionsInfo) getRegion(regionKey []byte) (*metapb.Region, *metapb.Peer) {
-	r.RLock()
-	defer r.RUnlock()
-
-	region := r.searchRegions.search(regionKey)
-	if region == nil {
-		return nil, nil
-	}
-
-	regionID := region.GetId()
-	leaderStoreID, ok := r.leaders.regionStores[regionID]
-	if ok {
-		return cloneRegion(region), leaderPeer(region, leaderStoreID)
-	}
-
-	return cloneRegion(region), nil
-}
-
-// getRegionByID gets the region and leader peer by regionID.
-func (r *regionsInfo) getRegionByID(regionID uint64) (*metapb.Region, *metapb.Peer) {
-	r.RLock()
-	defer r.RUnlock()
-
+func (r *regionsInfo) getRegion(regionID uint64) *regionInfo {
 	region, ok := r.regions[regionID]
-	if !ok {
-		return nil, nil
-	}
-
-	leaderStoreID, ok := r.leaders.regionStores[regionID]
-	if ok {
-		return cloneRegion(region), leaderPeer(region, leaderStoreID)
-	}
-
-	return cloneRegion(region), nil
-}
-
-// getRegions gets all the regions, returns nil if not found.
-func (r *regionsInfo) getRegions() []*metapb.Region {
-	r.RLock()
-	defer r.RUnlock()
-
-	regions := make([]*metapb.Region, 0, len(r.regions))
-	for _, region := range r.regions {
-		regions = append(regions, cloneRegion(region))
-	}
-
-	return regions
-}
-
-func (r *regionsInfo) addRegion(region *metapb.Region) {
-	r.searchRegions.insert(region)
-
-	_, ok := r.regions[region.GetId()]
-	if ok {
-		log.Fatalf("addRegion for already existed region in regions - %v", region)
-	}
-
-	r.regions[region.GetId()] = region
-
-	r.addRegionCount(region)
-}
-
-func (r *regionsInfo) updateRegion(region *metapb.Region) {
-	r.searchRegions.update(region)
-
-	oldRegion, ok := r.regions[region.GetId()]
-	if !ok {
-		log.Fatalf("updateRegion for none existed region in regions - %v", region)
-	}
-
-	r.regions[region.GetId()] = region
-
-	r.addRegionCount(region)
-	r.removeRegionCount(oldRegion)
-}
-
-func (r *regionsInfo) removeRegion(region *metapb.Region) {
-	r.searchRegions.remove(region)
-
-	_, ok := r.regions[region.GetId()]
-	if !ok {
-		log.Fatalf("removeRegion for none existed region in regions - %v", region)
-	}
-
-	delete(r.regions, region.GetId())
-
-	r.leaders.remove(region.GetId())
-
-	r.removeRegionCount(region)
-}
-
-func (r *regionsInfo) addRegionCount(region *metapb.Region) {
-	for _, peer := range region.GetPeers() {
-		r.storeRegionCount[peer.GetStoreId()]++
-	}
-}
-
-func (r *regionsInfo) removeRegionCount(region *metapb.Region) {
-	for _, peer := range region.GetPeers() {
-		r.storeRegionCount[peer.GetStoreId()]--
-	}
-}
-
-func (r *regionsInfo) heartbeatVersion(region *metapb.Region) (bool, *metapb.Region, error) {
-	// For split, we should handle heartbeat carefully.
-	// E.g, for region 1 [a, c) -> 1 [a, b) + 2 [b, c).
-	// after split, region 1 and 2 will do heartbeat independently.
-	startKey := region.GetStartKey()
-	endKey := region.GetEndKey()
-
-	searchRegion := r.searchRegions.search(startKey)
-	if searchRegion == nil {
-		// Find no region for start key, insert directly.
-		r.addRegion(region)
-		return true, nil, nil
-	}
-
-	searchStartKey := searchRegion.GetStartKey()
-	searchEndKey := searchRegion.GetEndKey()
-
-	if bytes.Equal(startKey, searchStartKey) && bytes.Equal(endKey, searchEndKey) {
-		// we are the same, must check epoch here.
-		if err := checkStaleRegion(searchRegion, region); err != nil {
-			return false, nil, errors.Trace(err)
-		}
-
-		// TODO: If we support merge regions, we should check the detail epoch version.
-		return false, nil, nil
-	}
-
-	// overlap, remove old, insert new.
-	// E.g, 1 [a, c) -> 1 [a, b) + 2 [b, c), either new 1 or 2 reports, the region
-	// is overlapped with origin [a, c).
-	epoch := region.GetRegionEpoch()
-	searchEpoch := searchRegion.GetRegionEpoch()
-	if epoch.GetVersion() <= searchEpoch.GetVersion() ||
-		epoch.GetConfVer() < searchEpoch.GetConfVer() {
-		return false, nil, errors.Errorf("region %s has wrong epoch compared with %s", region, searchRegion)
-	}
-
-	r.removeRegion(searchRegion)
-	r.addRegion(region)
-	return true, searchRegion, nil
-}
-
-func (r *regionsInfo) heartbeatConfVer(region *metapb.Region) (bool, error) {
-	// ConfVer is handled after Version, so here
-	// we must get the region by ID.
-	cacheRegion := r.regions[region.GetId()]
-	if err := checkStaleRegion(cacheRegion, region); err != nil {
-		return false, errors.Trace(err)
-	}
-
-	if region.GetRegionEpoch().GetConfVer() > cacheRegion.GetRegionEpoch().GetConfVer() {
-		// ConfChanged, update
-		r.updateRegion(region)
-		return true, nil
-	}
-
-	return false, nil
-}
-
-// heartbeatResp is the response after heartbeat handling.
-// If putRegion is not nil, we should update it in etcd,
-// if removeRegion is not nil, we should remove it in etcd.
-type heartbeatResp struct {
-	putRegion    *metapb.Region
-	removeRegion *metapb.Region
-}
-
-// heartbeat handles heartbeat for the region.
-func (r *regionsInfo) heartbeat(region *metapb.Region, leaderPeer *metapb.Peer) (*heartbeatResp, error) {
-	r.Lock()
-	defer r.Unlock()
-
-	versionUpdated, removeRegion, err := r.heartbeatVersion(region)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	confVerUpdated, err := r.heartbeatConfVer(region)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	regionID := region.GetId()
-	storeID := leaderPeer.GetStoreId()
-	r.leaders.update(regionID, storeID)
-
-	resp := &heartbeatResp{
-		removeRegion: removeRegion,
-	}
-
-	if versionUpdated || confVerUpdated {
-		resp.putRegion = region
-	}
-
-	return resp, nil
-}
-
-func (r *regionsInfo) getStoreRegionCount(storeID uint64) int {
-	r.RLock()
-	defer r.RUnlock()
-
-	return int(r.storeRegionCount[storeID])
-}
-
-func (r *regionsInfo) getStoreLeaderCount(storeID uint64) int {
-	r.RLock()
-	defer r.RUnlock()
-
-	return len(r.leaders.storeRegions[storeID])
-}
-
-func (r *regionsInfo) getRegionCount() int {
-	r.RLock()
-	defer r.RUnlock()
-
-	return len(r.regions)
-}
-
-// randLeaderRegion selects a leader region from region cache randomly.
-func (r *regionsInfo) randLeaderRegion(storeID uint64) *metapb.Region {
-	r.RLock()
-	defer r.RUnlock()
-
-	storeRegions, ok := r.leaders.storeRegions[storeID]
 	if !ok {
 		return nil
 	}
+	return region.clone()
+}
 
-	start := time.Now()
-	idx, randIdx, randRegionID := 0, rand.Intn(len(storeRegions)), uint64(0)
-	for regionID := range storeRegions {
-		if idx == randIdx {
-			randRegionID = regionID
-			break
-		}
-
-		idx++
-	}
-
-	// TODO: if costs too much time, we may refactor the rand leader region way.
-	cost := time.Now().Sub(start)
-	randRegionDuration.WithLabelValues("leader").Observe(cost.Seconds())
-
-	region, ok := r.regions[randRegionID]
+func (r *regionsInfo) addRegion(region *regionInfo) {
+	_, ok := r.regions[region.GetId()]
 	if ok {
-		return cloneRegion(region)
+		log.Panicf("add existed region: %v", region.Region)
 	}
 
+	// Update to tree and regions.
+	region = region.clone()
+	r.tree.update(region.Region)
+	r.regions[region.GetId()] = region
+
+	if region.Leader == nil {
+		return
+	}
+
+	// Update to leaders and followers.
+	for _, peer := range region.GetPeers() {
+		storeID := peer.GetStoreId()
+		if peer.GetId() == region.Leader.GetId() {
+			// Add leader peer to leaders.
+			store, ok := r.leaders[storeID]
+			if !ok {
+				store = make(map[uint64]*regionInfo)
+				r.leaders[storeID] = store
+			}
+			store[region.GetId()] = region
+		} else {
+			// Add follower peer to followers.
+			store, ok := r.followers[storeID]
+			if !ok {
+				store = make(map[uint64]*regionInfo)
+				r.followers[storeID] = store
+			}
+			store[region.GetId()] = region
+		}
+	}
+}
+
+func (r *regionsInfo) removeRegion(regionID uint64) {
+	region, ok := r.regions[regionID]
+	if !ok {
+		log.Panicf("remove non exist region: %v", regionID)
+	}
+
+	// Remove from tree and regions.
+	r.tree.remove(region.Region)
+	delete(r.regions, region.GetId())
+
+	// Remove from leaders and followers.
+	for _, peer := range region.GetPeers() {
+		storeID := peer.GetStoreId()
+		delete(r.leaders[storeID], region.GetId())
+		delete(r.followers[storeID], region.GetId())
+	}
+}
+
+func (r *regionsInfo) updateRegion(region *regionInfo) {
+	r.removeRegion(region.GetId())
+	r.addRegion(region)
+}
+
+func (r *regionsInfo) searchRegion(regionKey []byte) *regionInfo {
+	region := r.tree.search(regionKey)
+	if region == nil {
+		return nil
+	}
+	return r.getRegion(region.GetId())
+}
+
+func (r *regionsInfo) getRegions() []*regionInfo {
+	regions := make([]*regionInfo, 0, len(r.regions))
+	for _, region := range r.regions {
+		regions = append(regions, region.clone())
+	}
+	return regions
+}
+
+func (r *regionsInfo) getMetaRegions() []*metapb.Region {
+	regions := make([]*metapb.Region, 0, len(r.regions))
+	for _, region := range r.regions {
+		regions = append(regions, proto.Clone(region.Region).(*metapb.Region))
+	}
+	return regions
+}
+
+func (r *regionsInfo) getRegionCount() int {
+	return len(r.regions)
+}
+
+func (r *regionsInfo) getStoreRegionCount(storeID uint64) int {
+	return r.getStoreLeaderCount(storeID) + r.getStoreFollowerCount(storeID)
+}
+
+func (r *regionsInfo) getStoreLeaderCount(storeID uint64) int {
+	return len(r.leaders[storeID])
+}
+
+func (r *regionsInfo) getStoreFollowerCount(storeID uint64) int {
+	return len(r.followers[storeID])
+}
+
+func (r *regionsInfo) randLeaderRegion(storeID uint64) *regionInfo {
+	for _, region := range r.leaders[storeID] {
+		if region.Leader == nil {
+			log.Fatalf("rand leader region without leader: store %v region %v", storeID, region)
+		}
+		return region.clone()
+	}
 	return nil
 }
 
-// randRegion selects a region from region cache randomly.
-func (r *regionsInfo) randRegion(storeID uint64) (*metapb.Region, *metapb.Peer, *metapb.Peer) {
-	r.RLock()
-	defer r.RUnlock()
-
-	var (
-		region   *metapb.Region
-		leader   *metapb.Peer
-		follower *metapb.Peer
-	)
-
-	start := time.Now()
-	for _, rg := range r.regions {
-		for _, peer := range rg.GetPeers() {
-			if peer.GetStoreId() == storeID {
-				// Check whether it is leader region of this store.
-				regionID := rg.GetId()
-				leaderStoreID, ok := r.leaders.regionStores[regionID]
-				if ok {
-					if leaderStoreID != storeID {
-						region = cloneRegion(rg)
-						follower = peer
-						leader = leaderPeer(region, leaderStoreID)
-						break
-					}
-				}
-			}
+func (r *regionsInfo) randFollowerRegion(storeID uint64) *regionInfo {
+	for _, region := range r.followers[storeID] {
+		if region.Leader == nil {
+			log.Fatalf("rand follower region without leader: store %v region %v", storeID, region)
 		}
+		return region.clone()
 	}
-
-	// TODO: if costs too much time, we may refactor the rand region way.
-	cost := time.Now().Sub(start)
-	randRegionDuration.WithLabelValues("follower").Observe(cost.Seconds())
-
-	return region, leader, follower
+	return nil
 }
 
-// clusterInfo is cluster cache info.
 type clusterInfo struct {
 	sync.RWMutex
-
 	meta    *metapb.Cluster
 	stores  *storesInfo
 	regions *regionsInfo
@@ -521,7 +279,31 @@ func (c *clusterInfo) getStore(storeID uint64) *storeInfo {
 func (c *clusterInfo) setStore(store *storeInfo) {
 	c.Lock()
 	defer c.Unlock()
-	c.stores.setStore(store.clone())
+	c.stores.setStore(store)
+}
+
+func (c *clusterInfo) getRegion(regionID uint64) *regionInfo {
+	c.RLock()
+	defer c.RUnlock()
+	return c.regions.getRegion(regionID)
+}
+
+func (c *clusterInfo) searchRegion(regionKey []byte) *regionInfo {
+	c.RLock()
+	defer c.RUnlock()
+	return c.regions.searchRegion(regionKey)
+}
+
+func (c *clusterInfo) addRegion(region *regionInfo) {
+	c.Lock()
+	defer c.Unlock()
+	c.regions.addRegion(region)
+}
+
+func (c *clusterInfo) updateRegion(region *regionInfo) {
+	c.Lock()
+	defer c.Unlock()
+	c.regions.updateRegion(region)
 }
 
 func (c *clusterInfo) getStores() []*storeInfo {
@@ -536,31 +318,16 @@ func (c *clusterInfo) getMetaStores() []*metapb.Store {
 	return c.stores.getMetaStores()
 }
 
-func (c *clusterInfo) getStoreCount() int {
+func (c *clusterInfo) getRegions() []*regionInfo {
 	c.RLock()
 	defer c.RUnlock()
-	return c.stores.getStoreCount()
+	return c.regions.getRegions()
 }
 
-func (c *clusterInfo) getRegion(regionID uint64) *regionInfo {
-	region, leader := c.regions.getRegionByID(regionID)
-	return newRegionInfo(region, leader)
-}
-
-func (c *clusterInfo) searchRegion(regionKey []byte) *regionInfo {
-	region, leader := c.regions.getRegion(regionKey)
-	return newRegionInfo(region, leader)
-}
-
-func (c *clusterInfo) addRegion(region *regionInfo) {
-	c.regions.addRegion(region.Region)
-	if region.Leader != nil {
-		c.regions.leaders.update(region.GetId(), region.Leader.GetStoreId())
-	}
-}
-
-func (c *clusterInfo) updateRegion(region *regionInfo) {
-	c.regions.updateRegion(region.Region)
+func (c *clusterInfo) getMetaRegions() []*metapb.Region {
+	c.RLock()
+	defer c.RUnlock()
+	return c.regions.getMetaRegions()
 }
 
 func (c *clusterInfo) getMetaRegions() []*metapb.Region {
@@ -568,38 +335,37 @@ func (c *clusterInfo) getMetaRegions() []*metapb.Region {
 }
 
 func (c *clusterInfo) getRegionCount() int {
+	c.RLock()
+	defer c.RUnlock()
 	return c.regions.getRegionCount()
 }
 
 func (c *clusterInfo) getStoreRegionCount(storeID uint64) int {
+	c.RLock()
+	defer c.RUnlock()
 	return c.regions.getStoreRegionCount(storeID)
 }
 
 func (c *clusterInfo) getStoreLeaderCount(storeID uint64) int {
+	c.RLock()
+	defer c.RUnlock()
 	return c.regions.getStoreLeaderCount(storeID)
 }
 
 func (c *clusterInfo) randLeaderRegion(storeID uint64) *regionInfo {
-	region := c.regions.randLeaderRegion(storeID)
-	if region == nil {
-		return nil
-	}
-	leader := leaderPeer(region, storeID)
-	if leader == nil {
-		return nil
-	}
-	return newRegionInfo(region, leader)
+	c.RLock()
+	defer c.RUnlock()
+	return c.regions.randLeaderRegion(storeID)
 }
 
 func (c *clusterInfo) randFollowerRegion(storeID uint64) *regionInfo {
-	region, leader, _ := c.regions.randRegion(storeID)
-	if region == nil || leader == nil {
-		return nil
-	}
-	return newRegionInfo(region, leader)
+	c.RLock()
+	defer c.RUnlock()
+	return c.regions.randFollowerRegion(storeID)
 }
 
 // handleStoreHeartbeat updates the store status.
+// It returns an error if the store is not found.
 func (c *clusterInfo) handleStoreHeartbeat(stats *pdpb.StoreStats) error {
 	c.Lock()
 	defer c.Unlock()
@@ -619,6 +385,36 @@ func (c *clusterInfo) handleStoreHeartbeat(stats *pdpb.StoreStats) error {
 	return nil
 }
 
-func (c *clusterInfo) handleRegionHeartbeat(region *regionInfo) (*heartbeatResp, error) {
-	return c.regions.heartbeat(region.Region, region.Leader)
+// handleRegionHeartbeat updates the region information.
+// It returns true if the region meta is updated (or added).
+// It returns an error if any error occurs.
+func (c *clusterInfo) handleRegionHeartbeat(region *regionInfo) (bool, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	origin := c.regions.getRegion(region.GetId())
+
+	// Region does not exist, add it.
+	if origin == nil {
+		c.regions.addRegion(region)
+		return true, nil
+	}
+
+	r := region.GetRegionEpoch()
+	o := origin.GetRegionEpoch()
+
+	// Region meta is stale, return an error.
+	if r.GetVersion() < o.GetVersion() || r.GetConfVer() < o.GetConfVer() {
+		return false, errors.Trace(errRegionEpochIsStale(region.GetId()))
+	}
+
+	// Region meta is updated, update region and return true.
+	if r.GetVersion() > o.GetVersion() || r.GetConfVer() > o.GetConfVer() {
+		c.regions.updateRegion(region)
+		return true, nil
+	}
+
+	// Region meta is the same, update region and return false.
+	c.regions.updateRegion(region)
+	return false, nil
 }

--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -108,12 +108,12 @@ func (s *testRegionsInfoSuite) Test(c *C) {
 
 		// Update leader to peer np-1.
 		region.Leader = region.Peers[np-1]
-		cache.updateRegion(region)
+		cache.setRegion(region)
 		checkRegion(c, cache.getRegion(i), region)
 		checkRegion(c, cache.searchRegion(regionKey), region)
 		checkRegions(c, cache, regions[0:(i+1)])
 
-		cache.removeRegion(region.GetId())
+		cache.removeRegion(region)
 		c.Assert(cache.getRegion(i), IsNil)
 		c.Assert(cache.searchRegion(regionKey), IsNil)
 		checkRegions(c, cache, regions[0:i])
@@ -189,7 +189,7 @@ func (s *testClusterInfoSuite) TestStoreHeartbeat(c *C) {
 	regions := newTestRegions(n, np)
 
 	for _, region := range regions {
-		cache.addRegion(region)
+		cache.setRegion(region)
 	}
 	c.Assert(cache.getRegionCount(), Equals, int(n))
 

--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -14,11 +14,9 @@
 package server
 
 import (
-	"math/rand"
 	"sync/atomic"
 
 	. "github.com/pingcap/check"
-	raftpb "github.com/pingcap/kvproto/pkg/eraftpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 )
@@ -61,6 +59,10 @@ func (s *testStoresInfoSuite) Test(c *C) {
 	c.Assert(cache.getStoreCount(), Equals, int(n))
 }
 
+var _ = Suite(&testRegionsInfoSuite{})
+
+type testRegionsInfoSuite struct{}
+
 // Create n regions (0..n) of n stores (0..n).
 // Each region contains np peers, the first peer is the leader.
 func newTestRegions(n, np uint64) []*regionInfo {
@@ -85,6 +87,55 @@ func newTestRegions(n, np uint64) []*regionInfo {
 	return regions
 }
 
+func (s *testRegionsInfoSuite) Test(c *C) {
+	n, np := uint64(10), uint64(3)
+	cache := newRegionsInfo()
+	regions := newTestRegions(n, np)
+
+	for i := uint64(0); i < n; i++ {
+		region := regions[i]
+		regionKey := []byte{byte(i)}
+
+		c.Assert(cache.getRegion(i), IsNil)
+		c.Assert(cache.searchRegion(regionKey), IsNil)
+		checkRegions(c, cache, regions[0:i])
+
+		cache.addRegion(region)
+		checkRegion(c, cache.getRegion(i), region)
+		checkRegion(c, cache.searchRegion(regionKey), region)
+		checkRegions(c, cache, regions[0:(i+1)])
+
+		// Update leader to peer np-1.
+		region.Leader = region.Peers[np-1]
+		cache.updateRegion(region)
+		checkRegion(c, cache.getRegion(i), region)
+		checkRegion(c, cache.searchRegion(regionKey), region)
+		checkRegions(c, cache, regions[0:(i+1)])
+
+		cache.removeRegion(region.GetId())
+		c.Assert(cache.getRegion(i), IsNil)
+		c.Assert(cache.searchRegion(regionKey), IsNil)
+		checkRegions(c, cache, regions[0:i])
+
+		// Reset leader to peer 0.
+		region.Leader = region.Peers[0]
+		cache.addRegion(region)
+		checkRegion(c, cache.getRegion(i), region)
+		checkRegions(c, cache, regions[0:(i+1)])
+		checkRegion(c, cache.searchRegion(regionKey), region)
+	}
+
+	for i := uint64(0); i < n; i++ {
+		region := cache.randLeaderRegion(i)
+		c.Assert(region.Leader.GetStoreId(), Equals, i)
+
+		region = cache.randFollowerRegion(i)
+		c.Assert(region.Leader.GetStoreId(), Not(Equals), i)
+
+		c.Assert(region.GetStorePeer(i), NotNil)
+	}
+}
+
 func checkRegion(c *C, a *regionInfo, b *regionInfo) {
 	c.Assert(a.Region, DeepEquals, b.Region)
 	c.Assert(a.Leader, DeepEquals, b.Leader)
@@ -93,11 +144,16 @@ func checkRegion(c *C, a *regionInfo, b *regionInfo) {
 func checkRegions(c *C, cache *regionsInfo, regions []*regionInfo) {
 	regionCount := make(map[uint64]int)
 	leaderCount := make(map[uint64]int)
+	followerCount := make(map[uint64]int)
 	for _, region := range regions {
 		for _, peer := range region.Peers {
 			regionCount[peer.StoreId]++
 			if peer.Id == region.Leader.Id {
 				leaderCount[peer.StoreId]++
+				checkRegion(c, cache.leaders[peer.StoreId][region.Id], region)
+			} else {
+				followerCount[peer.StoreId]++
+				checkRegion(c, cache.followers[peer.StoreId][region.Id], region)
 			}
 		}
 	}
@@ -109,8 +165,14 @@ func checkRegions(c *C, cache *regionsInfo, regions []*regionInfo) {
 	for id, count := range leaderCount {
 		c.Assert(cache.getStoreLeaderCount(id), Equals, count)
 	}
+	for id, count := range followerCount {
+		c.Assert(cache.getStoreFollowerCount(id), Equals, count)
+	}
 
 	for _, region := range cache.getRegions() {
+		checkRegion(c, region, regions[region.GetId()])
+	}
+	for _, region := range cache.getMetaRegions() {
 		c.Assert(region, DeepEquals, regions[region.GetId()].Region)
 	}
 }
@@ -163,12 +225,14 @@ func (s *testClusterInfoSuite) TestRegionHeartbeat(c *C) {
 
 	for i, region := range regions {
 		// region does not exist.
-		_, err := cache.handleRegionHeartbeat(region)
+		updated, err := cache.handleRegionHeartbeat(region)
+		c.Assert(updated, IsTrue)
 		c.Assert(err, IsNil)
 		checkRegions(c, cache.regions, regions[0:i+1])
 
 		// region is the same, not updated.
-		_, err = cache.handleRegionHeartbeat(region)
+		updated, err = cache.handleRegionHeartbeat(region)
+		c.Assert(updated, IsFalse)
 		c.Assert(err, IsNil)
 		checkRegions(c, cache.regions, regions[0:i+1])
 
@@ -178,7 +242,8 @@ func (s *testClusterInfoSuite) TestRegionHeartbeat(c *C) {
 		region.RegionEpoch = &metapb.RegionEpoch{
 			Version: epoch.GetVersion() + 1,
 		}
-		_, err = cache.handleRegionHeartbeat(region)
+		updated, err = cache.handleRegionHeartbeat(region)
+		c.Assert(updated, IsTrue)
 		c.Assert(err, IsNil)
 		checkRegions(c, cache.regions, regions[0:i+1])
 
@@ -187,7 +252,8 @@ func (s *testClusterInfoSuite) TestRegionHeartbeat(c *C) {
 		stale.RegionEpoch = &metapb.RegionEpoch{
 			ConfVer: epoch.GetConfVer() + 1,
 		}
-		_, err = cache.handleRegionHeartbeat(stale)
+		updated, err = cache.handleRegionHeartbeat(stale)
+		c.Assert(updated, IsFalse)
 		c.Assert(err, NotNil)
 		checkRegions(c, cache.regions, regions[0:i+1])
 
@@ -196,7 +262,8 @@ func (s *testClusterInfoSuite) TestRegionHeartbeat(c *C) {
 			Version: epoch.GetVersion() + 1,
 			ConfVer: epoch.GetConfVer() + 1,
 		}
-		_, err = cache.handleRegionHeartbeat(region)
+		updated, err = cache.handleRegionHeartbeat(region)
+		c.Assert(updated, IsTrue)
 		c.Assert(err, IsNil)
 		checkRegions(c, cache.regions, regions[0:i+1])
 
@@ -205,9 +272,81 @@ func (s *testClusterInfoSuite) TestRegionHeartbeat(c *C) {
 		stale.RegionEpoch = &metapb.RegionEpoch{
 			Version: epoch.GetVersion() + 1,
 		}
-		_, err = cache.handleRegionHeartbeat(stale)
+		updated, err = cache.handleRegionHeartbeat(stale)
+		c.Assert(updated, IsFalse)
 		c.Assert(err, NotNil)
 		checkRegions(c, cache.regions, regions[0:i+1])
+	}
+}
+
+func heartbeatRegions(c *C, cache *clusterInfo, regions []*metapb.Region) {
+	// Heartbeat and check region one by one.
+	for _, region := range regions {
+		r := newRegionInfo(region, nil)
+
+		updated, err := cache.handleRegionHeartbeat(r)
+		c.Assert(updated, IsTrue)
+		c.Assert(err, IsNil)
+
+		checkRegion(c, cache.getRegion(r.GetId()), r)
+		checkRegion(c, cache.searchRegion(r.StartKey), r)
+
+		if len(r.EndKey) > 0 {
+			end := r.EndKey[0]
+			checkRegion(c, cache.searchRegion([]byte{end - 1}), r)
+		}
+	}
+
+	// Check all regions after handling all heartbeats.
+	for _, region := range regions {
+		r := newRegionInfo(region, nil)
+
+		checkRegion(c, cache.getRegion(r.GetId()), r)
+		checkRegion(c, cache.searchRegion(r.StartKey), r)
+
+		if len(r.EndKey) > 0 {
+			end := r.EndKey[0]
+			checkRegion(c, cache.searchRegion([]byte{end - 1}), r)
+			result := cache.searchRegion([]byte{end + 1})
+			c.Assert(result.GetId(), Not(Equals), r.GetId())
+		}
+	}
+}
+
+func (s *testClusterInfoSuite) TestRegionHeartbeatSplitAndMerge(c *C) {
+	cache := newClusterInfo(newMockIDAllocator())
+	regions := []*metapb.Region{
+		{
+			Id:          1,
+			StartKey:    []byte{},
+			EndKey:      []byte{},
+			RegionEpoch: &metapb.RegionEpoch{},
+		},
+	}
+
+	// Byte will underflow/overflow if n > 7.
+	n := 7
+
+	// Split.
+	for i := 0; i < n; i++ {
+		regions = splitRegions(regions)
+		heartbeatRegions(c, cache, regions)
+	}
+
+	// Merge.
+	for i := 0; i < n; i++ {
+		regions = mergeRegions(regions)
+		heartbeatRegions(c, cache, regions)
+	}
+
+	// Split twice and merge once.
+	for i := 0; i < n*2; i++ {
+		if (i+1)%3 == 0 {
+			regions = mergeRegions(regions)
+		} else {
+			regions = splitRegions(regions)
+		}
+		heartbeatRegions(c, cache, regions)
 	}
 }
 
@@ -238,262 +377,15 @@ func (s *testClusterUtilSuite) TestCheckStaleRegion(c *C) {
 	c.Assert(checkStaleRegion(region, origin), NotNil)
 }
 
-var _ = Suite(&testClusterCacheSuite{})
-
-type testClusterCacheSuite struct {
-	testClusterBaseSuite
-}
-
-func (s *testClusterCacheSuite) SetUpSuite(c *C) {
-	s.svr, s.cleanup = newTestServer(c)
-	s.client = s.svr.client
-
-	go s.svr.Run()
-}
-
-func (s *testClusterCacheSuite) TearDownSuite(c *C) {
-	s.cleanup()
-}
-
-func (s *testClusterCacheSuite) TestCache(c *C) {
-	leaderPd := mustGetLeader(c, s.client, s.svr.getLeaderPath())
-
-	conn, err := rpcConnect(leaderPd.GetAddr())
-	c.Assert(err, IsNil)
-	defer conn.Close()
-
-	clusterID := s.svr.clusterID
-
-	req := s.newBootstrapRequest(c, clusterID, "127.0.0.1:1")
-	store1 := req.Bootstrap.Store
-
-	_, err = s.svr.bootstrapCluster(req.Bootstrap)
-	c.Assert(err, IsNil)
-
-	cluster := s.svr.GetRaftCluster()
-	c.Assert(cluster, NotNil)
-
-	stats := &pdpb.StoreStats{
-		StoreId:            store1.GetId(),
-		Capacity:           100,
-		Available:          50,
-		SendingSnapCount:   1,
-		ReceivingSnapCount: 1,
-	}
-
-	c.Assert(cluster.cachedCluster.handleStoreHeartbeat(stats), IsNil)
-
-	// Check cachedCluster.
-	c.Assert(cluster.cachedCluster.getMeta().GetId(), Equals, clusterID)
-	c.Assert(cluster.cachedCluster.getMeta().GetMaxPeerCount(), Equals, uint32(3))
-
-	cacheStore := cluster.cachedCluster.getStore(store1.GetId())
-	c.Assert(cacheStore.Store, DeepEquals, store1)
-	c.Assert(cluster.cachedCluster.regions.regions, HasLen, 1)
-	c.Assert(cluster.cachedCluster.regions.searchRegions.length(), Equals, 1)
-	c.Assert(cluster.cachedCluster.regions.leaders.storeRegions, HasLen, 0)
-	c.Assert(cluster.cachedCluster.regions.leaders.regionStores, HasLen, 0)
-
-	// Add another store.
-	store2 := s.newStore(c, 0, "127.0.0.1:2")
-	err = cluster.putStore(store2)
-	c.Assert(err, IsNil)
-
-	stats = &pdpb.StoreStats{
-		StoreId:            store2.GetId(),
-		Capacity:           100,
-		Available:          50,
-		SendingSnapCount:   1,
-		ReceivingSnapCount: 1,
-	}
-
-	c.Assert(cluster.cachedCluster.handleStoreHeartbeat(stats), IsNil)
-
-	// Check cachedCluster.
-	c.Assert(cluster.cachedCluster.getMeta().GetId(), Equals, clusterID)
-	c.Assert(cluster.cachedCluster.getMeta().GetMaxPeerCount(), Equals, uint32(3))
-
-	cacheStore = cluster.cachedCluster.getStore(store1.GetId())
-	c.Assert(cacheStore.Store, DeepEquals, store1)
-	cacheStore = cluster.cachedCluster.getStore(store2.GetId())
-	c.Assert(cacheStore.Store, DeepEquals, store2)
-	cacheStores := cluster.cachedCluster.getStores()
-	c.Assert(cacheStores, HasLen, 2)
-	c.Assert(cluster.cachedCluster.regions.regions, HasLen, 1)
-
-	// There is only one region now, directly use it for test.
-	regionKey := []byte("a")
-	region, leader := cluster.getRegion(regionKey)
-	c.Assert(leader, IsNil)
-	c.Assert(region.Peers, HasLen, 1)
-
-	cacheRegions := cluster.cachedCluster.regions
-	c.Assert(cacheRegions.regions, HasLen, 1)
-	c.Assert(cacheRegions.searchRegions.length(), Equals, 1)
-	c.Assert(cacheRegions.leaders.storeRegions, HasLen, 0)
-	c.Assert(cacheRegions.leaders.regionStores, HasLen, 0)
-
-	leader = region.GetPeers()[0]
-	res := heartbeatRegion(c, conn, clusterID, 0, region, leader)
-	c.Assert(res.GetPeer(), NotNil)
-	c.Assert(res.GetChangeType(), Equals, raftpb.ConfChangeType_AddNode)
-	c.Assert(leader.GetId(), Not(Equals), res.GetPeer().GetId())
-
-	cacheStores = cluster.cachedCluster.getStores()
-	c.Assert(cacheStores, HasLen, 2)
-	c.Assert(cacheRegions.regions, HasLen, 1)
-	cacheRegion := cacheRegions.regions[region.GetId()]
-	c.Assert(cacheRegion, DeepEquals, region)
-
-	c.Assert(cacheRegions.leaders.storeRegions, HasKey, store1.GetId())
-	c.Assert(cacheRegions.leaders.storeRegions, Not(HasKey), store2.GetId())
-
-	c.Assert(cacheRegions.leaders.storeRegions[store1.GetId()], HasKey, region.GetId())
-	c.Assert(cacheRegions.leaders.regionStores[region.GetId()], Equals, store1.GetId())
-
-	// Add another peer.
-	region.Peers = append(region.Peers, res.GetPeer())
-	region.RegionEpoch.ConfVer = region.GetRegionEpoch().GetConfVer() + 1
-
-	res = heartbeatRegion(c, conn, clusterID, 0, region, leader)
-	c.Assert(res, IsNil)
-
-	c.Assert(cluster.cachedCluster.regions.regions, HasLen, 1)
-
-	oldRegionID := region.GetId()
-	cacheRegion = cacheRegions.regions[oldRegionID]
-	region, _ = cluster.getRegion(regionKey)
-	c.Assert(region.GetPeers(), HasLen, 2)
-	c.Assert(cacheRegion, DeepEquals, region)
-
-	c.Assert(cacheRegions.leaders.storeRegions, HasKey, store1.GetId())
-	c.Assert(cacheRegions.leaders.storeRegions, Not(HasKey), store2.GetId())
-
-	c.Assert(cacheRegions.leaders.storeRegions[store1.GetId()], HasKey, region.GetId())
-	c.Assert(cacheRegions.leaders.regionStores[region.GetId()], Equals, store1.GetId())
-
-	// Test change leader peer.
-	newLeader := region.GetPeers()[1]
-	c.Assert(leader.GetId(), Not(Equals), newLeader.GetId())
-
-	// There is no store to add peer, so the return res is nil.
-	res = heartbeatRegion(c, conn, clusterID, 0, region, newLeader)
-	c.Assert(res, IsNil)
-
-	region, leader = cluster.getRegion(regionKey)
-	c.Assert(leader, DeepEquals, newLeader)
-	c.Assert(region.GetPeers(), HasLen, 2)
-	c.Assert(cacheRegion, DeepEquals, region)
-
-	c.Assert(cluster.cachedCluster.getStoreCount(), Equals, 2)
-	c.Assert(cacheRegions.regions, HasLen, 1)
-	c.Assert(cacheRegions.leaders.storeRegions, Not(HasKey), store1.GetId())
-	c.Assert(cacheRegions.leaders.storeRegions, HasKey, store2.GetId())
-
-	c.Assert(cacheRegions.leaders.storeRegions[store2.GetId()], HasKey, region.GetId())
-	c.Assert(cacheRegions.leaders.regionStores[region.GetId()], Equals, store2.GetId())
-
-	region, leader = cluster.getRegion(regionKey)
-	c.Assert(leader, DeepEquals, newLeader)
-	c.Assert(cacheRegion, DeepEquals, region)
-
-	s.svr.cluster.stop()
-
-	// Check GetStores.
-	stores := map[uint64]*metapb.Store{
-		store1.GetId(): store1,
-		store2.GetId(): store2,
-	}
-
-	cluster = s.svr.GetRaftCluster()
-	c.Assert(cluster, IsNil)
-
-	allStores := s.svr.cluster.GetStores()
-	c.Assert(allStores, HasLen, 2)
-	for _, store := range allStores {
-		c.Assert(stores, HasKey, store.GetId())
-	}
-}
-
-func randRegions(count int) []*metapb.Region {
-	regions := make([]*metapb.Region, 0, count)
-	for i := 0; i < count; i++ {
-		peers := make([]*metapb.Peer, 0, 3)
-		for j := 0; j < 3; j++ {
-			peer := &metapb.Peer{StoreId: uint64(rand.Intn(count))}
-			peers = append(peers, peer)
-		}
-		region := &metapb.Region{
-			Id:       uint64(i),
-			StartKey: []byte{byte(i)},
-			EndKey:   []byte{byte(i + 1)},
-			Peers:    peers,
-		}
-		regions = append(regions, region)
-	}
-	return regions
-}
-
-func checkStoreRegionCount(c *C, r *regionsInfo, regions []*metapb.Region) {
-	stores := make(map[uint64]int)
-	for _, region := range regions {
-		for _, peer := range region.GetPeers() {
-			stores[peer.GetStoreId()]++
-		}
-	}
-	for id, count := range stores {
-		c.Assert(r.getStoreRegionCount(id), Equals, count)
-	}
-}
-
-func (s *testClusterCacheSuite) TestStoreRegionCount(c *C) {
-	count := 10
-	addRegions := randRegions(count)
-	updateRegions := randRegions(count)
-
-	r := newRegionsInfo()
-
-	var regions []*metapb.Region
-	for _, region := range addRegions {
-		r.addRegion(region)
-		regions = append(regions, region)
-		checkStoreRegionCount(c, r, regions)
-	}
-	checkStoreRegionCount(c, r, addRegions)
-
-	for i, region := range updateRegions {
-		r.updateRegion(region)
-		regions[i] = region
-		checkStoreRegionCount(c, r, regions)
-	}
-	checkStoreRegionCount(c, r, updateRegions)
-
-	for len(regions) > 0 {
-		r.removeRegion(regions[0])
-		regions = regions[1:]
-		checkStoreRegionCount(c, r, regions)
-	}
-}
-
 // mockIDAllocator mocks IDAllocator and it is only used for test.
 type mockIDAllocator struct {
 	base uint64
 }
 
 func newMockIDAllocator() *mockIDAllocator {
-	return &mockIDAllocator{
-		base: 0,
-	}
+	return &mockIDAllocator{base: 0}
 }
 
 func (alloc *mockIDAllocator) Alloc() (uint64, error) {
 	return atomic.AddUint64(&alloc.base, 1), nil
-}
-
-func (s *testClusterCacheSuite) TestIDAlloc(c *C) {
-	cluster := newClusterInfo(newMockIDAllocator())
-
-	id, err := cluster.idAlloc.Alloc()
-	c.Assert(err, IsNil)
-	c.Assert(id, Greater, uint64(0))
 }

--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -48,6 +48,7 @@ func (s *testStoresInfoSuite) Test(c *C) {
 		c.Assert(cache.getStore(i), DeepEquals, stores[i])
 		c.Assert(cache.getStoreCount(), Equals, int(i+1))
 	}
+	c.Assert(cache.getStoreCount(), Equals, int(n))
 
 	for _, store := range cache.getStores() {
 		c.Assert(store, DeepEquals, stores[store.GetId()])

--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -278,6 +278,23 @@ func (s *testClusterInfoSuite) TestRegionHeartbeat(c *C) {
 		c.Assert(err, NotNil)
 		checkRegions(c, cache.regions, regions[0:i+1])
 	}
+
+	regionCounts := make(map[uint64]int)
+	for _, region := range regions {
+		for _, peer := range region.GetPeers() {
+			regionCounts[peer.GetStoreId()]++
+		}
+	}
+	for id, count := range regionCounts {
+		c.Assert(cache.getStoreRegionCount(id), Equals, count)
+	}
+
+	for _, region := range cache.getRegions() {
+		checkRegion(c, region, regions[region.GetId()])
+	}
+	for _, region := range cache.getMetaRegions() {
+		c.Assert(region, DeepEquals, regions[region.GetId()].Region)
+	}
 }
 
 func heartbeatRegions(c *C, cache *clusterInfo, regions []*metapb.Region) {

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -336,7 +336,7 @@ func (c *RaftCluster) cacheAllRegions() error {
 			}
 
 			nextID = region.GetId() + 1
-			c.cachedCluster.addRegion(newRegionInfo(region, nil))
+			c.cachedCluster.setRegion(newRegionInfo(region, nil))
 		}
 	}
 

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -317,9 +317,6 @@ func (c *RaftCluster) cacheAllRegions() error {
 	nextID := uint64(0)
 	endRegionKey := makeRegionKey(c.clusterRoot, math.MaxUint64)
 
-	c.cachedCluster.regions.Lock()
-	defer c.cachedCluster.regions.Unlock()
-
 	for {
 		key := makeRegionKey(c.clusterRoot, nextID)
 		resp, err := kvGet(c.s.client, key, clientv3.WithRange(endRegionKey))
@@ -343,7 +340,7 @@ func (c *RaftCluster) cacheAllRegions() error {
 		}
 	}
 
-	log.Infof("cache all %d regions cost %s", len(c.cachedCluster.regions.regions), time.Now().Sub(start))
+	log.Infof("cache all %d regions cost %s", c.cachedCluster.getRegionCount(), time.Now().Sub(start))
 	return nil
 }
 

--- a/server/cluster_worker.go
+++ b/server/cluster_worker.go
@@ -16,6 +16,7 @@ package server
 import (
 	"bytes"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -118,7 +119,7 @@ func (c *RaftCluster) handleReportSplit(request *pdpb.ReportSplitRequest) (*pdpb
 	}
 
 	// Build origin region by using left and right.
-	originRegion := cloneRegion(left)
+	originRegion := proto.Clone(left).(*metapb.Region)
 	originRegion.RegionEpoch = nil
 	originRegion.EndKey = right.GetEndKey()
 

--- a/server/cluster_worker_test.go
+++ b/server/cluster_worker_test.go
@@ -340,10 +340,10 @@ func mustGetRegion(c *C, cluster *RaftCluster, key []byte, expect *metapb.Region
 
 func checkSearchRegions(c *C, cluster *RaftCluster, keys ...[]byte) {
 	cacheRegions := cluster.cachedCluster.regions
-	c.Assert(cacheRegions.searchRegions.length(), Equals, len(keys))
+	c.Assert(cacheRegions.tree.length(), Equals, len(keys))
 
 	for _, key := range keys {
-		getItem := cacheRegions.searchRegions.search(key)
+		getItem := cacheRegions.tree.search(key)
 		c.Assert(getItem, NotNil)
 	}
 }

--- a/server/region_test.go
+++ b/server/region_test.go
@@ -14,6 +14,9 @@
 package server
 
 import (
+	"math"
+
+	"github.com/gogo/protobuf/proto"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
@@ -95,28 +98,144 @@ func (s *testRegionSuite) TestRegionTree(c *C) {
 	c.Assert(tree.search([]byte("a")), IsNil)
 
 	regionA := newRegion([]byte("a"), []byte("b"))
+	regionB := newRegion([]byte("b"), []byte("c"))
 	regionC := newRegion([]byte("c"), []byte("d"))
 	regionD := newRegion([]byte("d"), []byte{})
 
-	tree.insert(regionA)
-	tree.insert(regionC)
-
+	tree.update(regionA)
+	tree.update(regionC)
 	c.Assert(tree.search([]byte{}), IsNil)
 	c.Assert(tree.search([]byte("a")), Equals, regionA)
 	c.Assert(tree.search([]byte("b")), IsNil)
 	c.Assert(tree.search([]byte("c")), Equals, regionC)
 	c.Assert(tree.search([]byte("d")), IsNil)
-	c.Assert(tree.search([]byte("e")), IsNil)
 
+	tree.update(regionB)
 	tree.remove(regionC)
-	tree.insert(regionD)
-
+	tree.update(regionD)
 	c.Assert(tree.search([]byte{}), IsNil)
 	c.Assert(tree.search([]byte("a")), Equals, regionA)
-	c.Assert(tree.search([]byte("b")), IsNil)
+	c.Assert(tree.search([]byte("b")), Equals, regionB)
 	c.Assert(tree.search([]byte("c")), IsNil)
 	c.Assert(tree.search([]byte("d")), Equals, regionD)
-	c.Assert(tree.search([]byte("e")), Equals, regionD)
+
+	// region with the same range and different region id will not be delete.
+	region0 := newRegionItem([]byte{}, []byte("a")).region
+	tree.update(region0)
+	c.Assert(tree.search([]byte{}), Equals, region0)
+	anotherRegion0 := newRegionItem([]byte{}, []byte("a")).region
+	anotherRegion0.Id = 123
+	tree.remove(anotherRegion0)
+	c.Assert(tree.search([]byte{}), Equals, region0)
+
+	// overlaps with 0, A, B, C.
+	region0D := newRegionItem([]byte(""), []byte("d")).region
+	tree.update(region0D)
+	c.Assert(tree.search([]byte{}), Equals, region0D)
+	c.Assert(tree.search([]byte("a")), Equals, region0D)
+	c.Assert(tree.search([]byte("b")), Equals, region0D)
+	c.Assert(tree.search([]byte("c")), Equals, region0D)
+	c.Assert(tree.search([]byte("d")), Equals, regionD)
+
+	// overlaps with D.
+	regionE := newRegionItem([]byte("e"), []byte{}).region
+	tree.update(regionE)
+	c.Assert(tree.search([]byte{}), Equals, region0D)
+	c.Assert(tree.search([]byte("a")), Equals, region0D)
+	c.Assert(tree.search([]byte("b")), Equals, region0D)
+	c.Assert(tree.search([]byte("c")), Equals, region0D)
+	c.Assert(tree.search([]byte("d")), IsNil)
+	c.Assert(tree.search([]byte("e")), Equals, regionE)
+}
+
+func splitRegions(regions []*metapb.Region) []*metapb.Region {
+	results := make([]*metapb.Region, 0, len(regions)*2)
+	for _, region := range regions {
+		start, end := byte(0), byte(math.MaxUint8)
+		if len(region.StartKey) > 0 {
+			start = region.StartKey[0]
+		}
+		if len(region.EndKey) > 0 {
+			end = region.EndKey[0]
+		}
+		middle := []byte{start/2 + end/2}
+		left := proto.Clone(region).(*metapb.Region)
+		left.Id = region.Id + uint64(len(regions))
+		left.EndKey = middle
+		left.RegionEpoch.Version++
+		right := proto.Clone(region).(*metapb.Region)
+		right.Id = region.Id + uint64(len(regions)*2)
+		right.StartKey = middle
+		right.RegionEpoch.Version++
+		results = append(results, left, right)
+	}
+	return results
+}
+
+func mergeRegions(regions []*metapb.Region) []*metapb.Region {
+	results := make([]*metapb.Region, 0, len(regions)/2)
+	for i := 0; i < len(regions); i += 2 {
+		left := regions[i]
+		right := regions[i]
+		if i+1 < len(regions) {
+			right = regions[i+1]
+		}
+		region := &metapb.Region{
+			Id:       left.Id + uint64(len(regions)),
+			StartKey: left.StartKey,
+			EndKey:   right.EndKey,
+		}
+		if left.RegionEpoch.Version > right.RegionEpoch.Version {
+			region.RegionEpoch = left.RegionEpoch
+		} else {
+			region.RegionEpoch = right.RegionEpoch
+		}
+		region.RegionEpoch.Version++
+		results = append(results, region)
+	}
+	return results
+}
+
+func updateRegions(c *C, tree *regionTree, regions []*metapb.Region) {
+	for _, region := range regions {
+		tree.update(region)
+		c.Assert(tree.search(region.StartKey), Equals, region)
+		if len(region.EndKey) > 0 {
+			end := region.EndKey[0]
+			c.Assert(tree.search([]byte{end - 1}), Equals, region)
+			c.Assert(tree.search([]byte{end + 1}), Not(Equals), region)
+		}
+	}
+}
+
+func (s *testRegionSuite) TestRegionTreeSplitAndMerge(c *C) {
+	tree := newRegionTree()
+	regions := []*metapb.Region{newRegionItem([]byte{}, []byte{}).region}
+
+	// Byte will underflow/overflow if n > 7.
+	n := 7
+
+	// Split.
+	for i := 0; i < n; i++ {
+		regions = splitRegions(regions)
+		updateRegions(c, tree, regions)
+	}
+
+	// Merge.
+	for i := 0; i < n; i++ {
+		regions = mergeRegions(regions)
+		updateRegions(c, tree, regions)
+	}
+
+	// Split twice and merge once.
+	for i := 0; i < n*2; i++ {
+		if (i+1)%3 == 0 {
+			regions = mergeRegions(regions)
+		} else {
+			regions = splitRegions(regions)
+		}
+		updateRegions(c, tree, regions)
+	}
 }
 
 func newRegion(start, end []byte) *metapb.Region {


### PR DESCRIPTION
First, stores and regions are reorganized so that we can easily access
the information we need.

Second, the algorithm to handle region heartbeat is modified
accordingly, to handle Split and Merge.

It's hard to handle Split and Merge perfectly to keep the cache always
reflecting the newest information about which region is serving which
range. But we can keep the cache always updating according to the region
heartbeat.

Here's how we handle region heartbeat. First, if the region does not
exist, it is added to the cache directly. Second, if the region exists
but the heartbeat is stale, an error will be returned. Finally, if the
region exists and the heartbeat is not stale, it is updated to the
cache. Additionaly, every time a region is added or updated, all range
overlap regions will be deleted from the search tree first, and then
the region will be inserted. Note that regions deleted from the search
tree can still be found by the region id.

This PR relies on https://github.com/pingcap/pd/pull/353 and https://github.com/pingcap/pd/pull/356.
