### PR TITLE
server: add kv

### DIFF
--- a/server/cache.go
+++ b/server/cache.go
@@ -242,6 +242,7 @@ func newClusterInfo(id IDAllocator) *clusterInfo {
 	}
 }
 
+// Return nil if cluster is not bootstrapped.
 func loadClusterInfo(id IDAllocator, kv *kv) (*clusterInfo, error) {
 	c := newClusterInfo(id)
 

--- a/server/cache.go
+++ b/server/cache.go
@@ -242,6 +242,33 @@ func newClusterInfo(id IDAllocator) *clusterInfo {
 	}
 }
 
+func loadClusterInfo(id IDAllocator, kv *kv) (*clusterInfo, error) {
+	c := newClusterInfo(id)
+
+	c.meta = &metapb.Cluster{}
+	ok, err := kv.loadMeta(c.meta)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	start := time.Now()
+	if err := kv.loadStores(c.stores, kvRangeLimit); err != nil {
+		return nil, errors.Trace(err)
+	}
+	log.Infof("load %v stores cost %v", c.getStoreCount(), time.Since(start))
+
+	start = time.Now()
+	if err := kv.loadRegions(c.regions, kvRangeLimit); err != nil {
+		return nil, errors.Trace(err)
+	}
+	log.Infof("load %v regions cost %v", c.getRegionCount(), time.Since(start))
+
+	return c, nil
+}
+
 func (c *clusterInfo) allocID() (uint64, error) {
 	return c.id.Alloc()
 }

--- a/server/kv.go
+++ b/server/kv.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	kvRangeLimit      = 100000
-	kvRequestTimeout  = time.Second * 3
+	kvRequestTimeout  = time.Second * 10
 	kvSlowRequestTime = time.Second * 1
 )
 

--- a/server/kv.go
+++ b/server/kv.go
@@ -1,0 +1,199 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"math"
+	"path"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/gogo/protobuf/proto"
+	"github.com/juju/errors"
+	"github.com/ngaut/log"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"golang.org/x/net/context"
+)
+
+const (
+	kvRangeLimit      = 100000
+	kvRequestTimeout  = time.Second * 3
+	kvSlowRequestTime = time.Second * 1
+)
+
+var (
+	errTxnFailed = errors.New("failed to commit transaction")
+)
+
+// kv wraps all kv operations, keep it stateless.
+type kv struct {
+	s           *Server
+	client      *clientv3.Client
+	clusterPath string
+}
+
+func newKV(s *Server) *kv {
+	return &kv{
+		s:           s,
+		client:      s.client,
+		clusterPath: path.Join(s.rootPath, "raft"),
+	}
+}
+
+func (kv *kv) txn(cs ...clientv3.Cmp) clientv3.Txn { return kv.s.leaderTxn(cs...) }
+
+func (kv *kv) storePath(storeID uint64) string {
+	return path.Join(kv.clusterPath, "s", fmt.Sprintf("%020d", storeID))
+}
+
+func (kv *kv) regionPath(regionID uint64) string {
+	return path.Join(kv.clusterPath, "r", fmt.Sprintf("%020d", regionID))
+}
+
+func (kv *kv) loadMeta(meta *metapb.Cluster) (bool, error) {
+	return kv.loadProto(kv.clusterPath, meta)
+}
+
+func (kv *kv) saveMeta(meta *metapb.Cluster) error {
+	return kv.saveProto(kv.clusterPath, meta)
+}
+
+func (kv *kv) loadStore(storeID uint64, store *metapb.Store) (bool, error) {
+	return kv.loadProto(kv.storePath(storeID), store)
+}
+
+func (kv *kv) saveStore(store *metapb.Store) error {
+	return kv.saveProto(kv.storePath(store.GetId()), store)
+}
+
+func (kv *kv) loadRegion(regionID uint64, region *metapb.Region) (bool, error) {
+	return kv.loadProto(kv.regionPath(regionID), region)
+}
+
+func (kv *kv) saveRegion(region *metapb.Region) error {
+	return kv.saveProto(kv.regionPath(region.GetId()), region)
+}
+
+func (kv *kv) loadStores(stores *storesInfo, rangeLimit int64) error {
+	nextID := uint64(0)
+	endStore := kv.storePath(math.MaxUint64)
+	withRange := clientv3.WithRange(endStore)
+	withLimit := clientv3.WithLimit(rangeLimit)
+
+	for {
+		key := kv.storePath(nextID)
+		resp, err := kvGet(kv.client, key, withRange, withLimit)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if len(resp.Kvs) == 0 {
+			return nil
+		}
+
+		for _, item := range resp.Kvs {
+			store := &metapb.Store{}
+			if err := store.Unmarshal(item.Value); err != nil {
+				return errors.Trace(err)
+			}
+
+			nextID = store.GetId() + 1
+			stores.setStore(newStoreInfo(store))
+		}
+	}
+}
+
+func (kv *kv) loadRegions(regions *regionsInfo, rangeLimit int64) error {
+	nextID := uint64(0)
+	endRegion := kv.regionPath(math.MaxUint64)
+	withRange := clientv3.WithRange(endRegion)
+	withLimit := clientv3.WithLimit(rangeLimit)
+
+	for {
+		key := kv.regionPath(nextID)
+		resp, err := kvGet(kv.client, key, withRange, withLimit)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if len(resp.Kvs) == 0 {
+			return nil
+		}
+
+		for _, item := range resp.Kvs {
+			region := &metapb.Region{}
+			if err := region.Unmarshal(item.Value); err != nil {
+				return errors.Trace(err)
+			}
+
+			nextID = region.GetId() + 1
+			regions.setRegion(newRegionInfo(region, nil))
+		}
+	}
+}
+
+func (kv *kv) loadProto(key string, msg proto.Message) (bool, error) {
+	value, err := kv.load(key)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	if value == nil {
+		return false, nil
+	}
+	return true, proto.Unmarshal(value, msg)
+}
+
+func (kv *kv) saveProto(key string, msg proto.Message) error {
+	value, err := proto.Marshal(msg)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return kv.save(key, string(value))
+}
+
+func (kv *kv) load(key string) ([]byte, error) {
+	resp, err := kvGet(kv.client, key)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if n := len(resp.Kvs); n == 0 {
+		return nil, nil
+	} else if n > 1 {
+		return nil, errors.Errorf("load more than one kvs: key %v kvs %v", key, n)
+	}
+	return resp.Kvs[0].Value, nil
+}
+
+func (kv *kv) save(key, value string) error {
+	resp, err := kv.txn().Then(clientv3.OpPut(key, value)).Commit()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if !resp.Succeeded {
+		return errors.Trace(errTxnFailed)
+	}
+	return nil
+}
+
+func kvGet(c *clientv3.Client, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	ctx, cancel := context.WithTimeout(c.Ctx(), kvRequestTimeout)
+	defer cancel()
+
+	start := time.Now()
+	resp, err := clientv3.NewKV(c).Get(ctx, key, opts...)
+	if cost := time.Now().Sub(start); cost > kvSlowRequestTime {
+		log.Warnf("kv gets too slow: key %v cost %v err %v", key, cost, err)
+	}
+
+	return resp, errors.Trace(err)
+}

--- a/server/kv_test.go
+++ b/server/kv_test.go
@@ -1,0 +1,135 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/metapb"
+)
+
+var _ = Suite(&testKVSuite{})
+
+type testKVSuite struct {
+	server  *Server
+	cleanup cleanUpFunc
+}
+
+func (s *testKVSuite) SetUpTest(c *C) {
+	s.server, s.cleanup = mustRunTestServer(c)
+}
+
+func (s *testKVSuite) TearDownTest(c *C) {
+	s.cleanup()
+}
+
+func (s *testKVSuite) TestBasic(c *C) {
+	kv := newKV(s.server)
+
+	clusterID := s.server.clusterID
+	storePath := fmt.Sprintf("/pd/%v/raft/s/00000000000000000123", clusterID)
+	regionPath := fmt.Sprintf("/pd/%v/raft/r/00000000000000000123", clusterID)
+	c.Assert(kv.storePath(123), Equals, storePath)
+	c.Assert(kv.regionPath(123), Equals, regionPath)
+
+	meta := &metapb.Cluster{Id: 123}
+	ok, err := kv.loadMeta(meta)
+	c.Assert(ok, IsFalse)
+	c.Assert(err, IsNil)
+	c.Assert(kv.saveMeta(meta), IsNil)
+	newMeta := &metapb.Cluster{}
+	ok, err = kv.loadMeta(newMeta)
+	c.Assert(ok, IsTrue)
+	c.Assert(err, IsNil)
+	c.Assert(newMeta, DeepEquals, meta)
+
+	store := &metapb.Store{Id: 123}
+	ok, err = kv.loadStore(123, store)
+	c.Assert(ok, IsFalse)
+	c.Assert(err, IsNil)
+	c.Assert(kv.saveStore(store), IsNil)
+	newStore := &metapb.Store{}
+	ok, err = kv.loadStore(123, newStore)
+	c.Assert(ok, IsTrue)
+	c.Assert(err, IsNil)
+	c.Assert(newStore, DeepEquals, store)
+
+	region := &metapb.Region{Id: 123}
+	ok, err = kv.loadRegion(123, region)
+	c.Assert(ok, IsFalse)
+	c.Assert(err, IsNil)
+	c.Assert(kv.saveRegion(region), IsNil)
+	newRegion := &metapb.Region{}
+	ok, err = kv.loadRegion(123, newRegion)
+	c.Assert(ok, IsTrue)
+	c.Assert(err, IsNil)
+	c.Assert(newRegion, DeepEquals, region)
+}
+
+func mustSaveStores(c *C, kv *kv, n int) []*metapb.Store {
+	stores := make([]*metapb.Store, 0, n)
+	for i := 0; i < n; i++ {
+		store := &metapb.Store{Id: uint64(i)}
+		stores = append(stores, store)
+	}
+
+	for _, store := range stores {
+		c.Assert(kv.saveStore(store), IsNil)
+	}
+
+	return stores
+}
+
+func (s *testKVSuite) TestLoadStores(c *C) {
+	kv := newKV(s.server)
+	cache := newStoresInfo()
+
+	n := 10
+	stores := mustSaveStores(c, kv, n)
+	c.Assert(kv.loadStores(cache, 3), IsNil)
+
+	c.Assert(cache.getStoreCount(), Equals, n)
+	for _, store := range cache.getMetaStores() {
+		c.Assert(store, DeepEquals, stores[store.GetId()])
+	}
+}
+
+func mustSaveRegions(c *C, kv *kv, n int) []*metapb.Region {
+	regions := make([]*metapb.Region, 0, n)
+	for i := 0; i < n; i++ {
+		region := &metapb.Region{Id: uint64(i)}
+		regions = append(regions, region)
+	}
+
+	for _, region := range regions {
+		c.Assert(kv.saveRegion(region), IsNil)
+	}
+
+	return regions
+}
+
+func (s *testKVSuite) TestLoadRegions(c *C) {
+	kv := newKV(s.server)
+	cache := newRegionsInfo()
+
+	n := 10
+	regions := mustSaveRegions(c, kv, n)
+	c.Assert(kv.loadRegions(cache, 3), IsNil)
+
+	c.Assert(cache.getRegionCount(), Equals, n)
+	for _, region := range cache.getMetaRegions() {
+		c.Assert(region, DeepEquals, regions[region.GetId()])
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -70,6 +70,9 @@ type Server struct {
 	// a unique ID.
 	idAlloc *idAllocator
 
+	// for kv operation.
+	kv *kv
+
 	// for raft cluster
 	clusterLock sync.RWMutex
 	cluster     *RaftCluster
@@ -157,6 +160,7 @@ func (s *Server) StartEtcd(apiHandler http.Handler) error {
 
 	s.rootPath = path.Join(pdRootPath, strconv.FormatUint(s.clusterID, 10))
 	s.idAlloc = &idAllocator{s: s}
+	s.kv = newKV(s)
 	s.cluster = newRaftCluster(s, s.clusterID)
 
 	// Server has started.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -48,6 +48,13 @@ func newTestServer(c *C) (*Server, cleanUpFunc) {
 	return svr, cleanup
 }
 
+func mustRunTestServer(c *C) (*Server, cleanUpFunc) {
+	server, cleanup := newTestServer(c)
+	go server.Run()
+	mustWaitLeader(c, []*Server{server})
+	return server, cleanup
+}
+
 var stripUnix = strings.NewReplacer("unix://", "")
 
 func cleanServer(cfg *Config) {

--- a/server/util.go
+++ b/server/util.go
@@ -75,21 +75,6 @@ func PushMetric(cfg *Config) {
 	go metrics.PrometheusPushClient(cfg.Name, metircCfg.PushAddress, interval)
 }
 
-func kvGet(c *clientv3.Client, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
-	kv := clientv3.NewKV(c)
-
-	start := time.Now()
-	ctx, cancel := context.WithTimeout(c.Ctx(), requestTimeout)
-	resp, err := kv.Get(ctx, key, opts...)
-	cancel()
-
-	if cost := time.Now().Sub(start); cost > slowRequestTime {
-		log.Warnf("kv gets %s too slow, resp: %v, err: %v, cost: %s", key, resp, err, cost)
-	}
-
-	return resp, errors.Trace(err)
-}
-
 // A helper function to get value with key from etcd.
 // TODO: return the value revision for outer use.
 func getValue(c *clientv3.Client, key string, opts ...clientv3.OpOption) ([]byte, error) {


### PR DESCRIPTION
Add kv to wrap etcd operations.
Add limit when loading stores and regions, or it may failed when we have a lot of regions.
Load stores and regions inside `clusterInfo` to avoid locks and copies.
