### PR TITLE
server/leader: log pd leader ready to serve

### DIFF
--- a/server/leader.go
+++ b/server/leader.go
@@ -181,6 +181,8 @@ func (s *Server) campaignLeader() error {
 		return errors.Trace(err)
 	}
 
+	log.Infof("PD cluster leader %s is ready to serve", s.Name())
+
 	tsTicker := time.NewTicker(updateTimestampStep)
 	defer tsTicker.Stop()
 


### PR DESCRIPTION
Log pd leader ready to serve.

Only when a pd becomes a leader does it prints `PD cluster leader is ready to serve`. 

PTAL @siddontang @huachaohuang 

Close #363 