### PR TITLE
server/config: use random cluster id for new cluster

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -1,7 +1,5 @@
 # PD Configuration.
 
-cluster-id = 0
-
 name = "pd"
 data-dir = "default.pd"
 

--- a/pd-client/leader_change_test.go
+++ b/pd-client/leader_change_test.go
@@ -51,10 +51,12 @@ func (s *testLeaderChangeSuite) TestLeaderChange(c *C) {
 		}()
 	}
 
+	clusterID := uint64(0)
 	svrs := make(map[string]*server.Server, 3)
 	for i := 0; i < 3; i++ {
 		svr := <-ch
 		svrs[svr.GetAddr()] = svr
+		clusterID = svr.ClusterID()
 	}
 
 	endpoints := make([]string, 0, 3)
@@ -74,7 +76,7 @@ func (s *testLeaderChangeSuite) TestLeaderChange(c *C) {
 		}
 	}()
 
-	cli, err := NewClient(endpoints, 0)
+	cli, err := NewClient(endpoints, clusterID)
 	c.Assert(err, IsNil)
 	defer cli.Close()
 

--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -150,7 +150,7 @@ func (s *testClusterCacheSuite) TestCache(c *C) {
 	c.Assert(err, IsNil)
 	defer conn.Close()
 
-	clusterID := uint64(0)
+	clusterID := s.svr.clusterID
 
 	req := s.newBootstrapRequest(c, clusterID, "127.0.0.1:1")
 	store1 := req.Bootstrap.Store

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -150,11 +150,10 @@ func (s *Server) getClusterRootPath() string {
 // GetRaftCluster gets raft cluster.
 // If cluster has not been bootstrapped, return nil.
 func (s *Server) GetRaftCluster() *RaftCluster {
-	if s.cluster.isRunning() {
-		return s.cluster
+	if s.isClosed() || !s.cluster.isRunning() {
+		return nil
 	}
-
-	return nil
+	return s.cluster
 }
 
 func (s *Server) createRaftCluster() error {

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -230,7 +230,7 @@ func checkBootstrapRequest(clusterID uint64, req *pdpb.BootstrapRequest) error {
 }
 
 func (s *Server) bootstrapCluster(req *pdpb.BootstrapRequest) (*pdpb.Response, error) {
-	clusterID := s.cfg.ClusterID
+	clusterID := s.clusterID
 
 	log.Infof("try to bootstrap raft cluster %d with %v", clusterID, req)
 

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -120,7 +120,7 @@ func (s *testClusterSuite) TestBootstrap(c *C) {
 	c.Assert(err, IsNil)
 	defer conn.Close()
 
-	clusterID := uint64(0)
+	clusterID := s.svr.clusterID
 
 	// IsBootstrapped returns false.
 	req := s.newIsBootstrapRequest(clusterID)
@@ -272,7 +272,7 @@ func (s *testClusterSuite) TestGetPutConfig(c *C) {
 	c.Assert(err, IsNil)
 	defer conn.Close()
 
-	clusterID := uint64(0)
+	clusterID := s.svr.clusterID
 
 	storeAddr := "127.0.0.1:0"
 	s.tryBootstrapCluster(c, conn, clusterID, storeAddr)
@@ -499,7 +499,7 @@ func (s *testClusterSuite) TestClosedChannel(c *C) {
 	c.Assert(err, IsNil)
 	defer conn.Close()
 
-	clusterID := uint64(0)
+	clusterID := svr.clusterID
 	storeAddr := "127.0.0.1:0"
 	s.tryBootstrapCluster(c, conn, clusterID, storeAddr)
 

--- a/server/cluster_worker_test.go
+++ b/server/cluster_worker_test.go
@@ -174,14 +174,13 @@ func (s *testClusterWorkerSuite) newMockRaftStore(c *C, metaStore *metapb.Store)
 }
 
 func (s *testClusterWorkerSuite) SetUpTest(c *C) {
-	s.clusterID = 0
-
 	s.stores = make(map[uint64]*mockRaftStore)
 
 	s.svr, s.cleanup = newTestServer(c)
 	s.svr.cfg.nextRetryDelay = 50 * time.Millisecond
 
 	s.client = s.svr.client
+	s.clusterID = s.svr.clusterID
 
 	s.regionLeaders = make(map[uint64]metapb.Peer)
 

--- a/server/config.go
+++ b/server/config.go
@@ -17,7 +17,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"net/url"
 	"os"
 	"strings"
@@ -64,9 +63,6 @@ type Config struct {
 	// TsoSaveInterval is the interval to save timestamp.
 	TsoSaveInterval timeutil.Duration `toml:"tso-save-interval" json:"tso-save-interval"`
 
-	// ClusterID is the cluster ID communicating with other services.
-	ClusterID uint64 `toml:"cluster-id" json:"cluster-id"`
-
 	// MaxPeerCount for a region. default is 3.
 	MaxPeerCount uint64 `toml:"max-peer-count" json:"max-peer-count"`
 
@@ -90,7 +86,6 @@ func NewConfig() *Config {
 	fs.BoolVar(&cfg.Version, "v", false, "print version information and exit")
 	fs.StringVar(&cfg.configFile, "config", "", "Config file")
 
-	fs.Uint64Var(&cfg.ClusterID, "cluster-id", 0, "initial cluster ID for the pd cluster [deprecated]")
 	fs.StringVar(&cfg.Name, "name", defaultName, "human-readable name for this pd member")
 
 	fs.StringVar(&cfg.DataDir, "data-dir", "", "path to the data directory (default 'default.${name}')")
@@ -174,24 +169,7 @@ func (c *Config) Parse(arguments []string) error {
 		return errors.Errorf("'%s' is an invalid flag", c.FlagSet.Arg(0))
 	}
 
-	c.randomClusterID()
 	return nil
-}
-
-func (c *Config) randomClusterID() {
-	hasClusterID := false
-	c.FlagSet.Visit(func(f *flag.Flag) {
-		if f.Name == "cluster-id" {
-			hasClusterID = true
-		}
-	})
-	if hasClusterID {
-		return
-	}
-
-	// Generate a random cluster ID.
-	ts := uint64(time.Now().Unix())
-	c.ClusterID = (ts << 32) + uint64(rand.Uint32())
 }
 
 func (c *Config) validate() error {
@@ -406,8 +384,6 @@ func (c *Config) genEmbedEtcdConfig() (*embed.Config, error) {
 	cfg.Dir = c.DataDir
 	cfg.WalDir = ""
 	cfg.InitialCluster = c.InitialCluster
-	// Use unique cluster id as the etcd cluster token too.
-	cfg.InitialClusterToken = fmt.Sprintf("pd-%d", c.ClusterID)
 	cfg.ClusterState = c.InitialClusterState
 	cfg.EnablePprof = true
 	cfg.StrictReconfigCheck = !c.disableStrictReconfigCheck
@@ -448,8 +424,6 @@ func unixURL() string {
 // Because pd-client also needs this, so export here.
 func NewTestSingleConfig() *Config {
 	cfg := &Config{
-		// We use cluster 0 for all tests.
-		ClusterID:  0,
 		Name:       "pd",
 		ClientUrls: unixURL(),
 		PeerUrls:   unixURL(),

--- a/server/config.go
+++ b/server/config.go
@@ -17,6 +17,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/url"
 	"os"
 	"strings"
@@ -173,7 +174,24 @@ func (c *Config) Parse(arguments []string) error {
 		return errors.Errorf("'%s' is an invalid flag", c.FlagSet.Arg(0))
 	}
 
+	c.randomClusterID()
 	return nil
+}
+
+func (c *Config) randomClusterID() {
+	hasClusterID := false
+	c.FlagSet.Visit(func(f *flag.Flag) {
+		if f.Name == "cluster-id" {
+			hasClusterID = true
+		}
+	})
+	if hasClusterID {
+		return
+	}
+
+	// Generate a random cluster ID.
+	ts := uint64(time.Now().Unix())
+	c.ClusterID = (ts << 32) + uint64(rand.Uint32())
 }
 
 func (c *Config) validate() error {

--- a/server/config.go
+++ b/server/config.go
@@ -90,7 +90,7 @@ func NewConfig() *Config {
 	fs.BoolVar(&cfg.Version, "v", false, "print version information and exit")
 	fs.StringVar(&cfg.configFile, "config", "", "Config file")
 
-	fs.Uint64Var(&cfg.ClusterID, "cluster-id", 0, "initial cluster ID for the pd cluster")
+	fs.Uint64Var(&cfg.ClusterID, "cluster-id", 0, "initial cluster ID for the pd cluster [deprecated]")
 	fs.StringVar(&cfg.Name, "name", defaultName, "human-readable name for this pd member")
 
 	fs.StringVar(&cfg.DataDir, "data-dir", "", "path to the data directory (default 'default.${name}')")

--- a/server/conn.go
+++ b/server/conn.go
@@ -164,12 +164,12 @@ func (c *conn) handleRequest(req *pdpb.Request) (*pdpb.Response, error) {
 		if req.GetHeader() == nil {
 			req.Header = &pdpb.RequestHeader{}
 		}
-		req.GetHeader().ClusterId = c.s.cfg.ClusterID
+		req.GetHeader().ClusterId = c.s.clusterID
 	}
 
 	clusterID := req.GetHeader().GetClusterId()
-	if clusterID != c.s.cfg.ClusterID {
-		return nil, errors.Errorf("mismatch cluster id, need %d but got %d", c.s.cfg.ClusterID, clusterID)
+	if clusterID != c.s.clusterID {
+		return nil, errors.Errorf("mismatch cluster id, need %d but got %d", c.s.clusterID, clusterID)
 	}
 
 	switch req.GetCmdType() {

--- a/server/conn.go
+++ b/server/conn.go
@@ -159,6 +159,14 @@ func (c *conn) close() error {
 }
 
 func (c *conn) handleRequest(req *pdpb.Request) (*pdpb.Response, error) {
+	// Don't check cluster ID of this command type.
+	if req.GetCmdType() == pdpb.CommandType_GetPDMembers {
+		if req.GetHeader() == nil {
+			req.Header = &pdpb.RequestHeader{}
+		}
+		req.GetHeader().ClusterId = c.s.cfg.ClusterID
+	}
+
 	clusterID := req.GetHeader().GetClusterId()
 	if clusterID != c.s.cfg.ClusterID {
 		return nil, errors.Errorf("mismatch cluster id, need %d but got %d", c.s.cfg.ClusterID, clusterID)

--- a/server/conn.go
+++ b/server/conn.go
@@ -87,7 +87,10 @@ func (c *conn) run() {
 
 		var response *pdpb.Response
 
-		if !c.s.IsLeader() {
+		if err = c.checkRequest(request); err != nil {
+			log.Errorf("check request %s err %v", request, errors.ErrorStack(err))
+			response = newError(err)
+		} else if !c.s.IsLeader() {
 			response, err = p.handleRequest(msgID, request)
 			if err != nil {
 				log.Errorf("proxy request %s err %v", request, errors.ErrorStack(err))
@@ -98,7 +101,6 @@ func (c *conn) run() {
 			if err != nil {
 				log.Errorf("handle request %s err %v", request, errors.ErrorStack(err))
 				response = newError(err)
-
 			}
 		}
 
@@ -158,20 +160,23 @@ func (c *conn) close() error {
 	return errors.Trace(c.conn.Close())
 }
 
-func (c *conn) handleRequest(req *pdpb.Request) (*pdpb.Response, error) {
+func (c *conn) checkRequest(req *pdpb.Request) error {
 	// Don't check cluster ID of this command type.
 	if req.GetCmdType() == pdpb.CommandType_GetPDMembers {
-		if req.GetHeader() == nil {
+		if req.Header == nil {
 			req.Header = &pdpb.RequestHeader{}
 		}
-		req.GetHeader().ClusterId = c.s.clusterID
+		req.Header.ClusterId = c.s.clusterID
 	}
 
 	clusterID := req.GetHeader().GetClusterId()
 	if clusterID != c.s.clusterID {
-		return nil, errors.Errorf("mismatch cluster id, need %d but got %d", c.s.clusterID, clusterID)
+		return errors.Errorf("mismatch cluster id, need %d but got %d", c.s.clusterID, clusterID)
 	}
+	return nil
+}
 
+func (c *conn) handleRequest(req *pdpb.Request) (*pdpb.Response, error) {
 	switch req.GetCmdType() {
 	case pdpb.CommandType_Tso:
 		return c.handleTso(req)

--- a/server/id_test.go
+++ b/server/id_test.go
@@ -89,6 +89,7 @@ func (s *testAllocIDSuite) TestCommand(c *C) {
 	idReq := &pdpb.AllocIdRequest{}
 
 	req := &pdpb.Request{
+		Header:  newRequestHeader(s.svr.clusterID),
 		CmdType: pdpb.CommandType_AllocId,
 		AllocId: idReq,
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -23,11 +23,9 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/embed"
+	"github.com/ngaut/log"
 	. "github.com/pingcap/check"
-	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
-	"github.com/pingcap/pd/pkg/testutil"
 )
 
 func TestServer(t *testing.T) {
@@ -195,88 +193,62 @@ var _ = Suite(&testServerSuite{})
 
 type testServerSuite struct{}
 
-func newTestClusterIDConfig(c *C, args ...string) *Config {
-	cfg := NewConfig()
-	err := cfg.Parse(args)
-	c.Assert(err, IsNil)
+func newTestServersWithCfgs(c *C, cfgs []*Config) ([]*Server, cleanupFunc) {
+	svrs := make([]*Server, 0, len(cfgs))
 
-	cfg.Name = "pd"
-	cfg.ClientUrls = unixURL()
-	cfg.PeerUrls = unixURL()
-	cfg.InitialClusterState = embed.ClusterStateFlagNew
-	cfg.AdvertiseClientUrls = cfg.ClientUrls
-	cfg.AdvertisePeerUrls = cfg.PeerUrls
-	cfg.DataDir = "/tmp/test_pd_cluster_id"
-	cfg.InitialCluster = fmt.Sprintf("pd=%s", cfg.PeerUrls)
-	cfg.disableStrictReconfigCheck = true
-
-	return cfg
-}
-
-func newTestBootstrapRequest(clusterID uint64) *pdpb.Request {
-	store := &metapb.Store{Id: 1}
-	peer := &metapb.Peer{Id: 1, StoreId: 1}
-	region := &metapb.Region{Id: 1, Peers: []*metapb.Peer{peer}}
-	return &pdpb.Request{
-		Header:  newRequestHeader(clusterID),
-		CmdType: pdpb.CommandType_Bootstrap,
-		Bootstrap: &pdpb.BootstrapRequest{
-			Store:  store,
-			Region: region,
-		},
+	ch := make(chan *Server)
+	for _, cfg := range cfgs {
+		go func(cfg *Config) {
+			svr, err := NewServer(cfg)
+			c.Assert(err, IsNil)
+			go svr.Run()
+			ch <- svr
+		}(cfg)
 	}
+
+	for i := 0; i < len(cfgs); i++ {
+		svrs = append(svrs, <-ch)
+	}
+	mustWaitLeader(c, svrs)
+
+	cleanup := func() {
+		for _, svr := range svrs {
+			svr.Close()
+		}
+		for _, cfg := range cfgs {
+			cleanServer(cfg)
+		}
+	}
+
+	return svrs, cleanup
 }
 
-func (s *testServerSuite) mustBootstrapCluster(c *C, cfg *Config) uint64 {
-	svr, err := NewServer(cfg)
-	c.Assert(err, IsNil)
+func (s *testServerSuite) TestClusterID(c *C) {
+	cfgs := NewTestMultiConfig(3)
+	for i, cfg := range cfgs {
+		cfg.DataDir = fmt.Sprintf("/tmp/test_pd_cluster_id_%d", i)
+		cleanServer(cfg)
+	}
 
-	go svr.Run()
-	defer svr.Close()
-	mustWaitLeader(c, []*Server{svr})
+	svrs, cleanup := newTestServersWithCfgs(c, cfgs)
 
-	request := newTestBootstrapRequest(svr.cfg.ClusterID)
-	testutil.MustRPCRequest(c, svr.GetAddr(), request)
-	return svr.cfg.ClusterID
-}
+	// All PDs should have the same cluster ID.
+	clusterID := svrs[0].clusterID
+	c.Assert(clusterID, Not(Equals), uint64(0))
+	for _, svr := range svrs {
+		log.Debug(svr.clusterID)
+		c.Assert(svr.clusterID, Equals, clusterID)
+	}
 
-func (s *testServerSuite) TestFlagClusterID(c *C) {
-	clusterID := uint64(1)
+	// Restart all PDs.
+	for _, svr := range svrs {
+		svr.Close()
+	}
+	svrs, cleanup = newTestServersWithCfgs(c, cfgs)
+	defer cleanup()
 
-	// Bootstrap server with cluster ID specified to 1.
-	cfg := newTestClusterIDConfig(c, "-cluster-id", "1")
-	cleanServer(cfg)
-	c.Assert(cfg.ClusterID, Equals, clusterID)
-	c.Assert(s.mustBootstrapCluster(c, cfg), Equals, clusterID)
-
-	// New config with a random cluster ID.
-	cfg = newTestClusterIDConfig(c)
-	c.Assert(cfg.ClusterID, Not(Equals), uint64(0))
-
-	// New server and the cluster ID is still 1.
-	svr, err := NewServer(cfg)
-	c.Assert(err, IsNil)
-	c.Assert(svr.cfg.ClusterID, Equals, clusterID)
-	svr.Close()
-	cleanServer(cfg)
-}
-
-func (s *testServerSuite) TestRandomClusterID(c *C) {
-	// Bootstrap server with random cluster ID.
-	cfg := newTestClusterIDConfig(c)
-	c.Assert(cfg.ClusterID, Not(Equals), uint64(0))
-	cleanServer(cfg)
-	clusterID := s.mustBootstrapCluster(c, cfg)
-
-	// New config with cluster ID specified to 1.
-	cfg = newTestClusterIDConfig(c, "-cluster-id", "1")
-	c.Assert(cfg.ClusterID, Equals, uint64(1))
-	c.Assert(cfg.ClusterID, Not(Equals), clusterID)
-
-	// New server and the cluster ID is still the original cluster ID.
-	svr, err := NewServer(cfg)
-	c.Assert(err, IsNil)
-	c.Assert(svr.cfg.ClusterID, Equals, clusterID)
-	svr.Close()
-	cleanServer(cfg)
+	// All PDs should have the same cluster ID as before.
+	for _, svr := range svrs {
+		c.Assert(svr.clusterID, Equals, clusterID)
+	}
 }

--- a/server/tso_test.go
+++ b/server/tso_test.go
@@ -68,6 +68,7 @@ func (s *testTsoSuite) testGetTimestamp(c *C, conn net.Conn, n int) pdpb.Timesta
 	}
 
 	req := &pdpb.Request{
+		Header:  newRequestHeader(s.svr.clusterID),
 		CmdType: pdpb.CommandType_Tso,
 		Tso:     tso,
 	}


### PR DESCRIPTION
If the cluster is bootstrapped, use the saved cluster ID.
Else if the cluster ID is specified in the command line flags, use the specified cluster ID.
Else use a random cluster ID.

Closes https://github.com/pingcap/pd/issues/362