### PR TITLE
server/balancer: check started operator

### DIFF
--- a/server/balancer_worker.go
+++ b/server/balancer_worker.go
@@ -100,7 +100,7 @@ func (bw *balancerWorker) addBalanceOperator(regionID uint64, op *balanceOperato
 
 	oldOp, ok := bw.balanceOperators[regionID]
 	if ok {
-		if oldOp.Started {
+		if !oldOp.Start.IsZero() {
 			// Old operator is still in progress, don't replace it.
 			return false
 		}
@@ -125,7 +125,6 @@ func (bw *balancerWorker) addBalanceOperator(regionID uint64, op *balanceOperato
 
 	collectBalancerCounterMetrics(op)
 
-	op.Start = time.Now()
 	bw.balanceOperators[regionID] = op
 	bw.historyOperators.add(regionID, op)
 

--- a/server/balancer_worker.go
+++ b/server/balancer_worker.go
@@ -100,7 +100,7 @@ func (bw *balancerWorker) addBalanceOperator(regionID uint64, op *balanceOperato
 
 	oldOp, ok := bw.balanceOperators[regionID]
 	if ok {
-		if oldOp.Index != 0 {
+		if oldOp.Started {
 			// Old operator is still in progress, don't replace it.
 			return false
 		}

--- a/server/cluster_worker_test.go
+++ b/server/cluster_worker_test.go
@@ -648,6 +648,7 @@ func (s *testClusterWorkerSuite) TestBalanceOperatorPriority(c *C) {
 	c.Assert(resp, DeepEquals, removePeerOperator.ChangePeer)
 	op := bw.getBalanceOperator(region.GetId())
 	c.Assert(op.Type, Equals, balanceOP)
+	bw.removeBalanceOperator(region.GetId())
 
 	err = cluster.putConfig(&metapb.Cluster{
 		Id:           s.clusterID,
@@ -662,22 +663,32 @@ func (s *testClusterWorkerSuite) TestBalanceOperatorPriority(c *C) {
 	// replicaOP finishes immediately, so the op is nil here.
 	c.Assert(op, IsNil)
 
-	// Add an in progress balanceOP.
+	// Add a balanceOP.
 	addPeer := s.newPeer(c, 999, 0)
 	addPeerOperator := newAddPeerOperator(region.GetId(), addPeer)
 	bop = newBalanceOperator(regionInfo, balanceOP, addPeerOperator, removePeerOperator)
-	bop.Index = 1
 	ok = bw.addBalanceOperator(region.GetId(), bop)
 	c.Assert(ok, IsTrue)
 
-	// New adminOP will not replace an in progress balanceOP.
-	aop := newBalanceOperator(regionInfo, adminOP, removePeerOperator)
-	ok = bw.addBalanceOperator(region.GetId(), aop)
-	c.Assert(ok, IsFalse)
+	// Change MaxPeerCount to 1 to let the operator start.
+	cluster.putConfig(&metapb.Cluster{
+		Id:           s.clusterID,
+		MaxPeerCount: 1,
+	})
+	resp = heartbeatRegion(c, conn, s.clusterID, 0, region, leader)
+	c.Assert(resp, DeepEquals, addPeerOperator.ChangePeer)
+
+	// The balanceOP will not replaced by a replicaOP because it has started.
+	cluster.putConfig(&metapb.Cluster{
+		Id:           s.clusterID,
+		MaxPeerCount: 3,
+	})
+	resp = heartbeatRegion(c, conn, s.clusterID, 0, region, leader)
+	c.Assert(resp, DeepEquals, addPeerOperator.ChangePeer)
 	bw.removeBalanceOperator(region.GetId())
 
 	// Add an adminOP.
-	aop = newBalanceOperator(regionInfo, adminOP, removePeerOperator)
+	aop := newBalanceOperator(regionInfo, adminOP, removePeerOperator)
 	ok = bw.addBalanceOperator(region.GetId(), aop)
 	c.Assert(ok, IsTrue)
 	// Add an adminOP again is OK.

--- a/server/operator.go
+++ b/server/operator.go
@@ -69,6 +69,7 @@ type balanceOperator struct {
 	Index    int         `json:"index"`
 	Start    time.Time   `json:"start"`
 	End      time.Time   `json:"end"`
+	Started  bool        `json:"started"`
 	Finished bool        `json:"finished"`
 	Ops      []Operator  `json:"operators"`
 	Region   *regionInfo `json:"region"`
@@ -121,6 +122,11 @@ func (bo *balanceOperator) Do(ctx *opContext, region *regionInfo) (bool, *pdpb.R
 		return true, nil, nil
 	}
 
+	if !bo.Started {
+		bo.Started = true
+		bo.Start = time.Now()
+	}
+
 	finished, res, err := bo.Ops[bo.Index].Do(ctx, region)
 	if err != nil {
 		return false, nil, errors.Trace(err)
@@ -132,6 +138,10 @@ func (bo *balanceOperator) Do(ctx *opContext, region *regionInfo) (bool, *pdpb.R
 	bo.Index++
 
 	bo.Finished = bo.Index >= len(bo.Ops)
+	if bo.Finished {
+		bo.End = time.Now()
+	}
+
 	return bo.Finished, res, nil
 }
 

--- a/server/operator.go
+++ b/server/operator.go
@@ -64,15 +64,13 @@ const (
 
 // balanceOperator is used to do region balance.
 type balanceOperator struct {
-	ID       uint64      `json:"id"`
-	Type     optype      `json:"type"`
-	Index    int         `json:"index"`
-	Start    time.Time   `json:"start"`
-	End      time.Time   `json:"end"`
-	Started  bool        `json:"started"`
-	Finished bool        `json:"finished"`
-	Ops      []Operator  `json:"operators"`
-	Region   *regionInfo `json:"region"`
+	ID     uint64      `json:"id"`
+	Type   optype      `json:"type"`
+	Index  int         `json:"index"`
+	Start  time.Time   `json:"start"`
+	End    time.Time   `json:"end"`
+	Ops    []Operator  `json:"operators"`
+	Region *regionInfo `json:"region"`
 }
 
 func newBalanceOperator(region *regionInfo, optype optype, ops ...Operator) *balanceOperator {
@@ -85,8 +83,8 @@ func newBalanceOperator(region *regionInfo, optype optype, ops ...Operator) *bal
 }
 
 func (bo *balanceOperator) String() string {
-	ret := fmt.Sprintf("[balanceOperator]id: %d, index: %d, start: %s, end: %s, finished: %v, region: %v, ops:",
-		bo.ID, bo.Index, bo.Start, bo.End, bo.Finished, bo.Region)
+	ret := fmt.Sprintf("[balanceOperator]id: %d, index: %d, start: %s, end: %s, region: %v, ops:",
+		bo.ID, bo.Index, bo.Start, bo.End, bo.Region)
 
 	for i := range bo.Ops {
 		ret += fmt.Sprintf(" [%d - %v] ", i, bo.Ops[i])
@@ -98,7 +96,7 @@ func (bo *balanceOperator) String() string {
 // Check checks whether operator already finished or not.
 func (bo *balanceOperator) check(region *regionInfo) (bool, error) {
 	if bo.Index >= len(bo.Ops) {
-		bo.Finished = true
+		bo.End = time.Now()
 		return true, nil
 	}
 
@@ -122,8 +120,7 @@ func (bo *balanceOperator) Do(ctx *opContext, region *regionInfo) (bool, *pdpb.R
 		return true, nil, nil
 	}
 
-	if !bo.Started {
-		bo.Started = true
+	if bo.Start.IsZero() {
 		bo.Start = time.Now()
 	}
 
@@ -137,12 +134,10 @@ func (bo *balanceOperator) Do(ctx *opContext, region *regionInfo) (bool, *pdpb.R
 
 	bo.Index++
 
-	bo.Finished = bo.Index >= len(bo.Ops)
-	if bo.Finished {
+	if bo.Index >= len(bo.Ops) {
 		bo.End = time.Now()
 	}
-
-	return bo.Finished, res, nil
+	return !bo.End.IsZero(), res, nil
 }
 
 // getRegionID returns the region id which the operator for balance.


### PR DESCRIPTION
When the index is 0, the first operator may has started by not finished,
so we need to add a flag to check whether the balancer has started.

Closes https://github.com/pingcap/pd/issues/343.