### PR TITLE
pd-client: close leader connection if not used

### DIFF
--- a/pd-client/conn.go
+++ b/pd-client/conn.go
@@ -88,6 +88,13 @@ func (c *conn) Close() {
 	c.Conn.Close()
 	close(c.quit)
 	c.wg.Wait()
+
+	// Close the connection in case it is not used.
+	select {
+	case conn := <-c.ConnChan:
+		conn.Close()
+	default:
+	}
 }
 
 func (c *conn) connectLeader(urls []string, interval time.Duration) {

--- a/pd-client/leader_change_test.go
+++ b/pd-client/leader_change_test.go
@@ -127,7 +127,6 @@ func mustConnectLeader(c *C, urls []string, leaderAddr string) {
 	case <-time.After(time.Second * 10):
 		c.Fatal("failed to connect to pd")
 	}
-	defer conn.Close()
 
 	conn.wg.Add(1)
 	go conn.connectLeader(urls, time.Second)
@@ -145,4 +144,8 @@ func mustConnectLeader(c *C, urls []string, leaderAddr string) {
 	conn.wg.Add(1)
 	go conn.connectLeader(urls, time.Second)
 	time.Sleep(time.Second * 3)
+	// Ensure the leader connection will be closed if we don't use it.
+	c.Assert(len(conn.ConnChan), Equals, 1)
+	conn.Close()
+	c.Assert(len(conn.ConnChan), Equals, 0)
 }


### PR DESCRIPTION
The leader connection may not be closed if it is not used before the
conn has been closed.