### PR TITLE
server/leader: return error when no leader

### DIFF
--- a/server/api/redirector.go
+++ b/server/api/redirector.go
@@ -27,7 +27,6 @@ const (
 )
 
 const (
-	errNoLeaderFound       = "no leader found"
 	errRedirectFailed      = "redirect failed"
 	errRedirectToNotLeader = "redirect to not leader"
 )
@@ -58,10 +57,6 @@ func (h *redirector) ServeHTTP(w http.ResponseWriter, r *http.Request, next http
 	leader, err := h.s.GetLeader()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	if leader == nil {
-		http.Error(w, errNoLeaderFound, http.StatusInternalServerError)
 		return
 	}
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -218,9 +218,6 @@ func (p *leaderProxy) handleRequest(msgID uint64, req *pdpb.Request) (*pdpb.Resp
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		if leader == nil {
-			return nil, errors.New("no leader")
-		}
 		conn, err := rpcConnect(leader.GetAddr())
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/server/leader_test.go
+++ b/server/leader_test.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/errors"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 )
@@ -40,6 +41,12 @@ func (s *testGetLeaderSuite) SetUpSuite(c *C) {
 
 	svr, err := NewServer(cfg)
 	c.Assert(err, IsNil)
+
+	// There's no leader before the server has started.
+	leader, err := svr.GetLeader()
+	c.Assert(leader, IsNil)
+	c.Assert(errors.Cause(err), Equals, errNoLeader)
+
 	go svr.Run()
 
 	s.svr = svr


### PR DESCRIPTION
The get leader API does not check nil leader, it may panic when no
leader.

I think is more reasonable to return an error when no leader in
`GetLeader()`, so we don't need to check nil leader everywhere.

Ref: https://s3.amazonaws.com/archive.travis-ci.org/jobs/172596650/log.txt