### PR TITLE
server/selector: add selector interface and balance selector

### DIFF
--- a/server/cache.go
+++ b/server/cache.go
@@ -420,6 +420,18 @@ func (c *clusterInfo) randFollowerRegion(storeID uint64) *regionInfo {
 	return c.regions.randFollowerRegion(storeID)
 }
 
+func (c *clusterInfo) getRegionStores(region *regionInfo) []*storeInfo {
+	c.RLock()
+	defer c.RUnlock()
+	var stores []*storeInfo
+	for id := range region.GetStoreIds() {
+		if store := c.stores.getStore(id); store != nil {
+			stores = append(stores, store)
+		}
+	}
+	return stores
+}
+
 // handleStoreHeartbeat updates the store status.
 func (c *clusterInfo) handleStoreHeartbeat(stats *pdpb.StoreStats) error {
 	c.Lock()

--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -353,6 +353,12 @@ func (s *testClusterInfoSuite) testRegionHeartbeat(c *C, cache *clusterInfo) {
 		c.Assert(region, DeepEquals, regions[region.GetId()].Region)
 	}
 
+	for _, region := range regions {
+		for _, store := range cache.getRegionStores(region) {
+			c.Assert(region.GetStorePeer(store.GetId()), NotNil)
+		}
+	}
+
 	// Test with kv.
 	if kv := cache.kv; kv != nil {
 		for _, region := range regions {

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -1,0 +1,43 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+func scheduleLeader(cluster *clusterInfo, s Selector) (*regionInfo, *storeInfo, *storeInfo) {
+	sourceStores := cluster.getStores()
+
+	source := s.SelectSource(sourceStores)
+	if source == nil {
+		return nil, nil, nil
+	}
+
+	region := cluster.randLeaderRegion(source.GetId())
+	if region == nil {
+		return nil, nil, nil
+	}
+
+	followers := region.GetFollowers()
+	targetStores := make([]*storeInfo, 0, len(followers))
+	for id := range followers {
+		if store := cluster.getStore(id); store != nil {
+			targetStores = append(targetStores, store)
+		}
+	}
+
+	target := s.SelectTarget(targetStores)
+	if target == nil {
+		return nil, nil, nil
+	}
+
+	return region, source, target
+}

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -26,16 +26,10 @@ func scheduleLeader(cluster *clusterInfo, s Selector) (*regionInfo, *storeInfo, 
 		return nil, nil, nil
 	}
 
-	followers := region.GetFollowers()
-	targetStores := make([]*storeInfo, 0, len(followers))
-	for id := range followers {
-		if store := cluster.getStore(id); store != nil {
-			targetStores = append(targetStores, store)
-		}
-	}
+	targetStores := cluster.getRegionStores(region)
 
 	target := s.SelectTarget(targetStores)
-	if target == nil {
+	if target == nil || target.GetId() == source.GetId() {
 		return nil, nil, nil
 	}
 

--- a/server/selector.go
+++ b/server/selector.go
@@ -1,0 +1,64 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+// Selector is an interface to select source and target store to schedule.
+type Selector interface {
+	SelectSource(stores []*storeInfo, filters ...Filter) *storeInfo
+	SelectTarget(stores []*storeInfo, filters ...Filter) *storeInfo
+}
+
+type balanceSelector struct {
+	scorer  Scorer
+	filters []Filter
+}
+
+func newBalanceSelector(scorer Scorer, filters []Filter) *balanceSelector {
+	return &balanceSelector{
+		scorer:  scorer,
+		filters: filters,
+	}
+}
+
+func (s *balanceSelector) SelectSource(stores []*storeInfo, filters ...Filter) *storeInfo {
+	var result *storeInfo
+	for _, store := range stores {
+		if filterSource(store, filters) {
+			continue
+		}
+		if filterSource(store, s.filters) {
+			continue
+		}
+		if result == nil || s.scorer.Score(result) < s.scorer.Score(store) {
+			result = store
+		}
+	}
+	return result
+}
+
+func (s *balanceSelector) SelectTarget(stores []*storeInfo, filters ...Filter) *storeInfo {
+	var result *storeInfo
+	for _, store := range stores {
+		if filterTarget(store, filters) {
+			continue
+		}
+		if filterTarget(store, s.filters) {
+			continue
+		}
+		if result == nil || s.scorer.Score(result) > s.scorer.Score(store) {
+			result = store
+		}
+	}
+	return result
+}

--- a/server/selector.go
+++ b/server/selector.go
@@ -32,9 +32,11 @@ func newBalanceSelector(scorer Scorer, filters []Filter) *balanceSelector {
 }
 
 func (s *balanceSelector) SelectSource(stores []*storeInfo, filters ...Filter) *storeInfo {
+	filters = append(s.filters, filters...)
+
 	var result *storeInfo
 	for _, store := range stores {
-		if filterSource(store, append(s.filters, filters...)) {
+		if filterSource(store, filters) {
 			continue
 		}
 		if result == nil || s.scorer.Score(result) < s.scorer.Score(store) {
@@ -45,9 +47,11 @@ func (s *balanceSelector) SelectSource(stores []*storeInfo, filters ...Filter) *
 }
 
 func (s *balanceSelector) SelectTarget(stores []*storeInfo, filters ...Filter) *storeInfo {
+	filters = append(s.filters, filters...)
+
 	var result *storeInfo
 	for _, store := range stores {
-		if filterTarget(store, append(s.filters, filters...)) {
+		if filterTarget(store, filters) {
 			continue
 		}
 		if result == nil || s.scorer.Score(result) > s.scorer.Score(store) {

--- a/server/selector.go
+++ b/server/selector.go
@@ -34,10 +34,7 @@ func newBalanceSelector(scorer Scorer, filters []Filter) *balanceSelector {
 func (s *balanceSelector) SelectSource(stores []*storeInfo, filters ...Filter) *storeInfo {
 	var result *storeInfo
 	for _, store := range stores {
-		if filterSource(store, filters) {
-			continue
-		}
-		if filterSource(store, s.filters) {
+		if filterSource(store, append(s.filters, filters...)) {
 			continue
 		}
 		if result == nil || s.scorer.Score(result) < s.scorer.Score(store) {
@@ -50,10 +47,7 @@ func (s *balanceSelector) SelectSource(stores []*storeInfo, filters ...Filter) *
 func (s *balanceSelector) SelectTarget(stores []*storeInfo, filters ...Filter) *storeInfo {
 	var result *storeInfo
 	for _, store := range stores {
-		if filterTarget(store, filters) {
-			continue
-		}
-		if filterTarget(store, s.filters) {
+		if filterTarget(store, append(s.filters, filters...)) {
 			continue
 		}
 		if result == nil || s.scorer.Score(result) > s.scorer.Score(store) {


### PR DESCRIPTION
We can use selector to abstract different strategies to select the
source and target stores.