### PR TITLE
server: adjust Config immediately after parsing

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -461,6 +461,7 @@ func NewTestSingleConfig() *Config {
 	cfg.tickMs = 100
 	cfg.electionMs = 1000
 
+	cfg.adjust()
 	return cfg
 }
 

--- a/server/config.go
+++ b/server/config.go
@@ -181,7 +181,8 @@ func (c *Config) Parse(arguments []string) error {
 		return errors.Errorf("'%s' is an invalid flag", c.FlagSet.Arg(0))
 	}
 
-	return nil
+	err = c.adjust()
+	return errors.Trace(err)
 }
 
 func (c *Config) validate() error {

--- a/server/join_test.go
+++ b/server/join_test.go
@@ -89,6 +89,8 @@ func startPdWith(cfg *Config) (*Server, error) {
 	abortCh := make(chan struct{}, 1)
 
 	go func() {
+		// TODO: Decouple join from cfg.adjust().
+		cfg.adjust()
 		svr, err := CreateServer(cfg)
 		if err != nil {
 			errCh <- errors.Trace(err)

--- a/server/server.go
+++ b/server/server.go
@@ -93,10 +93,6 @@ func NewServer(cfg *Config) (*Server, error) {
 
 // CreateServer creates the UNINITIALIZED pd server with given configuration.
 func CreateServer(cfg *Config) (*Server, error) {
-	if err := cfg.adjust(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	log.Infof("PD config - %v", cfg)
 
 	s := &Server{


### PR DESCRIPTION
Adjust Config immediately after parsing. Also fix a bug caused by #411 :
```
metricutil.go:83: [error] could not push metrics to Prometheus Pushgateway: unexpected status code 400 while pushing to http://10.9.113.105:9091/metrics/job//instance/10-9-84-63: job name is required
```

PTAL @huachaohuang @siddontang 