### PR TITLE
server: fix data race on initClusterID()

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -235,6 +235,11 @@ func (s *Server) Run() {
 
 // ServeHTTP hijack the HTTP connection and switch to RPC.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Before hijacke any connection, make sure the pd is initialized.
+	if s.isClosed() {
+		return
+	}
+
 	hj, ok := w.(http.Hijacker)
 	if !ok {
 		log.Errorf("server doesn't support hijacking: conn %v", w)


### PR DESCRIPTION
Data race occurred between [server.go#L193](https://github.com/pingcap/pd/blob/master/server/server.go#L193) and [conn.go#L173](https://github.com/pingcap/pd/blob/master/server/conn.go#L173).

PTAL @huachaohuang @siddontang 

Detailed log: 

```
==================
WARNING: DATA RACE
Write at 0x00c42209bb38 by 2016/12/06 06:11:45 conn.go:96: [error] proxy request cmd_type:AllocId alloc_id:<>  err /home/travis/gopath/src/github.com/pingcap/pd/server/leader.go:111: server is closed
/home/travis/gopath/src/github.com/pingcap/pd/server/conn.go:232: 
goroutine 120:
  github.com/pingcap/pd/server.(*Server).initClusterID()
      /home/travis/gopath/src/github.com/pingcap/pd/server/server.go:176 +0x1e0
  github.com/pingcap/pd/server.(*Server).StartEtcd()
      /home/travis/gopath/src/github.com/pingcap/pd/server/server.go:152 +0x71f
  github.com/pingcap/pd/server.NewServer()
      /home/travis/gopath/src/github.com/pingcap/pd/server/server.go:91 +0xbe
  github.com/pingcap/pd/server.(*testGetLeaderSuite).SetUpSuite()
      /home/travis/gopath/src/github.com/pingcap/pd/server/leader_test.go:42 +0x14b
  runtime.call32()
      /home/travis/.gimme/versions/go1.7.3.linux.amd64/src/runtime/asm_amd64.s:479 +0x4b
  reflect.Value.Call()
      /home/travis/.gimme/versions/go1.7.3.linux.amd64/src/reflect/value.go:302 +0xc0
  github.com/pingcap/pd/vendor/github.com/pingcap/check.(*suiteRunner).runFixture.func1()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/pingcap/check/check.go:721 +0x187
  github.com/pingcap/pd/vendor/github.com/pingcap/check.(*suiteRunner).forkCall.func1()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/pingcap/check/check.go:666 +0x89

Previous read at 0x00c42209bb38 by goroutine 252:
  github.com/pingcap/pd/server.(*conn).checkRequest()
      /home/travis/gopath/src/github.com/pingcap/pd/server/conn.go:173 +0xa7
  github.com/pingcap/pd/server.(*conn).run()
      /home/travis/gopath/src/github.com/pingcap/pd/server/conn.go:90 +0x2d8

Goroutine 120 (running) created at:
  github.com/pingcap/pd/vendor/github.com/pingcap/check.(*suiteRunner).forkCall()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/pingcap/check/check.go:667 +0x41c
  github.com/pingcap/pd/vendor/github.com/pingcap/check.(*suiteRunner).runFunc()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/pingcap/check/check.go:673 +0x7e
  github.com/pingcap/pd/vendor/github.com/pingcap/check.(*suiteRunner).runFixture()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/pingcap/check/check.go:722 +0x7e
  github.com/pingcap/pd/vendor/github.com/pingcap/check.(*suiteRunner).run()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/pingcap/check/check.go:612 +0x11d
  github.com/pingcap/pd/vendor/github.com/pingcap/check.Run()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/pingcap/check/run.go:92 +0x5a
  github.com/pingcap/pd/vendor/github.com/pingcap/check.RunAll()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/pingcap/check/run.go:84 +0x112
  github.com/pingcap/pd/vendor/github.com/pingcap/check.TestingT()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/pingcap/check/run.go:72 +0x708
  github.com/pingcap/pd/server.TestServer()
      /home/travis/gopath/src/github.com/pingcap/pd/server/server_test.go:32 +0x38
  testing.tRunner()
      /home/travis/.gimme/versions/go1.7.3.linux.amd64/src/testing/testing.go:610 +0xc9

Goroutine 252 (running) created at:
  github.com/pingcap/pd/server.(*Server).ServeHTTP()
      /home/travis/gopath/src/github.com/pingcap/pd/server/server.go:265 +0x2f7
  net/http.(*ServeMux).ServeHTTP()
      /home/travis/.gimme/versions/go1.7.3.linux.amd64/src/net/http/server.go:2022 +0xa1
  net/http.serverHandler.ServeHTTP()
      /home/travis/.gimme/versions/go1.7.3.linux.amd64/src/net/http/server.go:2202 +0xbb
  net/http.(*conn).serve()
      /home/travis/.gimme/versions/go1.7.3.linux.amd64/src/net/http/server.go:1579 +0x5f6
==================
```