### PR TITLE
pkg/testutil: add some comments

### DIFF
--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -16,21 +16,23 @@ package testutil
 import (
 	"net"
 
-	. "github.com/pingcap/check"
+	"github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/pd/pkg/rpcutil"
 )
 
-func MustRPCCall(c *C, conn net.Conn, request *pdpb.Request) *pdpb.Response {
+// MustRPCCall fails current test if fails to make a RPC call.
+func MustRPCCall(c *check.C, conn net.Conn, request *pdpb.Request) *pdpb.Response {
 	resp, err := rpcutil.Call(conn, 0, request)
-	c.Assert(err, IsNil)
-	c.Assert(resp, NotNil)
+	c.Assert(err, check.IsNil)
+	c.Assert(resp, check.NotNil)
 	return resp
 }
 
-func MustRPCRequest(c *C, urls string, request *pdpb.Request) *pdpb.Response {
+// MustRPCRequest fails current test if fails to make RPC requests.
+func MustRPCRequest(c *check.C, urls string, request *pdpb.Request) *pdpb.Response {
 	resp, err := rpcutil.Request(urls, 0, request)
-	c.Assert(err, IsNil)
-	c.Assert(resp, NotNil)
+	c.Assert(err, check.IsNil)
+	c.Assert(resp, check.NotNil)
 	return resp
 }


### PR DESCRIPTION
This PR addresses issues reported by [Go report card](https://goreportcard.com/report/github.com/pingcap/pd).

Note that gocyclo reports [`handleRequest()`](https://github.com/pingcap/pd/blob/8c16b74224edc3ce913772fff4e480b8d014beba/server/conn.go#L179) is too complex, which I think it is a [false alarm](https://goreportcard.com/report/github.com/pingcap/pd#gocyclo), so I did not make any changes to it.

If we really wants **100%**, we can use a `map[CommandType]func(*pdpb.Request) (*pdpb.Response, error)` later.

PTAL @huachaohuang @siddontang 