### PR TITLE
server/conn: remove EOF log

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -261,6 +261,8 @@ func (p *leaderProxy) handleRequest(msgID uint64, req *pdpb.Request) (*pdpb.Resp
 	return resp, errors.Trace(err)
 }
 
+var errClosed = errors.New("use of closed network connection")
+
 func isUnexpectedConnError(err error) bool {
 	if err == nil {
 		return false
@@ -268,7 +270,7 @@ func isUnexpectedConnError(err error) bool {
 	if errors.Cause(err) == io.EOF {
 		return false
 	}
-	if strings.Contains(err.Error(), "use of closed network connection") {
+	if strings.Contains(err.Error(), errClosed.Error()) {
 		return false
 	}
 	return true

--- a/server/conn.go
+++ b/server/conn.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"io"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/juju/errors"
@@ -73,7 +74,7 @@ func (c *conn) run() {
 		msg := &msgpb.Message{}
 		msgID, err := util.ReadMessage(c.rb, msg)
 		if err != nil {
-			if errors.Cause(err) != io.EOF {
+			if isUnexpectedConnError(err) {
 				log.Errorf("read request message err %v", err)
 			}
 			return
@@ -96,13 +97,17 @@ func (c *conn) run() {
 		} else if !c.s.IsLeader() {
 			response, err = p.handleRequest(msgID, request)
 			if err != nil {
-				log.Errorf("proxy request %s err %v", request, errors.ErrorStack(err))
+				if isUnexpectedConnError(err) {
+					log.Errorf("proxy request %s err %v", request, errors.ErrorStack(err))
+				}
 				response = newError(err)
 			}
 		} else {
 			response, err = c.handleRequest(request)
 			if err != nil {
-				log.Errorf("handle request %s err %v", request, errors.ErrorStack(err))
+				if isUnexpectedConnError(err) {
+					log.Errorf("handle request %s err %v", request, errors.ErrorStack(err))
+				}
 				response = newError(err)
 			}
 		}
@@ -130,12 +135,16 @@ func (c *conn) run() {
 		}
 
 		if err = util.WriteMessage(c.wb, msgID, msg); err != nil {
-			log.Errorf("write response message err %v", err)
+			if isUnexpectedConnError(err) {
+				log.Errorf("write response message err %v", err)
+			}
 			return
 		}
 
 		if err = c.wb.Flush(); err != nil {
-			log.Errorf("flush response message err %v", err)
+			if isUnexpectedConnError(err) {
+				log.Errorf("flush response message err %v", err)
+			}
 			return
 		}
 
@@ -160,7 +169,10 @@ func updateResponse(req *pdpb.Request, resp *pdpb.Response) {
 }
 
 func (c *conn) close() error {
-	return errors.Trace(c.conn.Close())
+	if err := c.conn.Close(); isUnexpectedConnError(err) {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 func (c *conn) checkRequest(req *pdpb.Request) error {
@@ -247,4 +259,17 @@ func (p *leaderProxy) handleRequest(msgID uint64, req *pdpb.Request) (*pdpb.Resp
 		p.conn = nil
 	}
 	return resp, errors.Trace(err)
+}
+
+func isUnexpectedConnError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Cause(err) == io.EOF {
+		return false
+	}
+	if strings.Contains(err.Error(), "use of closed network connection") {
+		return false
+	}
+	return true
 }

--- a/server/conn.go
+++ b/server/conn.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"bufio"
+	"io"
 	"net"
 	"time"
 
@@ -72,7 +73,9 @@ func (c *conn) run() {
 		msg := &msgpb.Message{}
 		msgID, err := util.ReadMessage(c.rb, msg)
 		if err != nil {
-			log.Errorf("read request message err %v", err)
+			if errors.Cause(err) != io.EOF {
+				log.Errorf("read request message err %v", err)
+			}
 			return
 		}
 

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -14,8 +14,10 @@
 package server
 
 import (
+	"io"
 	"time"
 
+	"github.com/juju/errors"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/pd/pkg/testutil"
@@ -88,6 +90,13 @@ func (s *testConnSuite) TestReconnect(c *C) {
 			c.Assert(svr.IsLeader(), IsFalse)
 		}
 	}
+}
+
+func (s *testConnSuite) TestUnexpectedError(c *C) {
+	c.Assert(isUnexpectedConnError(nil), IsFalse)
+	c.Assert(isUnexpectedConnError(errors.Trace(io.EOF)), IsFalse)
+	c.Assert(isUnexpectedConnError(errors.Trace(errClosed)), IsFalse)
+	c.Assert(isUnexpectedConnError(errors.Trace(io.ErrClosedPipe)), IsTrue)
 }
 
 func mustRequest(c *C, s *Server) *pdpb.Response {


### PR DESCRIPTION
EOF means the remote peer closes the connection actively, seems not a server error, we don't need to log it as error to confuse users.