### PR TITLE
cleanup operator and fix some pitfalls

### DIFF
--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -398,38 +398,29 @@ func (s *testReplicaCheckerSuite) TestConstraints(c *C) {
 	checkRemovePeer(c, rc.Check(region), 3)
 }
 
-func checkAddPeer(c *C, bop *balanceOperator, storeID uint64) {
-	op := bop.Ops[0].(*changePeerOperator)
+func checkAddPeer(c *C, bop Operator, storeID uint64) {
+	op := bop.(*regionOperator).Ops[0].(*changePeerOperator)
 	c.Assert(op.ChangePeer.GetChangeType(), Equals, raftpb.ConfChangeType_AddNode)
 	c.Assert(op.ChangePeer.GetPeer().GetStoreId(), Equals, storeID)
 }
 
-func checkRemovePeer(c *C, bop *balanceOperator, storeID uint64) {
-	op := bop.Ops[0].(*changePeerOperator)
+func checkRemovePeer(c *C, bop Operator, storeID uint64) {
+	op := bop.(*regionOperator).Ops[0].(*changePeerOperator)
 	c.Assert(op.ChangePeer.GetChangeType(), Equals, raftpb.ConfChangeType_RemoveNode)
 	c.Assert(op.ChangePeer.GetPeer().GetStoreId(), Equals, storeID)
 }
 
-func checkReplacePeer(c *C, bop *balanceOperator, sourceID, targetID uint64) {
-	op := bop.Ops[0].(*changePeerOperator)
-	c.Assert(op.ChangePeer.GetChangeType(), Equals, raftpb.ConfChangeType_RemoveNode)
-	c.Assert(op.ChangePeer.GetPeer().GetStoreId(), Equals, targetID)
-	op = bop.Ops[1].(*changePeerOperator)
-	c.Assert(op.ChangePeer.GetChangeType(), Equals, raftpb.ConfChangeType_AddNode)
-	c.Assert(op.ChangePeer.GetPeer().GetStoreId(), Equals, sourceID)
-}
-
-func checkTransferPeer(c *C, bop *balanceOperator, sourceID, targetID uint64) {
-	op := bop.Ops[0].(*changePeerOperator)
+func checkTransferPeer(c *C, bop Operator, sourceID, targetID uint64) {
+	op := bop.(*regionOperator).Ops[0].(*changePeerOperator)
 	c.Assert(op.ChangePeer.GetChangeType(), Equals, raftpb.ConfChangeType_AddNode)
 	c.Assert(op.ChangePeer.GetPeer().GetStoreId(), Equals, targetID)
-	op = bop.Ops[1].(*changePeerOperator)
+	op = bop.(*regionOperator).Ops[1].(*changePeerOperator)
 	c.Assert(op.ChangePeer.GetChangeType(), Equals, raftpb.ConfChangeType_RemoveNode)
 	c.Assert(op.ChangePeer.GetPeer().GetStoreId(), Equals, sourceID)
 }
 
-func checkTransferLeader(c *C, bop *balanceOperator, sourceID, targetID uint64) {
-	op := bop.Ops[0].(*transferLeaderOperator)
+func checkTransferLeader(c *C, bop Operator, sourceID, targetID uint64) {
+	op := bop.(*regionOperator).Ops[0].(*transferLeaderOperator)
 	c.Assert(op.OldLeader.GetStoreId(), Equals, sourceID)
 	c.Assert(op.NewLeader.GetStoreId(), Equals, targetID)
 }

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -41,7 +41,7 @@ type coordinator struct {
 	checker *replicaCheckController
 
 	schedulers map[string]*ScheduleController
-	operators  map[ResourceKind]map[uint64]*balanceOperator
+	operators  map[ResourceKind]map[uint64]Operator
 
 	regionCache *expireRegionCache
 	histories   *lruCache
@@ -61,9 +61,9 @@ func newCoordinator(cluster *clusterInfo, opt *scheduleOption) *coordinator {
 	c.ctx, c.cancel = context.WithCancel(context.TODO())
 
 	c.checker = newReplicaCheckController(c)
-	c.operators = make(map[ResourceKind]map[uint64]*balanceOperator)
-	c.operators[leaderKind] = make(map[uint64]*balanceOperator)
-	c.operators[storageKind] = make(map[uint64]*balanceOperator)
+	c.operators = make(map[ResourceKind]map[uint64]Operator)
+	c.operators[leaderKind] = make(map[uint64]Operator)
+	c.operators[storageKind] = make(map[uint64]Operator)
 
 	return c
 }
@@ -76,12 +76,13 @@ func (c *coordinator) dispatch(region *regionInfo) *pdpb.RegionHeartbeatResponse
 		return nil
 	}
 
-	ctx := newOpContext(c.hookStartEvent, c.hookEndEvent)
-	finished, res, err := op.Do(ctx, region)
-	if err != nil {
-		log.Errorf("failed to do operator for region %v: %v", region, err)
+	finished, res, err := op.Do(region)
+	if finished {
+		log.Infof("%v finished", op)
+		c.removeOperator(op)
 	}
-	if err != nil || finished {
+	if err != nil {
+		log.Errorf("%v failed: %v", op, err)
 		c.removeOperator(op)
 	}
 	return res
@@ -155,7 +156,7 @@ func (c *coordinator) runScheduler(s *ScheduleController) {
 				if op == nil {
 					continue
 				}
-				if c.addOperator(s.GetResourceKind(), op) {
+				if c.addOperator(op) {
 					break
 				}
 			}
@@ -166,11 +167,11 @@ func (c *coordinator) runScheduler(s *ScheduleController) {
 	}
 }
 
-func (c *coordinator) addOperator(kind ResourceKind, op *balanceOperator) bool {
+func (c *coordinator) addOperator(op Operator) bool {
 	c.Lock()
 	defer c.Unlock()
 
-	regionID := op.Region.GetId()
+	regionID := op.GetRegionID()
 	if c.getOperatorLocked(regionID) != nil {
 		return false
 	}
@@ -179,15 +180,15 @@ func (c *coordinator) addOperator(kind ResourceKind, op *balanceOperator) bool {
 	}
 
 	collectOperatorCounterMetrics(op)
-	c.operators[kind][op.Region.GetId()] = op
+	c.operators[op.GetResourceKind()][regionID] = op
 	return true
 }
 
-func (c *coordinator) removeOperator(op *balanceOperator) {
+func (c *coordinator) removeOperator(op Operator) {
 	c.Lock()
 	defer c.Unlock()
 
-	regionID := op.Region.GetId()
+	regionID := op.GetRegionID()
 	c.histories.add(regionID, op)
 	c.regionCache.set(regionID, nil)
 
@@ -196,13 +197,13 @@ func (c *coordinator) removeOperator(op *balanceOperator) {
 	}
 }
 
-func (c *coordinator) getOperator(regionID uint64) *balanceOperator {
+func (c *coordinator) getOperator(regionID uint64) Operator {
 	c.RLock()
 	defer c.RUnlock()
 	return c.getOperatorLocked(regionID)
 }
 
-func (c *coordinator) getOperatorLocked(regionID uint64) *balanceOperator {
+func (c *coordinator) getOperatorLocked(regionID uint64) Operator {
 	for _, ops := range c.operators {
 		if op, ok := ops[regionID]; ok {
 			return op
@@ -356,14 +357,14 @@ func (r *replicaCheckController) Check(region *regionInfo) {
 		return
 	}
 
-	if r.c.addOperator(storageKind, op) {
+	if r.c.addOperator(op) {
 		r.lastTime = time.Now()
 	}
 }
 
-func collectOperatorCounterMetrics(bop *balanceOperator) {
+func collectOperatorCounterMetrics(op Operator) {
 	metrics := make(map[string]uint64)
-	for _, op := range bop.Ops {
+	for _, op := range op.(*regionOperator).Ops {
 		switch o := op.(type) {
 		case *changePeerOperator:
 			metrics[o.Name]++

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -76,13 +76,8 @@ func (c *coordinator) dispatch(region *regionInfo) *pdpb.RegionHeartbeatResponse
 		return nil
 	}
 
-	finished, res, err := op.Do(region)
+	res, finished := op.Do(region)
 	if finished {
-		log.Infof("%v finished", op)
-		c.removeOperator(op)
-	}
-	if err != nil {
-		log.Errorf("%v failed: %v", op, err)
 		c.removeOperator(op)
 	}
 	return res

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -23,10 +23,21 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 )
 
-func newTestOperator(regionID uint64) *balanceOperator {
-	return &balanceOperator{
-		Region: newRegionInfo(&metapb.Region{Id: regionID}, nil),
-	}
+type testOperator struct {
+	RegionID uint64
+	Kind     ResourceKind
+}
+
+func newTestOperator(regionID uint64, kind ResourceKind) Operator {
+	region := newRegionInfo(&metapb.Region{Id: regionID}, nil)
+	op := &testOperator{RegionID: regionID, Kind: kind}
+	return newRegionOperator(region, op)
+}
+
+func (op *testOperator) GetRegionID() uint64           { return op.RegionID }
+func (op *testOperator) GetResourceKind() ResourceKind { return op.Kind }
+func (op *testOperator) Do(region *regionInfo) (bool, *pdpb.RegionHeartbeatResponse, error) {
+	return false, nil, nil
 }
 
 var _ = Suite(&testCoordinatorSuite{})
@@ -38,25 +49,26 @@ func (s *testCoordinatorSuite) TestBasic(c *C) {
 	_, opt := newTestScheduleConfig()
 	co := newCoordinator(cluster, opt)
 
-	op := newTestOperator(1)
-	co.addOperator(leaderKind, op)
-	c.Assert(co.getOperatorCount(leaderKind), Equals, 1)
-	c.Assert(co.getOperator(1).Region.GetId(), Equals, op.Region.GetId())
+	op := newTestOperator(1, leaderKind)
+	co.addOperator(op)
+	c.Assert(co.getOperatorCount(op.GetResourceKind()), Equals, 1)
+	c.Assert(co.getOperator(1).GetRegionID(), Equals, op.GetRegionID())
 
 	// Region 1 already has an operator, cannot add another one.
-	co.addOperator(storageKind, op)
-	c.Assert(co.getOperatorCount(storageKind), Equals, 0)
+	op = newTestOperator(1, storageKind)
+	co.addOperator(op)
+	c.Assert(co.getOperatorCount(op.GetResourceKind()), Equals, 0)
 
 	// Region 1 is in region cache, cannot add another one.
 	co.removeOperator(op)
-	co.addOperator(storageKind, op)
-	c.Assert(co.getOperatorCount(storageKind), Equals, 0)
+	co.addOperator(op)
+	c.Assert(co.getOperatorCount(op.GetResourceKind()), Equals, 0)
 
 	// Delete region 1 from region cache, then we can add a new operator.
 	co.regionCache.delete(1)
-	co.addOperator(storageKind, op)
-	c.Assert(co.getOperatorCount(storageKind), Equals, 1)
-	c.Assert(co.getOperator(1).Region.GetId(), Equals, op.Region.GetId())
+	co.addOperator(op)
+	c.Assert(co.getOperatorCount(op.GetResourceKind()), Equals, 1)
+	c.Assert(co.getOperator(1).GetRegionID(), Equals, op.GetRegionID())
 }
 
 func (s *testCoordinatorSuite) TestSchedule(c *C) {
@@ -92,7 +104,6 @@ func (s *testCoordinatorSuite) TestSchedule(c *C) {
 	resp := co.dispatch(region)
 	checkAddPeerResp(c, resp, 1)
 	region.Peers = append(region.Peers, resp.GetChangePeer().GetPeer())
-	c.Assert(co.dispatch(region), IsNil)
 	resp = co.dispatch(region)
 	checkRemovePeerResp(c, resp, 4)
 	region.Peers = []*metapb.Peer{
@@ -186,10 +197,16 @@ func (s *testCoordinatorSuite) TestPeerState(c *C) {
 
 	// If the new peer is pending, the operator will not finish.
 	region.PendingPeers = append(region.PendingPeers, newPeer)
-	checkAddPeerResp(c, co.dispatch(region), 1)
+	c.Assert(co.dispatch(region), IsNil)
+	c.Assert(co.getOperator(region.GetId()), NotNil)
 
 	// The new peer is not pending now, the operator will finish.
+	// And we will proceed to remove peer in store 4.
 	region.PendingPeers = nil
+	resp = co.dispatch(region)
+	checkRemovePeerResp(c, resp, 4)
+	tc.addLeaderRegion(1, 1, 2, 3)
+	region = cluster.getRegion(1)
 	c.Assert(co.dispatch(region), IsNil)
 }
 
@@ -224,14 +241,16 @@ func (s *testCoordinatorSuite) TestAddScheduler(c *C) {
 
 	// Transfer all leaders to store 1.
 	time.Sleep(100 * time.Millisecond)
-	checkTransferLeaderResp(c, co.dispatch(cluster.getRegion(2)), 1)
-	tc.addLeaderRegion(2, 1, 2, 3)
+	region2 := cluster.getRegion(2)
+	checkTransferLeaderResp(c, co.dispatch(region2), 1)
+	region2.Leader = region2.GetStorePeer(1)
+	c.Assert(co.dispatch(region2), IsNil)
+
 	time.Sleep(100 * time.Millisecond)
-	checkTransferLeaderResp(c, co.dispatch(cluster.getRegion(3)), 1)
-	tc.addLeaderRegion(3, 1, 2, 3)
-	time.Sleep(100 * time.Millisecond)
-	c.Assert(co.dispatch(cluster.getRegion(2)), IsNil)
-	c.Assert(co.dispatch(cluster.getRegion(3)), IsNil)
+	region3 := cluster.getRegion(3)
+	checkTransferLeaderResp(c, co.dispatch(region3), 1)
+	region3.Leader = region3.GetStorePeer(1)
+	c.Assert(co.dispatch(region3), IsNil)
 }
 
 var _ = Suite(&testControllerSuite{})
@@ -254,10 +273,10 @@ func (s *testControllerSuite) Test(c *C) {
 func (s *testControllerSuite) test(c *C, co *coordinator, ctrl Controller, kind ResourceKind) {
 	c.Assert(ctrl.AllowSchedule(), IsTrue)
 
-	co.addOperator(kind, newTestOperator(1))
+	co.addOperator(newTestOperator(1, kind))
 	c.Assert(ctrl.AllowSchedule(), IsTrue)
 
-	co.addOperator(kind, newTestOperator(2))
+	co.addOperator(newTestOperator(2, kind))
 	c.Assert(ctrl.AllowSchedule(), IsFalse)
 
 	co.wg.Add(1)

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -36,8 +36,8 @@ func newTestOperator(regionID uint64, kind ResourceKind) Operator {
 
 func (op *testOperator) GetRegionID() uint64           { return op.RegionID }
 func (op *testOperator) GetResourceKind() ResourceKind { return op.Kind }
-func (op *testOperator) Do(region *regionInfo) (bool, *pdpb.RegionHeartbeatResponse, error) {
-	return false, nil, nil
+func (op *testOperator) Do(region *regionInfo) (*pdpb.RegionHeartbeatResponse, bool) {
+	return nil, false
 }
 
 var _ = Suite(&testCoordinatorSuite{})

--- a/server/event.go
+++ b/server/event.go
@@ -159,6 +159,6 @@ func (op *splitOperator) GetResourceKind() ResourceKind {
 }
 
 // Do implements Operator.Do interface.
-func (op *splitOperator) Do(region *regionInfo) (bool, *pdpb.RegionHeartbeatResponse, error) {
-	return true, nil, nil
+func (op *splitOperator) Do(region *regionInfo) (*pdpb.RegionHeartbeatResponse, bool) {
+	return nil, true
 }

--- a/server/event.go
+++ b/server/event.go
@@ -17,6 +17,8 @@ import (
 	"sync/atomic"
 
 	raftpb "github.com/pingcap/kvproto/pkg/eraftpb"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
 )
 
 type statusType byte
@@ -63,6 +65,8 @@ type LogEvent struct {
 		StoreTo   uint64 `json:"store_to"`
 	} `json:"transfer_leader_event,omitempty"`
 }
+
+var baseID uint64
 
 func (c *coordinator) innerPostEvent(evt LogEvent) {
 	key := atomic.AddUint64(&baseID, 1)
@@ -124,4 +128,37 @@ func (c *coordinator) hookStartEvent(op Operator) {
 
 func (c *coordinator) hookEndEvent(op Operator) {
 	c.postEvent(op, evtEnd)
+}
+
+// TODO: These events are duplicated with history operators, we may
+// remove them eventually.
+
+// splitOperator is used to do region split, only for history operator mark.
+type splitOperator struct {
+	Name   string         `json:"name"`
+	Origin *metapb.Region `json:"origin"`
+	Left   *metapb.Region `json:"left"`
+	Right  *metapb.Region `json:"right"`
+}
+
+func newSplitOperator(origin *metapb.Region, left *metapb.Region, right *metapb.Region) *splitOperator {
+	return &splitOperator{
+		Name:   "split",
+		Origin: origin,
+		Left:   left,
+		Right:  right,
+	}
+}
+
+func (op *splitOperator) GetRegionID() uint64 {
+	return op.Origin.GetId()
+}
+
+func (op *splitOperator) GetResourceKind() ResourceKind {
+	return storageKind
+}
+
+// Do implements Operator.Do interface.
+func (op *splitOperator) Do(region *regionInfo) (bool, *pdpb.RegionHeartbeatResponse, error) {
+	return true, nil, nil
 }

--- a/server/operator.go
+++ b/server/operator.go
@@ -50,7 +50,7 @@ func newRegionOperator(region *regionInfo, ops ...Operator) *regionOperator {
 	kind := ops[0].GetResourceKind()
 	for _, op := range ops {
 		if op.GetResourceKind() != kind {
-			log.Fatal("new region operator with ops of different kinds")
+			log.Fatalf("new region operator with ops of different kinds %v and %v", op.GetResourceKind(), kind)
 		}
 	}
 

--- a/server/operator.go
+++ b/server/operator.go
@@ -15,7 +15,6 @@ package server
 
 import (
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	"github.com/juju/errors"
@@ -26,304 +25,187 @@ import (
 )
 
 const (
-	maxOperatorWaitTime        = 10 * time.Minute
-	maxTransferLeaderWaitCount = 3
+	maxOperatorWaitTime = 5 * time.Minute
 )
 
 var (
 	errOperatorTimeout = errors.New("operator timeout")
 )
 
-var baseID uint64
-
-type callback func(op Operator)
-
-type opContext struct {
-	start callback
-	end   callback
-}
-
-func newOpContext(start callback, end callback) *opContext {
-	return &opContext{
-		start: start,
-		end:   end,
-	}
-}
-
-func doCallback(f callback, op Operator) {
-	if f != nil {
-		f(op)
-	}
-}
-
-// Operator is the interface to do some operations.
+// Operator is an interface to schedule region.
 type Operator interface {
-	// Do does the operator, if finished then return true.
-	Do(ctx *opContext, region *regionInfo) (bool, *pdpb.RegionHeartbeatResponse, error)
+	GetRegionID() uint64
+	GetResourceKind() ResourceKind
+	Do(region *regionInfo) (bool, *pdpb.RegionHeartbeatResponse, error)
 }
 
-// balanceOperator is used to do region balance.
-type balanceOperator struct {
-	ID     uint64      `json:"id"`
+type regionOperator struct {
+	Region *regionInfo `json:"region"`
 	Index  int         `json:"index"`
 	Start  time.Time   `json:"start"`
 	End    time.Time   `json:"end"`
 	Ops    []Operator  `json:"operators"`
-	Region *regionInfo `json:"region"`
 }
 
-func newBalanceOperator(region *regionInfo, ops ...Operator) *balanceOperator {
-	return &balanceOperator{
-		ID:     atomic.AddUint64(&baseID, 1),
-		Ops:    ops,
+func newRegionOperator(region *regionInfo, ops ...Operator) *regionOperator {
+	// Do some check here, just fatal because it must be bug.
+	if len(ops) == 0 {
+		log.Fatal("new region operator with no ops")
+	}
+	kind := ops[0].GetResourceKind()
+	for _, op := range ops {
+		if op.GetResourceKind() != kind {
+			log.Fatal("new region operator with ops of different kinds")
+		}
+	}
+
+	return &regionOperator{
 		Region: region,
+		Start:  time.Now(),
+		Ops:    ops,
 	}
 }
 
-func (bo *balanceOperator) String() string {
-	ret := fmt.Sprintf("[balanceOperator]id: %d, index: %d, start: %s, end: %s, region: %v, ops:",
-		bo.ID, bo.Index, bo.Start, bo.End, bo.Region)
-
-	for i := range bo.Ops {
-		ret += fmt.Sprintf(" [%d - %v] ", i, bo.Ops[i])
-	}
-
-	return ret
+func (op *regionOperator) String() string {
+	return fmt.Sprintf("%+v", *op)
 }
 
-// Check checks whether operator already finished or not.
-func (bo *balanceOperator) check(region *regionInfo) (bool, error) {
-	if bo.Index >= len(bo.Ops) {
-		bo.End = time.Now()
-		return true, nil
-	}
-
-	err := checkStaleRegion(bo.Region.Region, region.Region)
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-
-	bo.Region = region.clone()
-
-	return false, nil
+func (op *regionOperator) GetRegionID() uint64 {
+	return op.Region.GetId()
 }
 
-// Do implements Operator.Do interface.
-func (bo *balanceOperator) Do(ctx *opContext, region *regionInfo) (bool, *pdpb.RegionHeartbeatResponse, error) {
-	ok, err := bo.check(region)
-	if err != nil {
-		return false, nil, errors.Trace(err)
-	}
-	if ok {
-		return true, nil, nil
-	}
+func (op *regionOperator) GetResourceKind() ResourceKind {
+	return op.Ops[0].GetResourceKind()
+}
 
-	if bo.Start.IsZero() {
-		bo.Start = time.Now()
-	}
-	if time.Since(bo.Start) > maxOperatorWaitTime {
+func (op *regionOperator) Do(region *regionInfo) (bool, *pdpb.RegionHeartbeatResponse, error) {
+	if time.Since(op.Start) > maxOperatorWaitTime {
 		return false, nil, errors.Trace(errOperatorTimeout)
 	}
-
-	finished, res, err := bo.Ops[bo.Index].Do(ctx, region)
-	if err != nil {
+	if err := checkStaleRegion(op.Region.Region, region.Region); err != nil {
 		return false, nil, errors.Trace(err)
 	}
-	if !finished {
-		return false, res, nil
+	op.Region = region.clone()
+
+	// If an operator is not finished, do it.
+	for ; op.Index < len(op.Ops); op.Index++ {
+		finished, res, err := op.Ops[op.Index].Do(region)
+		if !finished {
+			return finished, res, err
+		}
 	}
 
-	bo.Index++
-
-	if bo.Index >= len(bo.Ops) {
-		bo.End = time.Now()
-	}
-	return !bo.End.IsZero(), res, nil
+	return true, nil, nil
 }
 
-// getRegionID returns the region id which the operator for balance.
-func (bo *balanceOperator) getRegionID() uint64 {
-	return bo.Region.GetId()
-}
-
-// changePeerOperator is used to do peer change.
 type changePeerOperator struct {
-	ChangePeer *pdpb.ChangePeer `json:"operator"`
-	RegionID   uint64           `json:"regionid"`
 	Name       string           `json:"name"`
-	firstCheck bool
+	RegionID   uint64           `json:"region_id"`
+	ChangePeer *pdpb.ChangePeer `json:"change_peer"`
 }
 
 func newAddPeerOperator(regionID uint64, peer *metapb.Peer) *changePeerOperator {
 	return &changePeerOperator{
+		Name:     "add_peer",
+		RegionID: regionID,
 		ChangePeer: &pdpb.ChangePeer{
 			ChangeType: raftpb.ConfChangeType_AddNode.Enum(),
 			Peer:       peer,
 		},
-		RegionID:   regionID,
-		Name:       "add_peer",
-		firstCheck: true,
 	}
 }
 
 func newRemovePeerOperator(regionID uint64, peer *metapb.Peer) *changePeerOperator {
 	return &changePeerOperator{
+		Name:     "remove_peer",
+		RegionID: regionID,
 		ChangePeer: &pdpb.ChangePeer{
 			ChangeType: raftpb.ConfChangeType_RemoveNode.Enum(),
 			Peer:       peer,
 		},
-		RegionID:   regionID,
-		Name:       "remove_peer",
-		firstCheck: true,
 	}
 }
 
-func (co *changePeerOperator) String() string {
-	return fmt.Sprintf("[changePeerOperator]regionID: %d, changePeer: %v", co.RegionID, co.ChangePeer)
+func (op *changePeerOperator) String() string {
+	return fmt.Sprintf("%+v", *op)
 }
 
-// check checks whether operator already finished or not.
-func (co *changePeerOperator) check(region *regionInfo) (bool, error) {
-	peer := co.ChangePeer.GetPeer()
-	if co.ChangePeer.GetChangeType() == raftpb.ConfChangeType_AddNode {
+func (op *changePeerOperator) GetRegionID() uint64 {
+	return op.RegionID
+}
+
+func (op *changePeerOperator) GetResourceKind() ResourceKind {
+	return storageKind
+}
+
+func (op *changePeerOperator) Do(region *regionInfo) (bool, *pdpb.RegionHeartbeatResponse, error) {
+	// Check if operator is finished.
+	peer := op.ChangePeer.GetPeer()
+	switch op.ChangePeer.GetChangeType() {
+	case raftpb.ConfChangeType_AddNode:
 		if region.GetPendingPeer(peer.GetId()) != nil {
-			// We don't know whether the added peer can work or not.
-			return false, nil
+			// Peer is added but not finished.
+			return false, nil, nil
 		}
 		if region.GetPeer(peer.GetId()) != nil {
-			return true, nil
+			// Peer is added and finished.
+			return true, nil, nil
 		}
-		log.Infof("balance [%s], try to add peer %s", region, peer)
-	} else if co.ChangePeer.GetChangeType() == raftpb.ConfChangeType_RemoveNode {
+	case raftpb.ConfChangeType_RemoveNode:
 		if region.GetPeer(peer.GetId()) == nil {
-			return true, nil
+			// Peer is removed.
+			return true, nil, nil
 		}
-		log.Infof("balance [%s], try to remove peer %s", region, peer)
 	}
 
-	return false, nil
-}
-
-// Do implements Operator.Do interface.
-func (co *changePeerOperator) Do(ctx *opContext, region *regionInfo) (bool, *pdpb.RegionHeartbeatResponse, error) {
-	ok, err := co.check(region)
-	if err != nil {
-		return false, nil, errors.Trace(err)
-	}
-	if ok {
-		return true, nil, nil
-	}
-
-	if co.firstCheck {
-		doCallback(ctx.start, co)
-		co.firstCheck = false
-	}
+	log.Infof("%s %s", op, region)
 
 	res := &pdpb.RegionHeartbeatResponse{
-		ChangePeer: co.ChangePeer,
+		ChangePeer: op.ChangePeer,
 	}
 	return false, res, nil
 }
 
-// transferLeaderOperator is used to do leader transfer.
 type transferLeaderOperator struct {
-	Count int `json:"count"`
-
+	Name      string       `json:"name"`
+	RegionID  uint64       `json:"region_id"`
 	OldLeader *metapb.Peer `json:"old_leader"`
 	NewLeader *metapb.Peer `json:"new_leader"`
-
-	RegionID uint64 `json:"regionid"`
-	Name     string `json:"name"`
-
-	firstCheck    bool
-	startCallback func(op Operator)
-	endCallback   func(op Operator)
 }
 
-func newTransferLeaderOperator(regionID uint64, oldLeader *metapb.Peer, newLeader *metapb.Peer) *transferLeaderOperator {
+func newTransferLeaderOperator(regionID uint64, oldLeader, newLeader *metapb.Peer) *transferLeaderOperator {
 	return &transferLeaderOperator{
-		OldLeader:  oldLeader,
-		NewLeader:  newLeader,
-		RegionID:   regionID,
-		Name:       "transfer_leader",
-		firstCheck: true,
+		Name:      "transfer_leader",
+		RegionID:  regionID,
+		OldLeader: oldLeader,
+		NewLeader: newLeader,
 	}
 }
 
-func (tlo *transferLeaderOperator) String() string {
-	return fmt.Sprintf("[transferLeaderOperator]count: %d,  oldLeader: %v, newLeader: %v",
-		tlo.Count, tlo.OldLeader, tlo.NewLeader)
+func (op *transferLeaderOperator) String() string {
+	return fmt.Sprintf("%+v", *op)
 }
 
-// check checks whether operator already finished or not.
-func (tlo *transferLeaderOperator) check(region *regionInfo) (bool, error) {
-	if region.Leader == nil {
-		return false, errors.New("invalid leader peer")
-	}
-
-	// If the leader has already been changed to new leader, we finish it.
-	if region.Leader.GetId() == tlo.NewLeader.GetId() {
-		return true, nil
-	}
-
-	log.Infof("balance [%d][%s], try to transfer leader from %s to %s", tlo.Count, region, tlo.OldLeader, tlo.NewLeader)
-	return false, nil
+func (op *transferLeaderOperator) GetRegionID() uint64 {
+	return op.RegionID
 }
 
-// Do implements Operator.Do interface.
-func (tlo *transferLeaderOperator) Do(ctx *opContext, region *regionInfo) (bool, *pdpb.RegionHeartbeatResponse, error) {
-	ok, err := tlo.check(region)
-	if err != nil {
-		return false, nil, errors.Trace(err)
-	}
-	if ok {
-		doCallback(ctx.end, tlo)
+func (op *transferLeaderOperator) GetResourceKind() ResourceKind {
+	return leaderKind
+}
+
+func (op *transferLeaderOperator) Do(region *regionInfo) (bool, *pdpb.RegionHeartbeatResponse, error) {
+	// Check if operator is finished.
+	if region.Leader.GetId() == op.NewLeader.GetId() {
 		return true, nil, nil
 	}
 
-	if tlo.firstCheck {
-		doCallback(ctx.start, tlo)
-		tlo.firstCheck = false
-	}
-
-	// If tlo.count is greater than 0, then we should check whether it exceeds the maxTransferLeaderWaitCount.
-	if tlo.Count > 0 {
-		if tlo.Count >= maxTransferLeaderWaitCount {
-			return false, nil, errors.Errorf("transfer leader operator called %d times but still be unsucceessful - %v", tlo.Count, tlo)
-		}
-
-		tlo.Count++
-		return false, nil, nil
-	}
+	log.Infof("%s %v", op, region)
 
 	res := &pdpb.RegionHeartbeatResponse{
 		TransferLeader: &pdpb.TransferLeader{
-			Peer: tlo.NewLeader,
+			Peer: op.NewLeader,
 		},
 	}
-	tlo.Count++
 	return false, res, nil
-}
-
-// splitOperator is used to do region split, only for history operator mark.
-type splitOperator struct {
-	Origin *metapb.Region `json:"origin"`
-	Left   *metapb.Region `json:"left"`
-	Right  *metapb.Region `json:"right"`
-
-	Name string `json:"name"`
-}
-
-func newSplitOperator(origin *metapb.Region, left *metapb.Region, right *metapb.Region) *splitOperator {
-	return &splitOperator{
-		Origin: origin,
-		Left:   left,
-		Right:  right,
-		Name:   "split",
-	}
-}
-
-// Do implements Operator.Do interface.
-func (so *splitOperator) Do(ctx *opContext, region *regionInfo) (bool, *pdpb.RegionHeartbeatResponse, error) {
-	return true, nil, nil
 }

--- a/server/region.go
+++ b/server/region.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/btree"
@@ -52,6 +53,10 @@ func (r *regionInfo) clone() *regionInfo {
 		DownPeers:    downPeers,
 		PendingPeers: pendingPeers,
 	}
+}
+
+func (r *regionInfo) String() string {
+	return fmt.Sprintf("%+v", *r)
 }
 
 func (r *regionInfo) GetPeer(peerID uint64) *metapb.Peer {

--- a/server/scheduler_test.go
+++ b/server/scheduler_test.go
@@ -43,12 +43,12 @@ func (s *testShuffleLeaderSuite) Test(c *C) {
 
 	for i := 0; i < 4; i++ {
 		bop := sl.Schedule(cluster)
-		op := bop.Ops[0].(*transferLeaderOperator)
+		op := bop.(*regionOperator).Ops[0].(*transferLeaderOperator)
 
 		sourceID := op.OldLeader.GetStoreId()
 
 		bop = sl.Schedule(cluster)
-		op = bop.Ops[0].(*transferLeaderOperator)
+		op = bop.(*regionOperator).Ops[0].(*transferLeaderOperator)
 		c.Assert(op.NewLeader.GetStoreId(), Equals, sourceID)
 	}
 }


### PR DESCRIPTION
Cleanup the operator interface and implementation, fix some pitfalls:
- associate ResourceKind with operator;
- don't resend add peer response when the added peer is pending.