### PR TITLE
conf: update default configs to speed up schedule

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -26,13 +26,13 @@ min-region-count = 10
 min-leader-count = 10
 max-snapshot-count = 3
 min-balance-diff-ratio = 0.01
-max-store-down-duration = "30m"
+max-store-down-duration = "1h"
 leader-schedule-limit = 8
-leader-schedule-interval = "10s"
+leader-schedule-interval = "1s"
 storage-schedule-limit = 4
-storage-schedule-interval = "30s"
+storage-schedule-interval = "1s"
 replica-schedule-limit = 8
-replica-schedule-interval = "10s"
+replica-schedule-interval = "1s"
 
 [metric]
 # prometheus client push interval, set "0s" to disable prometheus.

--- a/server/config.go
+++ b/server/config.go
@@ -313,13 +313,13 @@ const (
 	defaultMinLeaderCount          = uint64(10)
 	defaultMaxSnapshotCount        = uint64(3)
 	defaultMinBalanceDiffRatio     = float64(0.01)
-	defaultMaxStoreDownDuration    = 30 * time.Minute
+	defaultMaxStoreDownDuration    = time.Hour
 	defaultLeaderScheduleLimit     = 8
-	defaultLeaderScheduleInterval  = 10 * time.Second
+	defaultLeaderScheduleInterval  = time.Second
 	defaultStorageScheduleLimit    = 4
-	defaultStorageScheduleInterval = 30 * time.Second
+	defaultStorageScheduleInterval = time.Second
 	defaultReplicaScheduleLimit    = 8
-	defaultReplicaScheduleInterval = 10 * time.Second
+	defaultReplicaScheduleInterval = time.Second
 )
 
 func newScheduleConfig() *ScheduleConfig {


### PR DESCRIPTION
The original default configs seems too conservative for most cases.