### PR TITLE
server: add location awareness replication

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -40,3 +40,8 @@ replica-schedule-interval = "1s"
 [replication]
 # The number of replicas for each region.
 max-replicas = 3
+# The label keys specified the location of a store.
+# The placement priorities is implied by the order of label keys.
+# For example, ["zone", "rack"] means that we should place replicas to
+# different zones first, then to different racks if we don't have enough zones.
+location-labels = []

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -43,21 +43,23 @@ func (l *leaderBalancer) GetResourceKind() ResourceKind {
 }
 
 func (l *leaderBalancer) Schedule(cluster *clusterInfo) Operator {
-	region, source, target := scheduleLeader(cluster, l.selector)
+	region, newLeader := scheduleTransferLeader(cluster, l.selector)
 	if region == nil {
 		return nil
 	}
 
-	diff := source.leaderRatio() - target.leaderRatio()
-	if diff < l.opt.GetMinBalanceDiffRatio() {
+	source := cluster.getStore(region.Leader.GetStoreId())
+	target := cluster.getStore(newLeader.GetStoreId())
+	if source.leaderRatio()-target.leaderRatio() < l.opt.GetMinBalanceDiffRatio() {
 		return nil
 	}
 
-	return newTransferLeader(region, target.GetId())
+	return newTransferLeader(region, newLeader)
 }
 
 type storageBalancer struct {
 	opt      *scheduleOption
+	rep      *Replication
 	selector Selector
 }
 
@@ -69,6 +71,7 @@ func newStorageBalancer(opt *scheduleOption) *storageBalancer {
 
 	return &storageBalancer{
 		opt:      opt,
+		rep:      opt.GetReplication(),
 		selector: newBalanceSelector(storageKind, filters),
 	}
 }
@@ -82,98 +85,158 @@ func (s *storageBalancer) GetResourceKind() ResourceKind {
 }
 
 func (s *storageBalancer) Schedule(cluster *clusterInfo) Operator {
-	region, source, target := scheduleStorage(cluster, s.opt, s.selector)
+	// Select a peer from the store with largest storage ratio.
+	region, oldPeer := scheduleRemovePeer(cluster, s.selector)
 	if region == nil {
 		return nil
 	}
 
-	diff := source.storageRatio() - target.storageRatio()
-	if diff < s.opt.GetMinBalanceDiffRatio() {
+	// We don't schedule region with abnormal number of replicas.
+	if len(region.GetPeers()) != s.rep.GetMaxReplicas() {
 		return nil
 	}
 
-	oldPeer := region.GetStorePeer(source.GetId())
-	newPeer, err := cluster.allocPeer(target.GetId())
-	if err != nil {
-		log.Errorf("failed to allocate peer: %v", err)
+	stores := cluster.getRegionStores(region)
+	source := cluster.getStore(oldPeer.GetStoreId())
+
+	// Allocate a new peer from the store with smallest storage ratio.
+	// We need to ensure the target store will not break the replication constraints.
+	excluded := newExcludedFilter(nil, region.GetStoreIds())
+	replication := newReplicationFilter(s.rep, stores, source)
+	newPeer := scheduleAddPeer(cluster, s.selector, excluded, replication)
+	if newPeer == nil {
+		return nil
+	}
+
+	target := cluster.getStore(newPeer.GetStoreId())
+	if source.storageRatio()-target.storageRatio() < s.opt.GetMinBalanceDiffRatio() {
 		return nil
 	}
 
 	return newTransferPeer(region, oldPeer, newPeer)
 }
 
-// replicaChecker ensures region has enough replicas.
+// replicaChecker ensures region has the best replicas.
 type replicaChecker struct {
-	cluster  *clusterInfo
-	opt      *scheduleOption
-	selector Selector
+	opt     *scheduleOption
+	rep     *Replication
+	cluster *clusterInfo
+	filters []Filter
 }
 
-func newReplicaChecker(cluster *clusterInfo, opt *scheduleOption) *replicaChecker {
+func newReplicaChecker(opt *scheduleOption, cluster *clusterInfo) *replicaChecker {
 	var filters []Filter
 	filters = append(filters, newStateFilter(opt))
 	filters = append(filters, newSnapshotCountFilter(opt))
 
 	return &replicaChecker{
-		cluster:  cluster,
-		opt:      opt,
-		selector: newBalanceSelector(storageKind, filters),
+		opt:     opt,
+		rep:     opt.GetReplication(),
+		cluster: cluster,
+		filters: filters,
 	}
 }
 
 func (r *replicaChecker) Check(region *regionInfo) Operator {
-	// If we have bad peer, we remove it first.
-	for _, peer := range r.collectBadPeers(region) {
-		return newRemovePeer(region, peer)
+	if op := r.checkDownPeer(region); op != nil {
+		return op
+	}
+	if op := r.checkOfflinePeer(region); op != nil {
+		return op
 	}
 
-	stores := r.cluster.getRegionStores(region)
-
-	// Remove redundant replicas.
-	if len(stores) > r.opt.GetMaxReplicas() {
-		source := r.selector.SelectSource(stores)
-		return newRemovePeer(region, region.GetStorePeer(source.GetId()))
+	if len(region.GetPeers()) < r.rep.GetMaxReplicas() {
+		newPeer, _ := r.addPeer(region)
+		if newPeer == nil {
+			return nil
+		}
+		return newAddPeer(region, newPeer)
 	}
 
-	// Ensure enough replicas.
-	if len(stores) < r.opt.GetMaxReplicas() {
-		return r.addPeer(region)
+	if len(region.GetPeers()) > r.rep.GetMaxReplicas() {
+		oldPeer, _ := r.removePeer(region)
+		if oldPeer == nil {
+			return nil
+		}
+		return newRemovePeer(region, oldPeer)
 	}
 
-	return nil
+	return r.checkBetterPeer(region)
 }
 
-func (r *replicaChecker) addPeer(region *regionInfo, filters ...Filter) Operator {
-	stores := r.cluster.getStores()
+// addPeer returns the best peer in other stores.
+func (r *replicaChecker) addPeer(region *regionInfo, filters ...Filter) (*metapb.Peer, int) {
+	filters = append(filters, r.filters...)
+	filters = append(filters, newExcludedFilter(nil, region.GetStoreIds()))
 
-	excluded := newExcludedFilter(nil, region.GetStoreIds())
-	target := r.selector.SelectTarget(stores, append(filters, excluded)...)
-	if target == nil {
-		return nil
-	}
+	var (
+		maxStore *storeInfo
+		maxScore int
+	)
 
-	newPeer, err := r.cluster.allocPeer(target.GetId())
-	if err != nil {
-		log.Errorf("failed to allocate peer: %v", err)
-		return nil
-	}
-
-	return newAddPeer(region, newPeer)
-}
-
-func (r *replicaChecker) collectBadPeers(region *regionInfo) map[uint64]*metapb.Peer {
-	badPeers := r.collectDownPeers(region)
-	for _, peer := range region.GetPeers() {
-		store := r.cluster.getStore(peer.GetStoreId())
-		if store == nil || !store.isUp() {
-			badPeers[peer.GetStoreId()] = peer
+	// Find the store with maximum score.
+	regionStores := r.cluster.getRegionStores(region)
+	for _, store := range r.cluster.getStores() {
+		if filterTarget(store, filters) {
+			continue
+		}
+		score := r.rep.GetReplicaScore(regionStores, store)
+		if maxStore == nil || compareStoreScore(store, score, maxStore, maxScore) > 0 {
+			maxStore = store
+			maxScore = score
 		}
 	}
-	return badPeers
+
+	if maxStore == nil {
+		return nil, 0
+	}
+
+	newPeer, err := r.cluster.allocPeer(maxStore.GetId())
+	if err != nil {
+		log.Errorf("failed to allocate peer: %v", err)
+		return nil, 0
+	}
+	return newPeer, maxScore
 }
 
-func (r *replicaChecker) collectDownPeers(region *regionInfo) map[uint64]*metapb.Peer {
-	downPeers := make(map[uint64]*metapb.Peer)
+// removePeer returns the worst peer in the region.
+func (r *replicaChecker) removePeer(region *regionInfo, filters ...Filter) (*metapb.Peer, int) {
+	filters = append(filters, r.filters...)
+
+	var (
+		minStore *storeInfo
+		minScore int
+	)
+
+	// Find the store with minimum score.
+	regionStores := r.cluster.getRegionStores(region)
+	for _, store := range regionStores {
+		if filterSource(store, filters) {
+			continue
+		}
+		score := r.rep.GetReplicaScore(regionStores, store)
+		if minStore == nil || compareStoreScore(store, score, minStore, minScore) < 0 {
+			minStore = store
+			minScore = score
+		}
+	}
+
+	if minStore == nil {
+		return nil, 0
+	}
+	return region.GetStorePeer(minStore.GetId()), minScore
+}
+
+// replacePeer returns the best peer to replace the region peer.
+func (r *replicaChecker) replacePeer(region *regionInfo, peer *metapb.Peer) (*metapb.Peer, int) {
+	// Get a new region without the peer we are going to replace.
+	newRegion := region.clone()
+	newRegion.RemoveStorePeer(peer.GetStoreId())
+	// Get the best peer in other stores.
+	return r.addPeer(newRegion, newExcludedFilter(nil, region.GetStoreIds()))
+}
+
+func (r *replicaChecker) checkDownPeer(region *regionInfo) Operator {
 	for _, stats := range region.DownPeers {
 		peer := stats.GetPeer()
 		if peer == nil {
@@ -186,7 +249,38 @@ func (r *replicaChecker) collectDownPeers(region *regionInfo) map[uint64]*metapb
 		if stats.GetDownSeconds() < uint64(r.opt.GetMaxStoreDownTime().Seconds()) {
 			continue
 		}
-		downPeers[peer.GetStoreId()] = peer
+		return newRemovePeer(region, peer)
 	}
-	return downPeers
+	return nil
+}
+
+func (r *replicaChecker) checkOfflinePeer(region *regionInfo) Operator {
+	for _, peer := range region.GetPeers() {
+		store := r.cluster.getStore(peer.GetStoreId())
+		if store == nil || store.isUp() {
+			continue
+		}
+		newPeer, _ := r.replacePeer(region, peer)
+		if newPeer == nil {
+			return nil
+		}
+		return newTransferPeer(region, peer, newPeer)
+	}
+	return nil
+}
+
+func (r *replicaChecker) checkBetterPeer(region *regionInfo) Operator {
+	oldPeer, oldScore := r.removePeer(region)
+	if oldPeer == nil {
+		return nil
+	}
+	newPeer, newScore := r.replacePeer(region, oldPeer)
+	if newPeer == nil {
+		return nil
+	}
+	// We can't find a better peer.
+	if newScore <= oldScore {
+		return nil
+	}
+	return newTransferPeer(region, oldPeer, newPeer)
 }

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -194,7 +194,7 @@ func (r *replicaChecker) selectBestPeer(region *regionInfo, filters ...Filter) (
 		bestScore int
 	)
 
-	// Find the store with maximum score.
+	// Find the store with best score.
 	regionStores := r.cluster.getRegionStores(region)
 	for _, store := range r.cluster.getStores() {
 		if filterTarget(store, filters) {
@@ -228,7 +228,7 @@ func (r *replicaChecker) selectWorstPeer(region *regionInfo, filters ...Filter) 
 		worstScore int
 	)
 
-	// Find the store with minimum score.
+	// Find the store with worst score.
 	regionStores := r.cluster.getRegionStores(region)
 	for _, store := range regionStores {
 		if filterSource(store, filters) {
@@ -277,7 +277,7 @@ func (r *replicaChecker) checkDownPeer(region *regionInfo) Operator {
 func (r *replicaChecker) checkOfflinePeer(region *regionInfo) Operator {
 	for _, peer := range region.GetPeers() {
 		store := r.cluster.getStore(peer.GetStoreId())
-		if store == nil || store.isUp() {
+		if store.isUp() {
 			continue
 		}
 		newPeer, _ := r.selectBestReplacement(region, peer)

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -185,13 +185,13 @@ func (r *replicaChecker) Check(region *regionInfo) Operator {
 }
 
 // selectBestPeer returns the best peer in other stores.
-func (r *replicaChecker) selectBestPeer(region *regionInfo, filters ...Filter) (*metapb.Peer, int) {
+func (r *replicaChecker) selectBestPeer(region *regionInfo, filters ...Filter) (*metapb.Peer, float64) {
 	filters = append(filters, r.filters...)
 	filters = append(filters, newExcludedFilter(nil, region.GetStoreIds()))
 
 	var (
 		bestStore *storeInfo
-		bestScore int
+		bestScore float64
 	)
 
 	// Find the store with best score.
@@ -220,12 +220,12 @@ func (r *replicaChecker) selectBestPeer(region *regionInfo, filters ...Filter) (
 }
 
 // selectWorstPeer returns the worst peer in the region.
-func (r *replicaChecker) selectWorstPeer(region *regionInfo, filters ...Filter) (*metapb.Peer, int) {
+func (r *replicaChecker) selectWorstPeer(region *regionInfo, filters ...Filter) (*metapb.Peer, float64) {
 	filters = append(filters, r.filters...)
 
 	var (
 		worstStore *storeInfo
-		worstScore int
+		worstScore float64
 	)
 
 	// Find the store with worst score.
@@ -248,7 +248,7 @@ func (r *replicaChecker) selectWorstPeer(region *regionInfo, filters ...Filter) 
 }
 
 // selectBestReplacement returns the best peer to replace the region peer.
-func (r *replicaChecker) selectBestReplacement(region *regionInfo, peer *metapb.Peer) (*metapb.Peer, int) {
+func (r *replicaChecker) selectBestReplacement(region *regionInfo, peer *metapb.Peer) (*metapb.Peer, float64) {
 	// Get a new region without the peer we are going to replace.
 	newRegion := region.clone()
 	newRegion.RemoveStorePeer(peer.GetStoreId())
@@ -298,7 +298,7 @@ func (r *replicaChecker) checkBetterPeer(region *regionInfo) Operator {
 	if newPeer == nil {
 		return nil
 	}
-	// We can't find a better peer (the smaller the better).
+	// We can't find a better peer (the lower the better).
 	if newScore >= oldScore {
 		return nil
 	}

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -226,16 +226,56 @@ func (s *testStorageBalancerSuite) TestBalance(c *C) {
 	c.Assert(sb.Schedule(cluster), IsNil)
 }
 
+func (s *testStorageBalancerSuite) TestReplicaScore(c *C) {
+	cluster := newClusterInfo(newMockIDAllocator())
+	tc := newTestClusterInfo(cluster)
+
+	_, opt := newTestScheduleConfig()
+	opt.rep = newTestReplication(3, "zone", "rack", "host")
+
+	sb := newStorageBalancer(opt)
+
+	// Store 1 has the largest storage ratio, so the balancer try to replace peer in store 1.
+	tc.addLabelsStore(1, 1, 0.5, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(2, 1, 0.4, map[string]string{"zone": "z1", "rack": "r2", "host": "h1"})
+	tc.addLabelsStore(3, 1, 0.3, map[string]string{"zone": "z1", "rack": "r2", "host": "h2"})
+
+	tc.addLeaderRegion(1, 1, 2, 3)
+	c.Assert(sb.Schedule(cluster), IsNil)
+
+	// Store 4 has smaller storage ratio than store 1 but the same rack with other stores.
+	tc.addLabelsStore(4, 1, 0.1, map[string]string{"zone": "z1", "rack": "r2", "host": "h3"})
+	c.Assert(sb.Schedule(cluster), IsNil)
+
+	// Store 5 has smaller storage ratio than store 1 and different rack with other stores.
+	tc.addLabelsStore(5, 1, 0.2, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	checkTransferPeer(c, sb.Schedule(cluster), 1, 5)
+
+	// Store 6 has smaller storage ratio than store 5 and different rack with other stores.
+	tc.addLabelsStore(6, 1, 0.1, map[string]string{"zone": "z1", "rack": "r1", "host": "h2"})
+	checkTransferPeer(c, sb.Schedule(cluster), 1, 6)
+
+	// Take down 4,5,6
+	tc.setStoreDown(4)
+	tc.setStoreDown(5)
+	tc.setStoreDown(6)
+	c.Assert(sb.Schedule(cluster), IsNil)
+
+	// Store 7 has different zone with other stores but larger storage ratio than store 1.
+	tc.addLabelsStore(7, 1, 0.7, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"})
+	c.Assert(sb.Schedule(cluster), IsNil)
+}
+
 var _ = Suite(&testReplicaCheckerSuite{})
 
 type testReplicaCheckerSuite struct{}
 
-func (s *testReplicaCheckerSuite) Test(c *C) {
+func (s *testReplicaCheckerSuite) TestBasic(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
 
 	cfg, opt := newTestScheduleConfig()
-	rc := newReplicaChecker(cluster, opt)
+	rc := newReplicaChecker(opt, cluster)
 
 	cfg.MaxSnapshotCount = 2
 
@@ -274,7 +314,7 @@ func (s *testReplicaCheckerSuite) Test(c *C) {
 	peer3, _ := cluster.allocPeer(3)
 	region.Peers = append(region.Peers, peer3)
 	checkRemovePeer(c, rc.Check(region), 1)
-	region.Peers = region.Peers[1:]
+	region.RemoveStorePeer(1)
 
 	// Peer in store 2 is down, remove it.
 	tc.setStoreDown(2)
@@ -287,9 +327,78 @@ func (s *testReplicaCheckerSuite) Test(c *C) {
 	region.DownPeers = nil
 	c.Assert(rc.Check(region), IsNil)
 
-	// Peer in store 2 is offline, remove it.
+	// Peer in store 3 is offline, transfer peer to store 1.
 	tc.setStoreOffline(3)
-	checkRemovePeer(c, rc.Check(region), 3)
+	checkTransferPeer(c, rc.Check(region), 3, 1)
+}
+
+func (s *testReplicaCheckerSuite) TestReplicaScore(c *C) {
+	cluster := newClusterInfo(newMockIDAllocator())
+	tc := newTestClusterInfo(cluster)
+
+	_, opt := newTestScheduleConfig()
+	opt.rep = newTestReplication(3, "zone", "rack", "host")
+
+	rc := newReplicaChecker(opt, cluster)
+
+	tc.addLabelsStore(1, 1, 0.5, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(2, 1, 0.4, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+
+	// We need 3 replicas.
+	tc.addLeaderRegion(1, 1)
+	region := tc.getRegion(1)
+	checkAddPeer(c, rc.Check(region), 2)
+	peer2, _ := cluster.allocPeer(2)
+	region.Peers = append(region.Peers, peer2)
+
+	// Store 1,2,3 have the same zone, rack, and host.
+	tc.addLabelsStore(3, 1, 0.5, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	checkAddPeer(c, rc.Check(region), 3)
+
+	// Store 4 has the same zone, rack, and host, but smaller storage ratio.
+	tc.addLabelsStore(4, 1, 0.4, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	checkAddPeer(c, rc.Check(region), 4)
+
+	// Store 5 has a different host.
+	tc.addLabelsStore(5, 1, 0.5, map[string]string{"zone": "z1", "rack": "r1", "host": "h2"})
+	checkAddPeer(c, rc.Check(region), 5)
+
+	// Store 6 has a different rack.
+	tc.addLabelsStore(6, 1, 0.3, map[string]string{"zone": "z1", "rack": "r2", "host": "h1"})
+	checkAddPeer(c, rc.Check(region), 6)
+
+	// Store 7 has a different zone.
+	tc.addLabelsStore(7, 1, 0.5, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"})
+	checkAddPeer(c, rc.Check(region), 7)
+
+	// Add peer to store 7 first because it has a different zone.
+	peer7, _ := cluster.allocPeer(7)
+	region.Peers = append(region.Peers, peer7)
+
+	// Replace peer in store 1 with store 6 because it has a different rack.
+	checkTransferPeer(c, rc.Check(region), 1, 6)
+	peer6, _ := cluster.allocPeer(6)
+	region.Peers = append(region.Peers, peer6)
+	checkRemovePeer(c, rc.Check(region), 1)
+	region.RemoveStorePeer(1)
+	c.Assert(rc.Check(region), IsNil)
+
+	// Store 8 has the same zone and different rack with store 7.
+	// Store 1 has the same zone and different rack with store 6.
+	// So store 8 and store 1 are equivalent.
+	tc.addLabelsStore(8, 1, 0.4, map[string]string{"zone": "z2", "rack": "r2", "host": "h1"})
+	c.Assert(rc.Check(region), IsNil)
+
+	// Store 9 has a different zone.
+	// Store 2 and 6 have the same replica score, but store 2 has larger storage ratio.
+	// So replace peer in store 2 with store 9.
+	tc.addLabelsStore(9, 1, 0.5, map[string]string{"zone": "z3", "rack": "r1", "host": "h1"})
+	checkTransferPeer(c, rc.Check(region), 2, 9)
+	peer9, _ := cluster.allocPeer(9)
+	region.Peers = append(region.Peers, peer9)
+	checkRemovePeer(c, rc.Check(region), 2)
+	region.RemoveStorePeer(2)
+	c.Assert(rc.Check(region), IsNil)
 }
 
 func checkAddPeer(c *C, bop Operator, storeID uint64) {

--- a/server/config.go
+++ b/server/config.go
@@ -334,6 +334,12 @@ func (c *ScheduleConfig) adjust() {
 type ReplicationConfig struct {
 	// MaxReplicas is the number of replicas for each region.
 	MaxReplicas uint64 `toml:"max-replicas" json:"max-replicas"`
+
+	// The label keys specified the location of a store.
+	// The placement priorities is implied by the order of label keys.
+	// For example, ["zone", "rack"] means that we should place replicas to
+	// different zones first, then to different racks if we don't have enough zones.
+	LocationLabels []string `toml:"location-labels" json:"location-labels"`
 }
 
 func (c *ReplicationConfig) adjust() {

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -327,7 +327,7 @@ func newReplicaCheckController(c *coordinator) *replicaCheckController {
 	return &replicaCheckController{
 		c:       c,
 		opt:     c.opt,
-		checker: newReplicaChecker(c.cluster, c.opt),
+		checker: newReplicaChecker(c.opt, c.cluster),
 	}
 }
 

--- a/server/filter.go
+++ b/server/filter.go
@@ -179,7 +179,7 @@ type replicationFilter struct {
 	rep        *Replication
 	stores     []*storeInfo
 	worstStore *storeInfo
-	worstScore int
+	worstScore float64
 }
 
 func newReplicationFilter(rep *Replication, stores []*storeInfo, worstStore *storeInfo) *replicationFilter {

--- a/server/filter.go
+++ b/server/filter.go
@@ -61,6 +61,22 @@ func (f *excludedFilter) FilterTarget(store *storeInfo) bool {
 	return ok
 }
 
+type cacheFilter struct {
+	cache *idCache
+}
+
+func newCacheFilter(cache *idCache) *cacheFilter {
+	return &cacheFilter{cache: cache}
+}
+
+func (f *cacheFilter) FilterSource(store *storeInfo) bool {
+	return f.cache.get(store.GetId())
+}
+
+func (f *cacheFilter) FilterTarget(store *storeInfo) bool {
+	return false
+}
+
 type stateFilter struct {
 	opt *scheduleOption
 }

--- a/server/region.go
+++ b/server/region.go
@@ -95,6 +95,16 @@ func (r *regionInfo) GetStorePeer(storeID uint64) *metapb.Peer {
 	return nil
 }
 
+func (r *regionInfo) RemoveStorePeer(storeID uint64) {
+	var peers []*metapb.Peer
+	for _, peer := range r.GetPeers() {
+		if peer.GetStoreId() != storeID {
+			peers = append(peers, peer)
+		}
+	}
+	r.Peers = peers
+}
+
 func (r *regionInfo) GetStoreIds() map[uint64]struct{} {
 	peers := r.GetPeers()
 	stores := make(map[uint64]struct{}, len(peers))

--- a/server/region_cache.go
+++ b/server/region_cache.go
@@ -27,6 +27,25 @@ type cacheItem struct {
 	expire time.Time
 }
 
+type idCache struct {
+	*expireRegionCache
+}
+
+func newIDCache(interval, ttl time.Duration) *idCache {
+	return &idCache{
+		expireRegionCache: newExpireRegionCache(interval, ttl),
+	}
+}
+
+func (c *idCache) set(id uint64) {
+	c.expireRegionCache.set(id, nil)
+}
+
+func (c *idCache) get(id uint64) bool {
+	_, ok := c.expireRegionCache.get(id)
+	return ok
+}
+
 // expireRegionCache is an expired region cache.
 type expireRegionCache struct {
 	sync.RWMutex

--- a/server/region_test.go
+++ b/server/region_test.go
@@ -63,6 +63,15 @@ func (s *testRegionSuite) TestRegionInfo(c *C) {
 	}
 	c.Assert(r.GetStorePeer(n), IsNil)
 
+	removePeer := &metapb.Peer{
+		Id:      n,
+		StoreId: n,
+	}
+	r.Peers = append(r.Peers, removePeer)
+	c.Assert(r.GetStorePeer(n), DeepEquals, removePeer)
+	r.RemoveStorePeer(n)
+	c.Assert(r.GetStorePeer(n), IsNil)
+
 	stores := r.GetStoreIds()
 	c.Assert(stores, HasLen, int(n))
 	for i := uint64(0); i < n; i++ {

--- a/server/replication.go
+++ b/server/replication.go
@@ -26,3 +26,60 @@ func newReplication(cfg *ReplicationConfig) *Replication {
 func (r *Replication) GetMaxReplicas() int {
 	return int(r.cfg.MaxReplicas)
 }
+
+// GetMaxReplicaScore returns the max replica score of a store.
+func (r *Replication) GetMaxReplicaScore() int {
+	return len(r.cfg.LocationLabels)
+}
+
+// GetReplicaScore returns the replica score of the store relative to the candidates.
+func (r *Replication) GetReplicaScore(candidates []*storeInfo, store *storeInfo) int {
+	for i, key := range r.cfg.LocationLabels {
+		value := store.labelValue(key)
+		if len(value) == 0 {
+			// If the store doesn't have this label, we assume
+			// it has the same value with all candidates.
+			continue
+		}
+
+		// Reset candidates.
+		stores := candidates
+		candidates = []*storeInfo{}
+
+		// Push stores with the same label value to candidates.
+		for _, s := range stores {
+			if s.GetId() == store.GetId() {
+				continue
+			}
+			if s.labelValue(key) == value {
+				candidates = append(candidates, s)
+			}
+		}
+
+		// If no candidates, it means the label value is different from others.
+		if len(candidates) == 0 {
+			return r.GetMaxReplicaScore() - i
+		}
+	}
+	return 0
+}
+
+// compareStoreScore compares which store is better for replication.
+// Returns 0 if store A is as good as store B.
+// Returns 1 if store A is better than store B.
+// Returns -1 if store B is better than store A.
+func compareStoreScore(storeA *storeInfo, scoreA int, storeB *storeInfo, scoreB int) int {
+	if scoreA > scoreB {
+		return 1
+	}
+	if scoreA < scoreB {
+		return -1
+	}
+	if storeA.storageRatio() < storeB.storageRatio() {
+		return 1
+	}
+	if storeA.storageRatio() > storeB.storageRatio() {
+		return -1
+	}
+	return 0
+}

--- a/server/replication.go
+++ b/server/replication.go
@@ -13,6 +13,8 @@
 
 package server
 
+import "math"
+
 // Replication provides some help to do replication.
 type Replication struct {
 	cfg *ReplicationConfig
@@ -27,18 +29,20 @@ func (r *Replication) GetMaxReplicas() int {
 	return int(r.cfg.MaxReplicas)
 }
 
-// GetMaxReplicaScore returns the max replica score of a store.
-func (r *Replication) GetMaxReplicaScore() int {
-	return len(r.cfg.LocationLabels)
-}
-
 // GetReplicaScore returns the replica score of the store relative to the candidates.
+// This score reflects the similarity of the store between the candidates, the smaller the better.
 func (r *Replication) GetReplicaScore(candidates []*storeInfo, store *storeInfo) int {
+	score := 0
+	maxReplicas := len(candidates) + 1
+
 	for i, key := range r.cfg.LocationLabels {
-		value := store.labelValue(key)
+		baseScore := int(math.Pow(float64(maxReplicas), float64(i)))
+
+		value := store.getLabelValue(key)
 		if len(value) == 0 {
 			// If the store doesn't have this label, we assume
 			// it has the same value with all candidates.
+			score += baseScore * len(candidates)
 			continue
 		}
 
@@ -51,17 +55,19 @@ func (r *Replication) GetReplicaScore(candidates []*storeInfo, store *storeInfo)
 			if s.GetId() == store.GetId() {
 				continue
 			}
-			if s.labelValue(key) == value {
+			if s.getLabelValue(key) == value {
+				score += baseScore
 				candidates = append(candidates, s)
 			}
 		}
 
 		// If no candidates, it means the label value is different from others.
 		if len(candidates) == 0 {
-			return r.GetMaxReplicaScore() - i
+			break
 		}
 	}
-	return 0
+
+	return score
 }
 
 // compareStoreScore compares which store is better for replication.
@@ -69,10 +75,10 @@ func (r *Replication) GetReplicaScore(candidates []*storeInfo, store *storeInfo)
 // Returns 1 if store A is better than store B.
 // Returns -1 if store B is better than store A.
 func compareStoreScore(storeA *storeInfo, scoreA int, storeB *storeInfo, scoreB int) int {
-	if scoreA > scoreB {
+	if scoreA < scoreB {
 		return 1
 	}
-	if scoreA < scoreB {
+	if scoreA > scoreB {
 		return -1
 	}
 	if storeA.storageRatio() < storeB.storageRatio() {

--- a/server/replication_test.go
+++ b/server/replication_test.go
@@ -1,0 +1,102 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import . "github.com/pingcap/check"
+
+func newTestReplication(maxReplicas int, locationLabels ...string) *Replication {
+	cfg := &ReplicationConfig{
+		MaxReplicas:    uint64(maxReplicas),
+		LocationLabels: locationLabels,
+	}
+	return newReplication(cfg)
+}
+
+var _ = Suite(&testReplicationSuite{})
+
+type testReplicationSuite struct{}
+
+func (s *testReplicationSuite) TestReplicaScore(c *C) {
+	cluster := newClusterInfo(newMockIDAllocator())
+	tc := newTestClusterInfo(cluster)
+	rep := newTestReplication(3, "zone", "rack", "host")
+
+	zones := []string{"z1", "z2", "z3"}
+	racks := []string{"r1", "r2", "r3"}
+	hosts := []string{"h1", "h2", "h3"}
+
+	var stores []*storeInfo
+	for i, zone := range zones {
+		for j, rack := range racks {
+			for k, host := range hosts {
+				storeID := uint64(i*len(racks)*len(hosts) + j*len(hosts) + k)
+				labels := map[string]string{
+					"zone": zone,
+					"rack": rack,
+					"host": host,
+				}
+
+				tc.addLabelsStore(storeID, 1, 0.1, labels)
+				store := cluster.getStore(storeID)
+				stores = append(stores, store)
+
+				score := 1
+				if k == 0 {
+					// A new rack.
+					score++
+					if j == 0 {
+						// A new zone.
+						score++
+					}
+				}
+				c.Assert(rep.GetReplicaScore(stores, store), Equals, score)
+			}
+		}
+	}
+
+	storeID := uint64(len(zones) * len(racks) * len(hosts))
+	tc.addLabelsStore(storeID, 1, 0.1, map[string]string{"zone": "z3"})
+	c.Assert(rep.GetReplicaScore(stores, cluster.getStore(storeID)), Equals, 0)
+	tc.addLabelsStore(storeID, 1, 0.1, map[string]string{"zone": "z4"})
+	c.Assert(rep.GetReplicaScore(stores, cluster.getStore(storeID)), Equals, 3)
+	tc.addLabelsStore(storeID, 1, 0.1, map[string]string{"rack": "r3"})
+	c.Assert(rep.GetReplicaScore(stores, cluster.getStore(storeID)), Equals, 0)
+	tc.addLabelsStore(storeID, 1, 0.1, map[string]string{"rack": "r4"})
+	c.Assert(rep.GetReplicaScore(stores, cluster.getStore(storeID)), Equals, 2)
+	tc.addLabelsStore(storeID, 1, 0.1, map[string]string{"host": "h3"})
+	c.Assert(rep.GetReplicaScore(stores, cluster.getStore(storeID)), Equals, 0)
+	tc.addLabelsStore(storeID, 1, 0.1, map[string]string{"host": "h4"})
+	c.Assert(rep.GetReplicaScore(stores, cluster.getStore(storeID)), Equals, 1)
+}
+
+func (s *testReplicationSuite) TestCompareStoreScore(c *C) {
+	cluster := newClusterInfo(newMockIDAllocator())
+	tc := newTestClusterInfo(cluster)
+
+	tc.addRegionStore(1, 1, 0.1)
+	tc.addRegionStore(2, 1, 0.1)
+	tc.addRegionStore(3, 1, 0.2)
+
+	store1 := cluster.getStore(1)
+	store2 := cluster.getStore(2)
+	store3 := cluster.getStore(3)
+
+	c.Assert(compareStoreScore(store1, 2, store2, 1), Equals, 1)
+	c.Assert(compareStoreScore(store1, 1, store2, 1), Equals, 0)
+	c.Assert(compareStoreScore(store1, 1, store2, 2), Equals, -1)
+
+	c.Assert(compareStoreScore(store1, 2, store3, 1), Equals, 1)
+	c.Assert(compareStoreScore(store1, 1, store3, 1), Equals, 1)
+	c.Assert(compareStoreScore(store1, 1, store3, 2), Equals, -1)
+}

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -13,7 +13,10 @@
 
 package server
 
-import "github.com/pingcap/kvproto/pkg/metapb"
+import (
+	"github.com/ngaut/log"
+	"github.com/pingcap/kvproto/pkg/metapb"
+)
 
 // Scheduler is an interface to schedule resources.
 type Scheduler interface {
@@ -44,12 +47,12 @@ func (s *grantLeaderScheduler) Schedule(cluster *clusterInfo) Operator {
 	if region == nil {
 		return nil
 	}
-	return newTransferLeader(region, s.StoreID)
+	return newTransferLeader(region, region.GetStorePeer(s.StoreID))
 }
 
 type shuffleLeaderScheduler struct {
 	selector Selector
-	source   *storeInfo
+	selected *metapb.Peer
 }
 
 func newShuffleLeaderScheduler() *shuffleLeaderScheduler {
@@ -68,31 +71,32 @@ func (s *shuffleLeaderScheduler) GetResourceKind() ResourceKind {
 
 func (s *shuffleLeaderScheduler) Schedule(cluster *clusterInfo) Operator {
 	// We shuffle leaders between stores:
-	// 1. select a store as a source store randomly.
+	// 1. select a store randomly.
 	// 2. transfer a leader from the store to another store.
 	// 3. transfer a leader to the store from another store.
 	// These will not change store's leader count, but swap leaders between stores.
 
-	// Select a source store and transfer a leader from it.
-	if s.source == nil {
-		region, source, target := scheduleLeader(cluster, s.selector)
+	// Select a store and transfer a leader from it.
+	if s.selected == nil {
+		region, newLeader := scheduleTransferLeader(cluster, s.selector)
 		if region == nil {
 			return nil
 		}
-		s.source = source // Mark the source store.
-		return newTransferLeader(region, target.GetId())
+		// Mark the selected store.
+		s.selected = region.Leader
+		return newTransferLeader(region, newLeader)
 	}
 
-	// Reset the source store.
-	source := s.source
-	s.source = nil
+	// Reset the selected store.
+	storeID := s.selected.GetStoreId()
+	s.selected = nil
 
-	// Transfer a leader to the source store.
-	region := cluster.randFollowerRegion(source.GetId())
+	// Transfer a leader to the selected store.
+	region := cluster.randFollowerRegion(storeID)
 	if region == nil {
 		return nil
 	}
-	return newTransferLeader(region, source.GetId())
+	return newTransferLeader(region, region.GetStorePeer(storeID))
 }
 
 func newAddPeer(region *regionInfo, peer *metapb.Peer) Operator {
@@ -111,46 +115,36 @@ func newTransferPeer(region *regionInfo, oldPeer, newPeer *metapb.Peer) Operator
 	return newRegionOperator(region, addPeer, removePeer)
 }
 
-func newTransferLeader(region *regionInfo, storeID uint64) Operator {
-	newLeader := region.GetStorePeer(storeID)
-	if newLeader == nil {
-		return nil
-	}
+func newTransferLeader(region *regionInfo, newLeader *metapb.Peer) Operator {
 	transferLeader := newTransferLeaderOperator(region.GetId(), region.Leader, newLeader)
 	return newRegionOperator(region, transferLeader)
 }
 
-// scheduleLeader schedules a region to transfer leader from the source store to the target store.
-func scheduleLeader(cluster *clusterInfo, s Selector) (*regionInfo, *storeInfo, *storeInfo) {
-	sourceStores := cluster.getStores()
-
-	source := s.SelectSource(sourceStores)
-	if source == nil {
-		return nil, nil, nil
-	}
-
-	region := cluster.randLeaderRegion(source.GetId())
-	if region == nil {
-		return nil, nil, nil
-	}
-
-	targetStores := cluster.getFollowerStores(region)
-
-	target := s.SelectTarget(targetStores)
-	if target == nil {
-		return nil, nil, nil
-	}
-
-	return region, source, target
-}
-
-// scheduleStorage schedules a region to transfer peer from the source store to the target store.
-func scheduleStorage(cluster *clusterInfo, opt *scheduleOption, s Selector) (*regionInfo, *storeInfo, *storeInfo) {
+// scheduleAddPeer schedules a new peer.
+func scheduleAddPeer(cluster *clusterInfo, s Selector, filters ...Filter) *metapb.Peer {
 	stores := cluster.getStores()
 
-	source := s.SelectSource(stores)
+	target := s.SelectTarget(stores, filters...)
+	if target == nil {
+		return nil
+	}
+
+	newPeer, err := cluster.allocPeer(target.GetId())
+	if err != nil {
+		log.Errorf("failed to allocate peer: %v", err)
+		return nil
+	}
+
+	return newPeer
+}
+
+// scheduleRemovePeer schedules a region to remove the peer.
+func scheduleRemovePeer(cluster *clusterInfo, s Selector, filters ...Filter) (*regionInfo, *metapb.Peer) {
+	stores := cluster.getStores()
+
+	source := s.SelectSource(stores, filters...)
 	if source == nil {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	region := cluster.randFollowerRegion(source.GetId())
@@ -158,19 +152,32 @@ func scheduleStorage(cluster *clusterInfo, opt *scheduleOption, s Selector) (*re
 		region = cluster.randLeaderRegion(source.GetId())
 	}
 	if region == nil {
-		return nil, nil, nil
+		return nil, nil
 	}
 
-	if len(region.GetPeers()) != opt.GetMaxReplicas() {
-		// We only schedule region with just enough replicas.
-		return nil, nil, nil
+	return region, region.GetStorePeer(source.GetId())
+}
+
+// scheduleTransferLeader schedules a region to transfer leader to the peer.
+func scheduleTransferLeader(cluster *clusterInfo, s Selector, filters ...Filter) (*regionInfo, *metapb.Peer) {
+	sourceStores := cluster.getStores()
+
+	source := s.SelectSource(sourceStores, filters...)
+	if source == nil {
+		return nil, nil
 	}
 
-	excluded := newExcludedFilter(nil, region.GetStoreIds())
-	target := s.SelectTarget(stores, excluded)
+	region := cluster.randLeaderRegion(source.GetId())
+	if region == nil {
+		return nil, nil
+	}
+
+	targetStores := cluster.getFollowerStores(region)
+
+	target := s.SelectTarget(targetStores)
 	if target == nil {
-		return nil, nil, nil
+		return nil, nil
 	}
 
-	return region, source, target
+	return region, region.GetStorePeer(target.GetId())
 }

--- a/server/store.go
+++ b/server/store.go
@@ -50,6 +50,15 @@ func (s *storeInfo) clone() *storeInfo {
 	}
 }
 
+func (s *storeInfo) labelValue(key string) string {
+	for _, label := range s.GetLabels() {
+		if label.GetKey() == key {
+			return label.GetValue()
+		}
+	}
+	return ""
+}
+
 func (s *storeInfo) isUp() bool {
 	return s.GetState() == metapb.StoreState_Up
 }

--- a/server/store.go
+++ b/server/store.go
@@ -50,15 +50,6 @@ func (s *storeInfo) clone() *storeInfo {
 	}
 }
 
-func (s *storeInfo) labelValue(key string) string {
-	for _, label := range s.GetLabels() {
-		if label.GetKey() == key {
-			return label.GetValue()
-		}
-	}
-	return ""
-}
-
 func (s *storeInfo) isUp() bool {
 	return s.GetState() == metapb.StoreState_Up
 }
@@ -105,6 +96,15 @@ func (s *storeInfo) resourceScores() []int {
 	scores = append(scores, int(s.leaderRatio()*100))
 	scores = append(scores, int(s.storageRatio()*100))
 	return scores
+}
+
+func (s *storeInfo) getLabelValue(key string) string {
+	for _, label := range s.GetLabels() {
+		if label.GetKey() == key {
+			return label.GetValue()
+		}
+	}
+	return ""
 }
 
 // StoreStatus contains information about a store's status.


### PR DESCRIPTION
Schedule replicas according to the location of stores.
For example, we can replicate data to different zones, racks and hosts.

Closes #454 