### PR TITLE
server/coordinator: fix context pitfall

### DIFF
--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -14,12 +14,12 @@
 package server
 
 import (
-	"context"
 	"sync"
 	"time"
 
 	"github.com/ngaut/log"
 	"github.com/pingcap/kvproto/pkg/pdpb"
+	"golang.org/x/net/context"
 )
 
 const (


### PR DESCRIPTION
According to golang package initialization, we may meet some
mysterious bugs if we do not use the same context package.

That is:

```
context.Canceled != context.Canceled
```

Because the first `Canceled` may comes from `"context"` and the
later one comes from `"golang.org/x/net/context"`.

PTAL @siddontang @huachaohuang 