### PR TITLE
server/balancer: guarantee replicas are safe if possible

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -45,3 +45,8 @@ max-replicas = 3
 # For example, ["zone", "rack"] means that we should place replicas to
 # different zones first, then to different racks if we don't have enough zones.
 location-labels = []
+# Allow to balance even if it is unsafe. The balance algorithm tries its best to
+# keep safe, but if resources are limited (not enough zones or racks), or under
+# some abnormal conditions (stores are down or full), the current implementation
+# can't balance and guarantee replicas are safe at the same time.
+#allow-unsafe-balance = false

--- a/conf/config.toml
+++ b/conf/config.toml
@@ -45,8 +45,3 @@ max-replicas = 3
 # For example, ["zone", "rack"] means that we should place replicas to
 # different zones first, then to different racks if we don't have enough zones.
 location-labels = []
-# Allow to balance even if it is unsafe. The balance algorithm tries its best to
-# keep safe, but if resources are limited (not enough zones or racks), or under
-# some abnormal conditions (stores are down or full), the current implementation
-# can't balance and guarantee replicas are safe at the same time.
-#allow-unsafe-balance = false

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -30,6 +30,7 @@ type leaderBalancer struct {
 func newLeaderBalancer(opt *scheduleOption) *leaderBalancer {
 	var filters []Filter
 	filters = append(filters, newStateFilter(opt))
+	filters = append(filters, newHealthFilter(opt))
 	filters = append(filters, newLeaderCountFilter(opt))
 
 	return &leaderBalancer{
@@ -74,6 +75,7 @@ func newStorageBalancer(opt *scheduleOption) *storageBalancer {
 	var filters []Filter
 	filters = append(filters, newCacheFilter(cache))
 	filters = append(filters, newStateFilter(opt))
+	filters = append(filters, newHealthFilter(opt))
 	filters = append(filters, newRegionCountFilter(opt))
 	filters = append(filters, newSnapshotCountFilter(opt))
 
@@ -118,11 +120,22 @@ func (s *storageBalancer) transferPeer(cluster *clusterInfo, region *regionInfo,
 	stores := cluster.getRegionStores(region)
 	source := cluster.getStore(oldPeer.GetStoreId())
 
-	// Allocate a new peer from the store with smallest storage ratio.
-	// We need to ensure the target store will not break the replication constraints.
+	// Allocate a new peer from the other store with smallest storage ratio.
 	excluded := newExcludedFilter(nil, region.GetStoreIds())
-	replication := newReplicationFilter(s.rep, stores, source)
-	newPeer := scheduleAddPeer(cluster, s.selector, excluded, replication)
+
+	// safeGuard guarantees the replica score after adding the new peer.
+	// It means that we are safe to add the new peer to the region.
+	safeGuard := newReplicaScoreFilter(s.rep, stores)
+	// distinctGuard guarantees the distinct score after replacing the old peer
+	// with the new peer.
+	distinctGuard := newDistinctScoreFilter(s.rep, stores, source)
+
+	// See if we can select a safe one first.
+	newPeer := scheduleAddPeer(cluster, s.selector, excluded, safeGuard, distinctGuard)
+	if newPeer == nil && s.rep.AllowUnsafeBalance() {
+		// If we can't, we find an unsafe one if it is allowed.
+		newPeer = scheduleAddPeer(cluster, s.selector, excluded, distinctGuard)
+	}
 	if newPeer == nil {
 		return nil
 	}
@@ -145,7 +158,7 @@ type replicaChecker struct {
 
 func newReplicaChecker(opt *scheduleOption, cluster *clusterInfo) *replicaChecker {
 	var filters []Filter
-	filters = append(filters, newStateFilter(opt))
+	filters = append(filters, newHealthFilter(opt))
 	filters = append(filters, newSnapshotCountFilter(opt))
 	filters = append(filters, newStorageThresholdFilter(opt))
 
@@ -166,7 +179,7 @@ func (r *replicaChecker) Check(region *regionInfo) Operator {
 	}
 
 	if len(region.GetPeers()) < r.rep.GetMaxReplicas() {
-		newPeer, _ := r.selectBestPeer(region)
+		newPeer, _ := r.selectBestPeer(region, r.filters...)
 		if newPeer == nil {
 			return nil
 		}
@@ -181,12 +194,13 @@ func (r *replicaChecker) Check(region *regionInfo) Operator {
 		return newRemovePeer(region, oldPeer)
 	}
 
-	return r.checkBetterPeer(region)
+	return r.checkBestReplacement(region)
 }
 
 // selectBestPeer returns the best peer in other stores.
 func (r *replicaChecker) selectBestPeer(region *regionInfo, filters ...Filter) (*metapb.Peer, float64) {
-	filters = append(filters, r.filters...)
+	// Add some must have filters.
+	filters = append(filters, newStateFilter(r.opt))
 	filters = append(filters, newExcludedFilter(nil, region.GetStoreIds()))
 
 	var (
@@ -194,13 +208,14 @@ func (r *replicaChecker) selectBestPeer(region *regionInfo, filters ...Filter) (
 		bestScore float64
 	)
 
-	// Find the store with best score.
-	regionStores := r.cluster.getRegionStores(region)
+	// Select the store with best distinct score.
+	// If the scores are the same, select the store with minimal storage ratio.
+	stores := r.cluster.getRegionStores(region)
 	for _, store := range r.cluster.getStores() {
 		if filterTarget(store, filters) {
 			continue
 		}
-		score := r.rep.GetReplicaScore(regionStores, store)
+		score := r.rep.GetDistinctScore(stores, store)
 		if bestStore == nil || compareStoreScore(store, score, bestStore, bestScore) > 0 {
 			bestStore = store
 			bestScore = score
@@ -221,20 +236,19 @@ func (r *replicaChecker) selectBestPeer(region *regionInfo, filters ...Filter) (
 
 // selectWorstPeer returns the worst peer in the region.
 func (r *replicaChecker) selectWorstPeer(region *regionInfo, filters ...Filter) (*metapb.Peer, float64) {
-	filters = append(filters, r.filters...)
-
 	var (
 		worstStore *storeInfo
 		worstScore float64
 	)
 
-	// Find the store with worst score.
-	regionStores := r.cluster.getRegionStores(region)
-	for _, store := range regionStores {
+	// Select the store with lowest distinct score.
+	// If the scores are the same, select the store with maximal storage ratio.
+	stores := r.cluster.getRegionStores(region)
+	for _, store := range stores {
 		if filterSource(store, filters) {
 			continue
 		}
-		score := r.rep.GetReplicaScore(regionStores, store)
+		score := r.rep.GetDistinctScore(stores, store)
 		if worstStore == nil || compareStoreScore(store, score, worstStore, worstScore) < 0 {
 			worstStore = store
 			worstScore = score
@@ -248,12 +262,13 @@ func (r *replicaChecker) selectWorstPeer(region *regionInfo, filters ...Filter) 
 }
 
 // selectBestReplacement returns the best peer to replace the region peer.
-func (r *replicaChecker) selectBestReplacement(region *regionInfo, peer *metapb.Peer) (*metapb.Peer, float64) {
+func (r *replicaChecker) selectBestReplacement(region *regionInfo, peer *metapb.Peer, filters ...Filter) (*metapb.Peer, float64) {
 	// Get a new region without the peer we are going to replace.
 	newRegion := region.clone()
 	newRegion.RemoveStorePeer(peer.GetStoreId())
 	// Get the best peer in other stores.
-	return r.selectBestPeer(newRegion, newExcludedFilter(nil, region.GetStoreIds()))
+	filters = append(filters, newExcludedFilter(nil, region.GetStoreIds()))
+	return r.selectBestPeer(newRegion, filters...)
 }
 
 func (r *replicaChecker) checkDownPeer(region *regionInfo) Operator {
@@ -280,26 +295,42 @@ func (r *replicaChecker) checkOfflinePeer(region *regionInfo) Operator {
 		if store.isUp() {
 			continue
 		}
-		newPeer, _ := r.selectBestReplacement(region, peer)
-		if newPeer == nil {
-			return nil
+
+		// See if we can select a safe replacement.
+		stores := r.cluster.getRegionStores(region)
+		safeGuard := newReplicaScoreFilter(r.rep, stores)
+		newPeer, _ := r.selectBestReplacement(region, peer, safeGuard)
+		if newPeer != nil {
+			// If the safe replacement is not available for now, we wait.
+			newStore := r.cluster.getStore(newPeer.GetStoreId())
+			if filterTarget(newStore, r.filters) {
+				return nil
+			}
+		} else {
+			// If we there is no safe replacement, we just find the best.
+			newPeer, _ = r.selectBestReplacement(region, peer, r.filters...)
+			if newPeer == nil {
+				return nil
+			}
 		}
+
 		return newTransferPeer(region, peer, newPeer)
 	}
+
 	return nil
 }
 
-func (r *replicaChecker) checkBetterPeer(region *regionInfo) Operator {
+func (r *replicaChecker) checkBestReplacement(region *regionInfo) Operator {
 	oldPeer, oldScore := r.selectWorstPeer(region)
 	if oldPeer == nil {
 		return nil
 	}
-	newPeer, newScore := r.selectBestReplacement(region, oldPeer)
+	newPeer, newScore := r.selectBestReplacement(region, oldPeer, r.filters...)
 	if newPeer == nil {
 		return nil
 	}
-	// We can't find a better peer (the lower the better).
-	if newScore >= oldScore {
+	// Make sure the new peer is better than the old peer.
+	if newScore <= oldScore {
 		return nil
 	}
 	return newTransferPeer(region, oldPeer, newPeer)

--- a/server/config.go
+++ b/server/config.go
@@ -340,13 +340,6 @@ type ReplicationConfig struct {
 	// For example, ["zone", "rack"] means that we should place replicas to
 	// different zones first, then to different racks if we don't have enough zones.
 	LocationLabels []string `toml:"location-labels" json:"location-labels"`
-
-	// Allow to balance even if it is unsafe. The balance algorithm tries its
-	// best to keep safe, but if resources are limited (not enough zones or
-	// racks), or under some abnormal conditions (stores are down or full), the
-	// current implementation can't balance and guarantee replicas are safe at
-	// the same time.
-	AllowUnsafeBalance bool `toml:"allow-unsafe-balance" json:"allow-unsafe-balance"`
 }
 
 func (c *ReplicationConfig) adjust() {

--- a/server/config.go
+++ b/server/config.go
@@ -340,6 +340,13 @@ type ReplicationConfig struct {
 	// For example, ["zone", "rack"] means that we should place replicas to
 	// different zones first, then to different racks if we don't have enough zones.
 	LocationLabels []string `toml:"location-labels" json:"location-labels"`
+
+	// Allow to balance even if it is unsafe. The balance algorithm tries its
+	// best to keep safe, but if resources are limited (not enough zones or
+	// racks), or under some abnormal conditions (stores are down or full), the
+	// current implementation can't balance and guarantee replicas are safe at
+	// the same time.
+	AllowUnsafeBalance bool `toml:"allow-unsafe-balance" json:"allow-unsafe-balance"`
 }
 
 func (c *ReplicationConfig) adjust() {

--- a/server/filter.go
+++ b/server/filter.go
@@ -191,30 +191,6 @@ func (f *storageThresholdFilter) FilterTarget(store *storeInfo) bool {
 	return store.storageRatio() > storageRatioThreshold
 }
 
-// replicaScoreFilter ensures that replica score will not decrease.
-type replicaScoreFilter struct {
-	rep       *Replication
-	stores    []*storeInfo
-	safeScore float64
-}
-
-func newReplicaScoreFilter(rep *Replication, stores []*storeInfo) *replicaScoreFilter {
-	return &replicaScoreFilter{
-		rep:       rep,
-		stores:    stores,
-		safeScore: rep.GetReplicaScore(stores),
-	}
-}
-
-func (f *replicaScoreFilter) FilterSource(store *storeInfo) bool {
-	return false
-}
-
-func (f *replicaScoreFilter) FilterTarget(store *storeInfo) bool {
-	newStores := append([]*storeInfo{store}, f.stores...)
-	return f.rep.GetReplicaScore(newStores) < f.safeScore
-}
-
 // distinctScoreFilter ensures that distinct score will not decrease.
 type distinctScoreFilter struct {
 	rep       *Replication

--- a/server/filter.go
+++ b/server/filter.go
@@ -211,7 +211,8 @@ func (f *replicaScoreFilter) FilterSource(store *storeInfo) bool {
 }
 
 func (f *replicaScoreFilter) FilterTarget(store *storeInfo) bool {
-	return f.rep.GetReplicaScore(append(f.stores, store)) < f.safeScore
+	newStores := append([]*storeInfo{store}, f.stores...)
+	return f.rep.GetReplicaScore(newStores) < f.safeScore
 }
 
 // distinctScoreFilter ensures that distinct score will not decrease.

--- a/server/filter.go
+++ b/server/filter.go
@@ -86,13 +86,7 @@ func newStateFilter(opt *scheduleOption) *stateFilter {
 }
 
 func (f *stateFilter) filter(store *storeInfo) bool {
-	if !store.isUp() {
-		return true
-	}
-	if store.stats.GetIsBusy() {
-		return true
-	}
-	return store.downTime() > f.opt.GetMaxStoreDownTime()
+	return !store.isUp()
 }
 
 func (f *stateFilter) FilterSource(store *storeInfo) bool {
@@ -100,6 +94,29 @@ func (f *stateFilter) FilterSource(store *storeInfo) bool {
 }
 
 func (f *stateFilter) FilterTarget(store *storeInfo) bool {
+	return f.filter(store)
+}
+
+type healthFilter struct {
+	opt *scheduleOption
+}
+
+func newHealthFilter(opt *scheduleOption) *healthFilter {
+	return &healthFilter{opt: opt}
+}
+
+func (f *healthFilter) filter(store *storeInfo) bool {
+	if store.stats.GetIsBusy() {
+		return true
+	}
+	return store.downTime() > f.opt.GetMaxStoreDownTime()
+}
+
+func (f *healthFilter) FilterSource(store *storeInfo) bool {
+	return f.filter(store)
+}
+
+func (f *healthFilter) FilterTarget(store *storeInfo) bool {
 	return f.filter(store)
 }
 
@@ -174,35 +191,56 @@ func (f *storageThresholdFilter) FilterTarget(store *storeInfo) bool {
 	return store.storageRatio() > storageRatioThreshold
 }
 
-// replicationFilter ensures that the target store will not break the replication constraints.
-type replicationFilter struct {
-	rep        *Replication
-	stores     []*storeInfo
-	worstStore *storeInfo
-	worstScore float64
+// replicaScoreFilter ensures that replica score will not decrease.
+type replicaScoreFilter struct {
+	rep       *Replication
+	stores    []*storeInfo
+	safeScore float64
 }
 
-func newReplicationFilter(rep *Replication, stores []*storeInfo, worstStore *storeInfo) *replicationFilter {
-	for i, s := range stores {
-		if s.GetId() == worstStore.GetId() {
-			stores = append(stores[:i], stores[i+1:]...)
-			break
-		}
-	}
-
-	return &replicationFilter{
-		rep:        rep,
-		stores:     stores,
-		worstStore: worstStore,
-		worstScore: rep.GetReplicaScore(stores, worstStore),
+func newReplicaScoreFilter(rep *Replication, stores []*storeInfo) *replicaScoreFilter {
+	return &replicaScoreFilter{
+		rep:       rep,
+		stores:    stores,
+		safeScore: rep.GetReplicaScore(stores),
 	}
 }
 
-func (f *replicationFilter) FilterSource(store *storeInfo) bool {
+func (f *replicaScoreFilter) FilterSource(store *storeInfo) bool {
 	return false
 }
 
-func (f *replicationFilter) FilterTarget(store *storeInfo) bool {
-	score := f.rep.GetReplicaScore(f.stores, store)
-	return compareStoreScore(store, score, f.worstStore, f.worstScore) < 0
+func (f *replicaScoreFilter) FilterTarget(store *storeInfo) bool {
+	return f.rep.GetReplicaScore(append(f.stores, store)) < f.safeScore
+}
+
+// distinctScoreFilter ensures that distinct score will not decrease.
+type distinctScoreFilter struct {
+	rep       *Replication
+	stores    []*storeInfo
+	safeScore float64
+}
+
+func newDistinctScoreFilter(rep *Replication, stores []*storeInfo, source *storeInfo) *distinctScoreFilter {
+	newStores := make([]*storeInfo, 0, len(stores)-1)
+	for _, s := range stores {
+		if s.GetId() == source.GetId() {
+			continue
+		}
+		newStores = append(newStores, s)
+	}
+
+	return &distinctScoreFilter{
+		rep:       rep,
+		stores:    newStores,
+		safeScore: rep.GetDistinctScore(newStores, source),
+	}
+}
+
+func (f *distinctScoreFilter) FilterSource(store *storeInfo) bool {
+	return false
+}
+
+func (f *distinctScoreFilter) FilterTarget(store *storeInfo) bool {
+	return f.rep.GetDistinctScore(f.stores, store) < f.safeScore
 }

--- a/server/replication.go
+++ b/server/replication.go
@@ -34,11 +34,6 @@ func (r *Replication) GetMaxReplicas() int {
 	return int(r.cfg.MaxReplicas)
 }
 
-// AllowUnsafeBalance returns true if it is allowed to do unsafe balance.
-func (r *Replication) AllowUnsafeBalance() bool {
-	return r.cfg.AllowUnsafeBalance
-}
-
 // GetReplicaScore returns the failure tolerance score of these replicas.
 // A higher score means these replicas can tolerant more kind of failures.
 func (r *Replication) GetReplicaScore(replicas []*storeInfo) float64 {

--- a/server/replication.go
+++ b/server/replication.go
@@ -13,10 +13,7 @@
 
 package server
 
-import (
-	"math"
-	"sort"
-)
+import "math"
 
 const replicaBaseScore = 100
 
@@ -32,46 +29,6 @@ func newReplication(cfg *ReplicationConfig) *Replication {
 // GetMaxReplicas returns the number of replicas for each region.
 func (r *Replication) GetMaxReplicas() int {
 	return int(r.cfg.MaxReplicas)
-}
-
-// GetReplicaScore returns the failure tolerance score of these replicas.
-// A higher score means these replicas can tolerant more kind of failures.
-func (r *Replication) GetReplicaScore(replicas []*storeInfo) float64 {
-	score := float64(0)
-
-	for i := range r.cfg.LocationLabels {
-		level := len(r.cfg.LocationLabels) - i - 1
-		levelScore := math.Pow(replicaBaseScore, float64(level))
-
-		// Collect replicas with the same location id.
-		ids := make(map[string]int, len(replicas))
-		for _, s := range replicas {
-			id := s.getLocationID(r.cfg.LocationLabels[0 : i+1])
-			if len(id) == 0 {
-				return 0
-			}
-			ids[id]++
-		}
-
-		// Count the number of replicas with the same location id.
-		counts := make([]int, 0, len(replicas))
-		for _, count := range ids {
-			counts = append(counts, count)
-		}
-		sort.Sort(sort.Reverse(sort.IntSlice(counts)))
-
-		// Check whether we can work if all replicas in the same location are down.
-		sum := 0
-		for c, count := range counts {
-			sum += count
-			if sum > (len(replicas)-1)/2 {
-				score += levelScore * float64(c)
-				break
-			}
-		}
-	}
-
-	return score
 }
 
 // GetDistinctScore returns the score that the other is distinct from the stores.

--- a/server/replication_test.go
+++ b/server/replication_test.go
@@ -15,11 +15,10 @@ package server
 
 import . "github.com/pingcap/check"
 
-func newTestReplication(maxReplicas int, unsafeBalance bool, locationLabels ...string) *Replication {
+func newTestReplication(maxReplicas int, locationLabels ...string) *Replication {
 	cfg := &ReplicationConfig{
-		MaxReplicas:        uint64(maxReplicas),
-		LocationLabels:     locationLabels,
-		AllowUnsafeBalance: unsafeBalance,
+		MaxReplicas:    uint64(maxReplicas),
+		LocationLabels: locationLabels,
 	}
 	return newReplication(cfg)
 }
@@ -31,7 +30,7 @@ type testReplicationSuite struct{}
 func (s *testReplicationSuite) TestReplicaScore(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
-	rep := newTestReplication(3, false, "zone", "rack", "host")
+	rep := newTestReplication(3, "zone", "rack", "host")
 
 	zones := []string{"z1", "z2", "z3"}
 	racks := []string{"r1", "r2", "r3"}
@@ -70,7 +69,7 @@ func (s *testReplicationSuite) TestReplicaScore(c *C) {
 func (s *testReplicationSuite) TestDistinctScore(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
-	rep := newTestReplication(3, false, "zone", "rack", "host")
+	rep := newTestReplication(3, "zone", "rack", "host")
 
 	zones := []string{"z1", "z2", "z3"}
 	racks := []string{"r1", "r2", "r3"}

--- a/server/replication_test.go
+++ b/server/replication_test.go
@@ -23,3 +23,86 @@ func newTestReplication(maxReplicas int, unsafeBalance bool, locationLabels ...s
 	}
 	return newReplication(cfg)
 }
+
+var _ = Suite(&testReplicationSuite{})
+
+type testReplicationSuite struct{}
+
+func (s *testReplicationSuite) TestReplicaScore(c *C) {
+	cluster := newClusterInfo(newMockIDAllocator())
+	tc := newTestClusterInfo(cluster)
+	rep := newTestReplication(3, false, "zone", "rack", "host")
+
+	zones := []string{"z1", "z2", "z3"}
+	racks := []string{"r1", "r2", "r3"}
+	hosts := []string{"h1", "h2", "h3"}
+
+	var stores []*storeInfo
+	for i, zone := range zones {
+		for j, rack := range racks {
+			for k, host := range hosts {
+				storeID := uint64(i*len(racks)*len(hosts) + j*len(hosts) + k)
+				labels := map[string]string{
+					"zone": zone,
+					"rack": rack,
+					"host": host,
+				}
+				tc.addLabelsStore(storeID, 1, 0.1, labels)
+				stores = append(stores, cluster.getStore(storeID))
+
+				// Number of zones failure we can tolerance.
+				nzones := i / 2
+				// Number of racks failure we can tolerance.
+				nracks := (i*len(racks) + j) / 2
+				// Number of hosts failure we can tolerance.
+				nhosts := (i*len(racks)*len(hosts) + j*len(hosts) + k) / 2
+				score := (nzones*replicaBaseScore+nracks)*replicaBaseScore + nhosts
+				c.Assert(rep.GetReplicaScore(stores), Equals, float64(score))
+			}
+		}
+	}
+
+	tc.addLabelsStore(100, 1, 0.1, map[string]string{})
+	stores = append(stores, cluster.getStore(100))
+	c.Assert(rep.GetReplicaScore(stores), Equals, float64(0))
+}
+
+func (s *testReplicationSuite) TestDistinctScore(c *C) {
+	cluster := newClusterInfo(newMockIDAllocator())
+	tc := newTestClusterInfo(cluster)
+	rep := newTestReplication(3, false, "zone", "rack", "host")
+
+	zones := []string{"z1", "z2", "z3"}
+	racks := []string{"r1", "r2", "r3"}
+	hosts := []string{"h1", "h2", "h3"}
+
+	var stores []*storeInfo
+	for i, zone := range zones {
+		for j, rack := range racks {
+			for k, host := range hosts {
+				storeID := uint64(i*len(racks)*len(hosts) + j*len(hosts) + k)
+				labels := map[string]string{
+					"zone": zone,
+					"rack": rack,
+					"host": host,
+				}
+				tc.addLabelsStore(storeID, 1, 0.1, labels)
+				store := cluster.getStore(storeID)
+				stores = append(stores, store)
+
+				// Number of stores with different zones.
+				nzones := i * len(racks) * len(hosts)
+				// Number of stores with different racks.
+				nracks := nzones + j*len(hosts)
+				// Number of stores with different hosts.
+				nhosts := nracks + k
+				score := (nzones*replicaBaseScore+nracks)*replicaBaseScore + nhosts
+				c.Assert(rep.GetDistinctScore(stores, store), Equals, float64(score))
+			}
+		}
+	}
+
+	tc.addLabelsStore(100, 1, 0.1, map[string]string{})
+	store := cluster.getStore(100)
+	c.Assert(rep.GetDistinctScore(stores, store), Equals, float64(0))
+}

--- a/server/replication_test.go
+++ b/server/replication_test.go
@@ -27,45 +27,6 @@ var _ = Suite(&testReplicationSuite{})
 
 type testReplicationSuite struct{}
 
-func (s *testReplicationSuite) TestReplicaScore(c *C) {
-	cluster := newClusterInfo(newMockIDAllocator())
-	tc := newTestClusterInfo(cluster)
-	rep := newTestReplication(3, "zone", "rack", "host")
-
-	zones := []string{"z1", "z2", "z3"}
-	racks := []string{"r1", "r2", "r3"}
-	hosts := []string{"h1", "h2", "h3"}
-
-	var stores []*storeInfo
-	for i, zone := range zones {
-		for j, rack := range racks {
-			for k, host := range hosts {
-				storeID := uint64(i*len(racks)*len(hosts) + j*len(hosts) + k)
-				labels := map[string]string{
-					"zone": zone,
-					"rack": rack,
-					"host": host,
-				}
-				tc.addLabelsStore(storeID, 1, 0.1, labels)
-				stores = append(stores, cluster.getStore(storeID))
-
-				// Number of zones failure we can tolerance.
-				nzones := i / 2
-				// Number of racks failure we can tolerance.
-				nracks := (i*len(racks) + j) / 2
-				// Number of hosts failure we can tolerance.
-				nhosts := (i*len(racks)*len(hosts) + j*len(hosts) + k) / 2
-				score := (nzones*replicaBaseScore+nracks)*replicaBaseScore + nhosts
-				c.Assert(rep.GetReplicaScore(stores), Equals, float64(score))
-			}
-		}
-	}
-
-	tc.addLabelsStore(100, 1, 0.1, map[string]string{})
-	stores = append(stores, cluster.getStore(100))
-	c.Assert(rep.GetReplicaScore(stores), Equals, float64(0))
-}
-
 func (s *testReplicationSuite) TestDistinctScore(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)

--- a/server/replication_test.go
+++ b/server/replication_test.go
@@ -106,3 +106,24 @@ func (s *testReplicationSuite) TestDistinctScore(c *C) {
 	store := cluster.getStore(100)
 	c.Assert(rep.GetDistinctScore(stores, store), Equals, float64(0))
 }
+
+func (s *testReplicationSuite) TestCompareStoreScore(c *C) {
+	cluster := newClusterInfo(newMockIDAllocator())
+	tc := newTestClusterInfo(cluster)
+
+	tc.addRegionStore(1, 1, 0.1)
+	tc.addRegionStore(2, 1, 0.1)
+	tc.addRegionStore(3, 1, 0.2)
+
+	store1 := cluster.getStore(1)
+	store2 := cluster.getStore(2)
+	store3 := cluster.getStore(3)
+
+	c.Assert(compareStoreScore(store1, 2, store2, 1), Equals, 1)
+	c.Assert(compareStoreScore(store1, 1, store2, 1), Equals, 0)
+	c.Assert(compareStoreScore(store1, 1, store2, 2), Equals, -1)
+
+	c.Assert(compareStoreScore(store1, 2, store3, 1), Equals, 1)
+	c.Assert(compareStoreScore(store1, 1, store3, 1), Equals, 1)
+	c.Assert(compareStoreScore(store1, 1, store3, 2), Equals, -1)
+}

--- a/server/replication_test.go
+++ b/server/replication_test.go
@@ -15,110 +15,11 @@ package server
 
 import . "github.com/pingcap/check"
 
-func newTestReplication(maxReplicas int, locationLabels ...string) *Replication {
+func newTestReplication(maxReplicas int, unsafeBalance bool, locationLabels ...string) *Replication {
 	cfg := &ReplicationConfig{
-		MaxReplicas:    uint64(maxReplicas),
-		LocationLabels: locationLabels,
+		MaxReplicas:        uint64(maxReplicas),
+		LocationLabels:     locationLabels,
+		AllowUnsafeBalance: unsafeBalance,
 	}
 	return newReplication(cfg)
-}
-
-var _ = Suite(&testReplicationSuite{})
-
-type testReplicationSuite struct{}
-
-func (s *testReplicationSuite) TestReplicaScore(c *C) {
-	cluster := newClusterInfo(newMockIDAllocator())
-	tc := newTestClusterInfo(cluster)
-	rep := newTestReplication(3, "zone", "rack", "host")
-
-	zones := []string{"z1", "z2", "z3"}
-	racks := []string{"r1", "r2", "r3"}
-	hosts := []string{"h1", "h2", "h3"}
-
-	var stores []*storeInfo
-	for i, zone := range zones {
-		for j, rack := range racks {
-			for k, host := range hosts {
-				storeID := uint64(i*len(racks)*len(hosts) + j*len(hosts) + k)
-				labels := map[string]string{
-					"zone": zone,
-					"rack": rack,
-					"host": host,
-				}
-
-				tc.addLabelsStore(storeID, 1, 0.1, labels)
-
-				store := cluster.getStore(storeID)
-				// We have (j*len(hosts) + k) replicas with the same zone,
-				// k replicas with the same rack.
-				score := float64(1*(j*len(hosts)+k)*1 + replicaBaseScore*k)
-				c.Assert(rep.GetReplicaScore(stores, store), Equals, score)
-
-				stores = append(stores, store)
-			}
-		}
-	}
-
-	baseScore := replicaBaseScore
-	zoneReplicas := len(racks) * len(hosts) // replicas with the same zone
-	rackReplicas := len(zones) * len(hosts) // replicas with the same rack
-	hostReplicas := len(zones) * len(racks) // replicas with the same host
-	storeID := uint64(len(zones) * len(racks) * len(hosts))
-
-	// Missing rack and host, we assume it has the same rack and host with
-	// other stores with the same zone.
-	tc.addLabelsStore(storeID, 1, 0.1, map[string]string{"zone": "z3"})
-	score := float64((1 + baseScore + baseScore*baseScore) * zoneReplicas)
-	c.Assert(rep.GetReplicaScore(stores, cluster.getStore(storeID)), Equals, score)
-
-	// Missing rack and host, but the zone is different with other stores.
-	tc.addLabelsStore(storeID, 1, 0.1, map[string]string{"zone": "z4"})
-	score = float64(0)
-	c.Assert(rep.GetReplicaScore(stores, cluster.getStore(storeID)), Equals, score)
-
-	// Missing zone and host, we assume it has the same zone with other stores
-	// and the same host with other stores with the same rack.
-	tc.addLabelsStore(storeID, 1, 0.1, map[string]string{"rack": "r3"})
-	score = float64(1*len(stores) + (baseScore+baseScore*baseScore)*rackReplicas)
-	c.Assert(rep.GetReplicaScore(stores, cluster.getStore(storeID)), Equals, score)
-
-	// Missing zone and host, we assume it has the same zone with other stores,
-	// but different rack with other stores.
-	tc.addLabelsStore(storeID, 1, 0.1, map[string]string{"rack": "r4"})
-	score = float64(1 * len(stores))
-	c.Assert(rep.GetReplicaScore(stores, cluster.getStore(storeID)), Equals, score)
-
-	// Missing zone and rack, we assume it has the same zone and rack with other
-	// stores with the same host.
-	tc.addLabelsStore(storeID, 1, 0.1, map[string]string{"host": "h3"})
-	score = float64((1+baseScore)*len(stores) + (baseScore*baseScore)*hostReplicas)
-	c.Assert(rep.GetReplicaScore(stores, cluster.getStore(storeID)), Equals, score)
-
-	// Missing zone and rack, we assume it has the same zone and rack with other
-	// stores, but different host with other stores.
-	tc.addLabelsStore(storeID, 1, 0.1, map[string]string{"host": "h4"})
-	score = float64((1 + baseScore) * len(stores))
-	c.Assert(rep.GetReplicaScore(stores, cluster.getStore(storeID)), Equals, score)
-}
-
-func (s *testReplicationSuite) TestCompareStoreScore(c *C) {
-	cluster := newClusterInfo(newMockIDAllocator())
-	tc := newTestClusterInfo(cluster)
-
-	tc.addRegionStore(1, 1, 0.1)
-	tc.addRegionStore(2, 1, 0.1)
-	tc.addRegionStore(3, 1, 0.2)
-
-	store1 := cluster.getStore(1)
-	store2 := cluster.getStore(2)
-	store3 := cluster.getStore(3)
-
-	c.Assert(compareStoreScore(store1, 1, store2, 2), Equals, 1)
-	c.Assert(compareStoreScore(store1, 1, store2, 1), Equals, 0)
-	c.Assert(compareStoreScore(store1, 2, store2, 1), Equals, -1)
-
-	c.Assert(compareStoreScore(store1, 1, store3, 2), Equals, 1)
-	c.Assert(compareStoreScore(store1, 1, store3, 1), Equals, 1)
-	c.Assert(compareStoreScore(store1, 2, store3, 1), Equals, -1)
 }

--- a/server/selector.go
+++ b/server/selector.go
@@ -34,7 +34,7 @@ func newBalanceSelector(kind ResourceKind, filters []Filter) *balanceSelector {
 }
 
 func (s *balanceSelector) SelectSource(stores []*storeInfo, filters ...Filter) *storeInfo {
-	filters = append(s.filters, filters...)
+	filters = append(filters, s.filters...)
 
 	var result *storeInfo
 	for _, store := range stores {
@@ -49,7 +49,7 @@ func (s *balanceSelector) SelectSource(stores []*storeInfo, filters ...Filter) *
 }
 
 func (s *balanceSelector) SelectTarget(stores []*storeInfo, filters ...Filter) *storeInfo {
-	filters = append(s.filters, filters...)
+	filters = append(filters, s.filters...)
 
 	var result *storeInfo
 	for _, store := range stores {

--- a/server/store.go
+++ b/server/store.go
@@ -114,7 +114,7 @@ func (s *storeInfo) getLocationID(keys []string) string {
 		if len(v) == 0 {
 			return ""
 		}
-		id += s.getLabelValue(k)
+		id += v
 	}
 	return id
 }

--- a/server/store.go
+++ b/server/store.go
@@ -107,6 +107,18 @@ func (s *storeInfo) getLabelValue(key string) string {
 	return ""
 }
 
+func (s *storeInfo) getLocationID(keys []string) string {
+	id := ""
+	for _, k := range keys {
+		v := s.getLabelValue(k)
+		if len(v) == 0 {
+			return ""
+		}
+		id += s.getLabelValue(k)
+	}
+	return id
+}
+
 // StoreStatus contains information about a store's status.
 type StoreStatus struct {
 	*pdpb.StoreStats


### PR DESCRIPTION
We can not do balance safely if we have only 3 data centers, because of https://github.com/pingcap/tikv/issues/1468.
So, the current implementation guarantee safety if we have more than 3 data centers, but we will still balance if we have only 3 data cetners.