### PR TITLE
server/leader: keep alive leader before initialization

### DIFF
--- a/server/leader.go
+++ b/server/leader.go
@@ -170,18 +170,18 @@ func (s *Server) campaignLeader() error {
 		return errors.New("campaign leader failed, other server may campaign ok")
 	}
 
+	// Make the leader keepalived.
+	ch, err := lessor.KeepAlive(s.client.Ctx(), clientv3.LeaseID(leaseResp.ID))
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	log.Debugf("campaign leader ok %s", s.Name())
 	s.enableLeader(true)
 	defer s.enableLeader(false)
 
 	// Try to create raft cluster.
 	err = s.createRaftCluster()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// Make the leader keepalived.
-	ch, err := lessor.KeepAlive(s.client.Ctx(), clientv3.LeaseID(leaseResp.ID))
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
We should keep alive before initialization (`createRaftCluster` and
`syncTimestamp`), otherwise, if the initialization takes too long (longer than
the leader lease), we will lose the leader lease.