### PR TITLE
server: remove balancer concept

### DIFF
--- a/server/api/scheduler.go
+++ b/server/api/scheduler.go
@@ -56,8 +56,8 @@ func (h *schedulerHandler) Post(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch name {
-	case "leader-balancer":
-		if err := h.AddLeaderBalancer(); err != nil {
+	case "balance-leader-scheduler":
+		if err := h.AddBalanceLeaderScheduler(); err != nil {
 			h.r.JSON(w, http.StatusInternalServerError, err.Error())
 			return
 		}

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -127,16 +127,16 @@ func newTestScheduleConfig() (*ScheduleConfig, *scheduleOption) {
 	return &cfg.Schedule, opt
 }
 
-var _ = Suite(&testLeaderBalancerSuite{})
+var _ = Suite(&testBalanceLeaderSchedulerSuite{})
 
-type testLeaderBalancerSuite struct{}
+type testBalanceLeaderSchedulerSuite struct{}
 
-func (s *testLeaderBalancerSuite) TestBalance(c *C) {
+func (s *testBalanceLeaderSchedulerSuite) TestBalance(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
 
 	cfg, opt := newTestScheduleConfig()
-	lb := newLeaderBalancer(opt)
+	lb := newBalanceLeaderScheduler(opt)
 
 	cfg.MinLeaderCount = 10
 	cfg.MinBalanceDiffRatio = 0.1
@@ -175,16 +175,16 @@ func (s *testLeaderBalancerSuite) TestBalance(c *C) {
 	c.Assert(lb.Schedule(cluster), IsNil)
 }
 
-var _ = Suite(&testStorageBalancerSuite{})
+var _ = Suite(&testBalanceStorageSchedulerSuite{})
 
-type testStorageBalancerSuite struct{}
+type testBalanceStorageSchedulerSuite struct{}
 
-func (s *testStorageBalancerSuite) TestBalance(c *C) {
+func (s *testBalanceStorageSchedulerSuite) TestBalance(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
 
 	cfg, opt := newTestScheduleConfig()
-	sb := newStorageBalancer(opt)
+	sb := newBalanceStorageScheduler(opt)
 
 	opt.SetMaxReplicas(1)
 	cfg.MinRegionCount = 10
@@ -226,14 +226,14 @@ func (s *testStorageBalancerSuite) TestBalance(c *C) {
 	c.Assert(sb.Schedule(cluster), IsNil)
 }
 
-func (s *testStorageBalancerSuite) TestReplicas3(c *C) {
+func (s *testBalanceStorageSchedulerSuite) TestReplicas3(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
 
 	_, opt := newTestScheduleConfig()
 	opt.rep = newTestReplication(3, "zone", "rack", "host")
 
-	sb := newStorageBalancer(opt)
+	sb := newBalanceStorageScheduler(opt)
 
 	// Store 1 has the largest storage ratio, so the balancer try to replace peer in store 1.
 	tc.addLabelsStore(1, 1, 0.5, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
@@ -290,14 +290,14 @@ func (s *testStorageBalancerSuite) TestReplicas3(c *C) {
 	c.Assert(sb.Schedule(cluster), IsNil)
 }
 
-func (s *testStorageBalancerSuite) TestReplicas5(c *C) {
+func (s *testBalanceStorageSchedulerSuite) TestReplicas5(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
 
 	_, opt := newTestScheduleConfig()
 	opt.rep = newTestReplication(5, "zone", "rack", "host")
 
-	sb := newStorageBalancer(opt)
+	sb := newBalanceStorageScheduler(opt)
 
 	tc.addLabelsStore(1, 1, 0.1, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
 	tc.addLabelsStore(2, 1, 0.2, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"})

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -81,8 +81,8 @@ func (c *coordinator) dispatch(region *regionInfo) *pdpb.RegionHeartbeatResponse
 }
 
 func (c *coordinator) run() {
-	c.addScheduler(newLeaderScheduleController(c, newLeaderBalancer(c.opt)))
-	c.addScheduler(newStorageScheduleController(c, newStorageBalancer(c.opt)))
+	c.addScheduler(newLeaderScheduleController(c, newBalanceLeaderScheduler(c.opt)))
+	c.addScheduler(newStorageScheduleController(c, newBalanceStorageScheduler(c.opt)))
 }
 
 func (c *coordinator) stop() {

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -214,8 +214,8 @@ func (s *testCoordinatorSuite) TestAddScheduler(c *C) {
 	defer co.stop()
 
 	c.Assert(co.schedulers, HasLen, 2)
-	c.Assert(co.removeScheduler("leader-balancer"), IsTrue)
-	c.Assert(co.removeScheduler("storage-balancer"), IsTrue)
+	c.Assert(co.removeScheduler("balance-leader-scheduler"), IsTrue)
+	c.Assert(co.removeScheduler("balance-storage-scheduler"), IsTrue)
 	c.Assert(co.schedulers, HasLen, 0)
 
 	// Add stores 1,2,3

--- a/server/handler.go
+++ b/server/handler.go
@@ -69,9 +69,9 @@ func (h *Handler) AddLeaderScheduler(s Scheduler) error {
 	return nil
 }
 
-// AddLeaderBalancer adds a leader-balancer.
-func (h *Handler) AddLeaderBalancer() error {
-	return h.AddLeaderScheduler(newLeaderBalancer(h.s.scheduleOpt))
+// AddBalanceLeaderScheduler adds a balance-leader-scheduler.
+func (h *Handler) AddBalanceLeaderScheduler() error {
+	return h.AddLeaderScheduler(newBalanceLeaderScheduler(h.s.scheduleOpt))
 }
 
 // AddGrantLeaderScheduler adds a grant-leader-scheduler.


### PR DESCRIPTION
Rename `LeaderBalancer` to `BalanceLeaderScheduler`,
Rename `StorageBalancer` to `BalanceStorageScheduler`.

Close https://github.com/pingcap/pd/issues/467.