### PR TITLE
[DNM] server: check store heartbeat before updating existed store

### DIFF
--- a/server/cache.go
+++ b/server/cache.go
@@ -461,6 +461,7 @@ func (c *clusterInfo) handleStoreHeartbeat(stats *pdpb.StoreStats) error {
 
 	store.stats.StoreStats = proto.Clone(stats).(*pdpb.StoreStats)
 	store.stats.LastHeartbeatTS = time.Now()
+	store.stats.HeartbeatCount = store.stats.HeartbeatCount + 1
 	store.stats.TotalRegionCount = c.regions.getRegionCount()
 	store.stats.LeaderRegionCount = c.regions.getStoreLeaderCount(storeID)
 

--- a/server/store.go
+++ b/server/store.go
@@ -125,6 +125,7 @@ type StoreStatus struct {
 
 	StartTS           time.Time `json:"start_ts"`
 	LastHeartbeatTS   time.Time `json:"last_heartbeat_ts"`
+	HeartbeatCount    int64     `json:"heartbeat_count"`
 	TotalRegionCount  int       `json:"total_region_count"`
 	LeaderRegionCount int       `json:"leader_region_count"`
 }
@@ -141,6 +142,7 @@ func (s *StoreStatus) clone() *StoreStatus {
 		StoreStats:        proto.Clone(s.StoreStats).(*pdpb.StoreStats),
 		StartTS:           s.StartTS,
 		LastHeartbeatTS:   s.LastHeartbeatTS,
+		HeartbeatCount:    s.HeartbeatCount,
 		TotalRegionCount:  s.TotalRegionCount,
 		LeaderRegionCount: s.LeaderRegionCount,
 	}
@@ -153,6 +155,16 @@ func (s *StoreStatus) GetUptime() time.Duration {
 		return uptime
 	}
 	return 0
+}
+
+// GetHeartbeatInterval roughly calculates the heartbeat interval.
+// returns zero interval when there is no heartbeat arrived.
+func (s *StoreStatus) GetHeartbeatInterval() time.Duration {
+	if s.HeartbeatCount == 0 {
+		return time.Duration(0)
+	}
+
+	return time.Duration(int64(s.LastHeartbeatTS.Sub(s.StartTS)) / s.HeartbeatCount)
 }
 
 // GetUsedSize returns the used storage size.


### PR DESCRIPTION
Check store heartbeat before updating existed store.
It doesn't provide true safety, but I think it is enough for now.

PTAL @huachaohuang @siddontang 

CC #482 