### PR TITLE
server: let scheduler control the resource limit

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -30,12 +30,10 @@ min-leader-count = 10
 max-snapshot-count = 3
 min-balance-diff-ratio = 0.01
 max-store-down-duration = "1h"
-leader-schedule-limit = 8
-leader-schedule-interval = "1s"
-storage-schedule-limit = 4
-storage-schedule-interval = "1s"
-replica-schedule-limit = 8
-replica-schedule-interval = "1s"
+schedule-interval = "5s"
+leader-schedule-limit = 16
+region-schedule-limit = 12
+replica-schedule-limit = 16
 
 [replication]
 # The number of replicas for each region.

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -47,6 +47,10 @@ func (l *balanceLeaderScheduler) GetResourceKind() ResourceKind {
 	return leaderKind
 }
 
+func (l *balanceLeaderScheduler) GetResourceLimit() uint64 {
+	return l.opt.GetLeaderScheduleLimit()
+}
+
 func (l *balanceLeaderScheduler) Schedule(cluster *clusterInfo) Operator {
 	region, newLeader := scheduleTransferLeader(cluster, l.selector)
 	if region == nil {
@@ -83,7 +87,7 @@ func newBalanceStorageScheduler(opt *scheduleOption) *balanceStorageScheduler {
 		opt:      opt,
 		rep:      opt.GetReplication(),
 		cache:    cache,
-		selector: newBalanceSelector(storageKind, filters),
+		selector: newBalanceSelector(regionKind, filters),
 	}
 }
 
@@ -92,7 +96,11 @@ func (s *balanceStorageScheduler) GetName() string {
 }
 
 func (s *balanceStorageScheduler) GetResourceKind() ResourceKind {
-	return storageKind
+	return regionKind
+}
+
+func (s *balanceStorageScheduler) GetResourceLimit() uint64 {
+	return s.opt.GetRegionScheduleLimit()
 }
 
 func (s *balanceStorageScheduler) Schedule(cluster *clusterInfo) Operator {

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -121,8 +121,7 @@ func newTestScheduleConfig() (*ScheduleConfig, *scheduleOption) {
 	cfg.adjust()
 	cfg.Schedule.MinLeaderCount = 1
 	cfg.Schedule.MinRegionCount = 1
-	cfg.Schedule.LeaderScheduleInterval.Duration = 10 * time.Millisecond
-	cfg.Schedule.StorageScheduleInterval.Duration = 10 * time.Millisecond
+	cfg.Schedule.ScheduleInterval.Duration = time.Nanosecond
 	opt := newScheduleOption(cfg)
 	return &cfg.Schedule, opt
 }

--- a/server/cluster_worker_test.go
+++ b/server/cluster_worker_test.go
@@ -444,9 +444,7 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit2(c *C) {
 }
 
 func (s *testClusterWorkerSuite) TestHeartbeatChangePeer(c *C) {
-	// Set interval to 0 for tests.
-	cfg, opt := s.svr.cfg, s.svr.scheduleOpt
-	cfg.Schedule.ReplicaScheduleInterval.Duration = 0
+	opt := s.svr.scheduleOpt
 
 	cluster := s.svr.GetRaftCluster()
 	c.Assert(cluster, NotNil)

--- a/server/config.go
+++ b/server/config.go
@@ -286,35 +286,27 @@ type ScheduleConfig struct {
 	// a store will be considered to be down if it hasn't reported heartbeats.
 	MaxStoreDownDuration timeutil.Duration `toml:"max-store-down-duration" json:"max-store-down-duration"`
 
+	// ScheduleInterval is the interval to schedule.
+	ScheduleInterval timeutil.Duration `toml:"schedule-interval" json:"schedule-interval"`
 	// LeaderScheduleLimit is the max coexist leader schedules.
 	LeaderScheduleLimit uint64 `toml:"leader-schedule-limit" json:"leader-schedule-limit"`
-	// LeaderScheduleInterval is the interval to schedule leader.
-	LeaderScheduleInterval timeutil.Duration `toml:"leader-schedule-interval" json:"leader-schedule-interval"`
-
-	// StorageScheduleLimit is the max coexist storage schedules.
-	StorageScheduleLimit uint64 `toml:"storage-schedule-limit" json:"storage-schedule-limit"`
-	// StorageScheduleInterval is the interval to schedule storage.
-	StorageScheduleInterval timeutil.Duration `toml:"storage-schedule-interval" json:"storage-schedule-interval"`
-
+	// RegionScheduleLimit is the max coexist region schedules.
+	RegionScheduleLimit uint64 `toml:"region-schedule-limit" json:"region-schedule-limit"`
 	// ReplicaScheduleLimit is the max coexist replica schedules.
 	ReplicaScheduleLimit uint64 `toml:"replica-schedule-limit" json:"replica-schedule-limit"`
-	// ReplicaScheduleInterval is the interval to schedule storage.
-	ReplicaScheduleInterval timeutil.Duration `toml:"replica-schedule-interval" json:"replica-schedule-interval"`
 }
 
 const (
-	defaultMaxReplicas             = uint64(3)
-	defaultMinRegionCount          = uint64(10)
-	defaultMinLeaderCount          = uint64(10)
-	defaultMaxSnapshotCount        = uint64(3)
-	defaultMinBalanceDiffRatio     = float64(0.01)
-	defaultMaxStoreDownDuration    = time.Hour
-	defaultLeaderScheduleLimit     = 8
-	defaultLeaderScheduleInterval  = time.Second
-	defaultStorageScheduleLimit    = 4
-	defaultStorageScheduleInterval = time.Second
-	defaultReplicaScheduleLimit    = 8
-	defaultReplicaScheduleInterval = time.Second
+	defaultMaxReplicas          = uint64(3)
+	defaultMinRegionCount       = uint64(10)
+	defaultMinLeaderCount       = uint64(10)
+	defaultMaxSnapshotCount     = uint64(3)
+	defaultMinBalanceDiffRatio  = float64(0.01)
+	defaultMaxStoreDownDuration = time.Hour
+	defaultScheduleInterval     = time.Minute
+	defaultLeaderScheduleLimit  = 16
+	defaultRegionScheduleLimit  = 12
+	defaultReplicaScheduleLimit = 16
 )
 
 func (c *ScheduleConfig) adjust() {
@@ -323,12 +315,10 @@ func (c *ScheduleConfig) adjust() {
 	adjustUint64(&c.MaxSnapshotCount, defaultMaxSnapshotCount)
 	adjustFloat64(&c.MinBalanceDiffRatio, defaultMinBalanceDiffRatio)
 	adjustDuration(&c.MaxStoreDownDuration, defaultMaxStoreDownDuration)
+	adjustDuration(&c.ScheduleInterval, defaultScheduleInterval)
 	adjustUint64(&c.LeaderScheduleLimit, defaultLeaderScheduleLimit)
-	adjustDuration(&c.LeaderScheduleInterval, defaultLeaderScheduleInterval)
-	adjustUint64(&c.StorageScheduleLimit, defaultStorageScheduleLimit)
-	adjustDuration(&c.StorageScheduleInterval, defaultStorageScheduleInterval)
+	adjustUint64(&c.RegionScheduleLimit, defaultRegionScheduleLimit)
 	adjustUint64(&c.ReplicaScheduleLimit, defaultReplicaScheduleLimit)
-	adjustDuration(&c.ReplicaScheduleInterval, defaultReplicaScheduleInterval)
 }
 
 // ReplicationConfig is the replication configuration.
@@ -400,28 +390,20 @@ func (o *scheduleOption) GetMaxStoreDownTime() time.Duration {
 	return o.load().MaxStoreDownDuration.Duration
 }
 
+func (o *scheduleOption) GetScheduleInterval() time.Duration {
+	return o.load().ScheduleInterval.Duration
+}
+
 func (o *scheduleOption) GetLeaderScheduleLimit() uint64 {
 	return o.load().LeaderScheduleLimit
 }
 
-func (o *scheduleOption) GetLeaderScheduleInterval() time.Duration {
-	return o.load().LeaderScheduleInterval.Duration
-}
-
-func (o *scheduleOption) GetStorageScheduleLimit() uint64 {
-	return o.load().StorageScheduleLimit
-}
-
-func (o *scheduleOption) GetStorageScheduleInterval() time.Duration {
-	return o.load().StorageScheduleInterval.Duration
+func (o *scheduleOption) GetRegionScheduleLimit() uint64 {
+	return o.load().RegionScheduleLimit
 }
 
 func (o *scheduleOption) GetReplicaScheduleLimit() uint64 {
 	return o.load().ReplicaScheduleLimit
-}
-
-func (o *scheduleOption) GetReplicaScheduleInterval() time.Duration {
-	return o.load().ReplicaScheduleInterval.Duration
 }
 
 // ParseUrls parse a string into multiple urls.

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -35,54 +35,60 @@ type coordinator struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	cluster *clusterInfo
-	opt     *scheduleOption
-	checker *replicaCheckController
-
-	schedulers map[string]*ScheduleController
-	operators  map[ResourceKind]map[uint64]Operator
+	cluster    *clusterInfo
+	opt        *scheduleOption
+	limiter    *scheduleLimiter
+	checker    *replicaChecker
+	operators  map[uint64]Operator
+	schedulers map[string]*scheduleController
 
 	histories *lruCache
 	events    *fifoCache
 }
 
 func newCoordinator(cluster *clusterInfo, opt *scheduleOption) *coordinator {
-	c := &coordinator{
+	ctx, cancel := context.WithCancel(context.TODO())
+	return &coordinator{
+		ctx:        ctx,
+		cancel:     cancel,
 		cluster:    cluster,
 		opt:        opt,
-		schedulers: make(map[string]*ScheduleController),
+		limiter:    newScheduleLimiter(),
+		checker:    newReplicaChecker(opt, cluster),
+		operators:  make(map[uint64]Operator),
+		schedulers: make(map[string]*scheduleController),
 		histories:  newLRUCache(historiesCacheSize),
 		events:     newFifoCache(eventsCacheSize),
 	}
-
-	c.ctx, c.cancel = context.WithCancel(context.TODO())
-
-	c.checker = newReplicaCheckController(c)
-	c.operators = make(map[ResourceKind]map[uint64]Operator)
-	c.operators[leaderKind] = make(map[uint64]Operator)
-	c.operators[storageKind] = make(map[uint64]Operator)
-
-	return c
 }
 
 func (c *coordinator) dispatch(region *regionInfo) *pdpb.RegionHeartbeatResponse {
-	c.checker.Check(region)
-
-	op := c.getOperator(region.GetId())
-	if op == nil {
-		return nil
-	}
-
-	res, finished := op.Do(region)
-	if finished {
+	// Check existed operator.
+	if op := c.getOperator(region.GetId()); op != nil {
+		res, finished := op.Do(region)
+		if !finished {
+			return res
+		}
 		c.removeOperator(op)
 	}
-	return res
+
+	// Check replica operator.
+	if c.limiter.operatorCount(regionKind) >= c.opt.GetReplicaScheduleLimit() {
+		return nil
+	}
+	if op := c.checker.Check(region); op != nil {
+		if c.addOperator(op) {
+			res, _ := op.Do(region)
+			return res
+		}
+	}
+
+	return nil
 }
 
 func (c *coordinator) run() {
-	c.addScheduler(newLeaderScheduleController(c, newBalanceLeaderScheduler(c.opt)))
-	c.addScheduler(newStorageScheduleController(c, newBalanceStorageScheduler(c.opt)))
+	c.addScheduler(newBalanceLeaderScheduler(c.opt))
+	c.addScheduler(newBalanceStorageScheduler(c.opt))
 }
 
 func (c *coordinator) stop() {
@@ -101,17 +107,17 @@ func (c *coordinator) getSchedulers() []string {
 	return names
 }
 
-func (c *coordinator) addScheduler(s *ScheduleController) bool {
+func (c *coordinator) addScheduler(scheduler Scheduler) bool {
 	c.Lock()
 	defer c.Unlock()
 
+	s := newScheduleController(c, scheduler)
 	if _, ok := c.schedulers[s.GetName()]; ok {
 		return false
 	}
 
 	c.wg.Add(1)
 	go c.runScheduler(s)
-
 	c.schedulers[s.GetName()] = s
 	return true
 }
@@ -130,7 +136,7 @@ func (c *coordinator) removeScheduler(name string) bool {
 	return true
 }
 
-func (c *coordinator) runScheduler(s *ScheduleController) {
+func (c *coordinator) runScheduler(s *scheduleController) {
 	defer c.wg.Done()
 
 	timer := time.NewTimer(s.GetInterval())
@@ -164,12 +170,13 @@ func (c *coordinator) addOperator(op Operator) bool {
 	defer c.Unlock()
 
 	regionID := op.GetRegionID()
-	if c.getOperatorLocked(regionID) != nil {
+	if _, ok := c.operators[regionID]; ok {
 		return false
 	}
 
+	c.limiter.addOperator(op)
+	c.operators[regionID] = op
 	collectOperatorCounterMetrics(op)
-	c.operators[op.GetResourceKind()][regionID] = op
 	return true
 }
 
@@ -178,26 +185,16 @@ func (c *coordinator) removeOperator(op Operator) {
 	defer c.Unlock()
 
 	regionID := op.GetRegionID()
-	c.histories.add(regionID, op)
+	c.limiter.removeOperator(op)
+	delete(c.operators, regionID)
 
-	for _, ops := range c.operators {
-		delete(ops, regionID)
-	}
+	c.histories.add(regionID, op)
 }
 
 func (c *coordinator) getOperator(regionID uint64) Operator {
 	c.RLock()
 	defer c.RUnlock()
-	return c.getOperatorLocked(regionID)
-}
-
-func (c *coordinator) getOperatorLocked(regionID uint64) Operator {
-	for _, ops := range c.operators {
-		if op, ok := ops[regionID]; ok {
-			return op
-		}
-	}
-	return nil
+	return c.operators[regionID]
 }
 
 func (c *coordinator) getOperators() map[uint64]Operator {
@@ -205,10 +202,8 @@ func (c *coordinator) getOperators() map[uint64]Operator {
 	defer c.RUnlock()
 
 	operators := make(map[uint64]Operator)
-	for _, ops := range c.operators {
-		for id, op := range ops {
-			operators[id] = op
-		}
+	for id, op := range c.operators {
+		operators[id] = op
 	}
 
 	return operators
@@ -226,128 +221,70 @@ func (c *coordinator) getHistories() []Operator {
 	return operators
 }
 
-func (c *coordinator) getOperatorCount(kind ResourceKind) int {
-	c.RLock()
-	defer c.RUnlock()
-	return len(c.operators[kind])
+type scheduleLimiter struct {
+	sync.RWMutex
+	counts map[ResourceKind]uint64
 }
 
-// Controller is an interface to control the speed of different schedulers.
-type Controller interface {
-	Ctx() context.Context
-	Stop()
-	GetInterval() time.Duration
-	AllowSchedule() bool
+func newScheduleLimiter() *scheduleLimiter {
+	return &scheduleLimiter{
+		counts: make(map[ResourceKind]uint64),
+	}
 }
 
-type leaderController struct {
-	c      *coordinator
-	ctx    context.Context
-	cancel context.CancelFunc
+func (l *scheduleLimiter) addOperator(op Operator) {
+	l.Lock()
+	defer l.Unlock()
+	l.counts[op.GetResourceKind()]++
 }
 
-func newLeaderController(c *coordinator) *leaderController {
-	l := &leaderController{c: c}
-	l.ctx, l.cancel = context.WithCancel(c.ctx)
-	return l
+func (l *scheduleLimiter) removeOperator(op Operator) {
+	l.Lock()
+	defer l.Unlock()
+	l.counts[op.GetResourceKind()]--
 }
 
-func (l *leaderController) Ctx() context.Context {
-	return l.ctx
+func (l *scheduleLimiter) operatorCount(kind ResourceKind) uint64 {
+	l.RLock()
+	defer l.RUnlock()
+	return l.counts[kind]
 }
 
-func (l *leaderController) Stop() {
-	l.cancel()
+type scheduleController struct {
+	Scheduler
+	opt     *scheduleOption
+	limiter *scheduleLimiter
+	ctx     context.Context
+	cancel  context.CancelFunc
 }
 
-func (l *leaderController) GetInterval() time.Duration {
-	return l.c.opt.GetLeaderScheduleInterval()
+func newScheduleController(c *coordinator, s Scheduler) *scheduleController {
+	ctx, cancel := context.WithCancel(c.ctx)
+	return &scheduleController{
+		Scheduler: s,
+		opt:       c.opt,
+		limiter:   c.limiter,
+		ctx:       ctx,
+		cancel:    cancel,
+	}
 }
 
-func (l *leaderController) AllowSchedule() bool {
-	return l.c.getOperatorCount(leaderKind) < int(l.c.opt.GetLeaderScheduleLimit())
-}
-
-type storageController struct {
-	c      *coordinator
-	ctx    context.Context
-	cancel context.CancelFunc
-}
-
-func newStorageController(c *coordinator) *storageController {
-	s := &storageController{c: c}
-	s.ctx, s.cancel = context.WithCancel(c.ctx)
-	return s
-}
-
-func (s *storageController) Ctx() context.Context {
+func (s *scheduleController) Ctx() context.Context {
 	return s.ctx
 }
 
-func (s *storageController) Stop() {
+func (s *scheduleController) Stop() {
 	s.cancel()
 }
 
-func (s *storageController) GetInterval() time.Duration {
-	return s.c.opt.GetStorageScheduleInterval()
+func (s *scheduleController) GetInterval() time.Duration {
+	limit := s.GetResourceLimit()
+	interval := s.opt.GetScheduleInterval().Nanoseconds()
+	return time.Duration(uint64(interval)/limit) * time.Nanosecond
 }
 
-func (s *storageController) AllowSchedule() bool {
-	return s.c.getOperatorCount(storageKind) < int(s.c.opt.GetStorageScheduleLimit())
-}
-
-// ScheduleController combines Scheduler with Controller.
-type ScheduleController struct {
-	Scheduler
-	Controller
-}
-
-func newLeaderScheduleController(c *coordinator, s Scheduler) *ScheduleController {
-	return &ScheduleController{
-		Scheduler:  s,
-		Controller: newLeaderController(c),
-	}
-}
-
-func newStorageScheduleController(c *coordinator, s Scheduler) *ScheduleController {
-	return &ScheduleController{
-		Scheduler:  s,
-		Controller: newStorageController(c),
-	}
-}
-
-type replicaCheckController struct {
-	c        *coordinator
-	opt      *scheduleOption
-	checker  *replicaChecker
-	lastTime time.Time
-}
-
-func newReplicaCheckController(c *coordinator) *replicaCheckController {
-	return &replicaCheckController{
-		c:       c,
-		opt:     c.opt,
-		checker: newReplicaChecker(c.opt, c.cluster),
-	}
-}
-
-func (r *replicaCheckController) Check(region *regionInfo) {
-	// Check limit and interval.
-	if time.Since(r.lastTime) < r.opt.GetReplicaScheduleInterval() {
-		return
-	}
-	if r.c.getOperatorCount(storageKind) >= int(r.opt.GetReplicaScheduleLimit()) {
-		return
-	}
-
-	op := r.checker.Check(region)
-	if op == nil {
-		return
-	}
-
-	if r.c.addOperator(op) {
-		r.lastTime = time.Now()
-	}
+func (s *scheduleController) AllowSchedule() bool {
+	return s.limiter.operatorCount(s.GetResourceKind()) < s.GetResourceLimit()
 }
 
 func collectOperatorCounterMetrics(op Operator) {

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -47,7 +47,7 @@ type coordinator struct {
 }
 
 func newCoordinator(cluster *clusterInfo, opt *scheduleOption) *coordinator {
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(context.Background())
 	return &coordinator{
 		ctx:        ctx,
 		cancel:     cancel,

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -77,17 +77,17 @@ func (s *testCoordinatorSuite) TestDispatch(c *C) {
 	defer co.stop()
 
 	// Transfer peer from store 4 to store 1.
-	tc.addRegionStore(1, 1, 0.1)
-	tc.addRegionStore(2, 2, 0.2)
-	tc.addRegionStore(3, 3, 0.3)
 	tc.addRegionStore(4, 4, 0.4)
+	tc.addRegionStore(3, 3, 0.3)
+	tc.addRegionStore(2, 2, 0.2)
+	tc.addRegionStore(1, 1, 0.1)
 	tc.addLeaderRegion(1, 2, 3, 4)
 
 	// Transfer leader from store 4 to store 1.
-	tc.updateLeaderCount(1, 1, 10)
-	tc.updateLeaderCount(2, 2, 10)
-	tc.updateLeaderCount(3, 3, 10)
 	tc.updateLeaderCount(4, 4, 10)
+	tc.updateLeaderCount(3, 3, 10)
+	tc.updateLeaderCount(2, 2, 10)
+	tc.updateLeaderCount(1, 1, 10)
 	tc.addLeaderRegion(2, 4, 1, 2, 3)
 
 	// Wait for schedule and turn off balance.
@@ -154,10 +154,10 @@ func (s *testCoordinatorSuite) TestPeerState(c *C) {
 	defer co.stop()
 
 	// Transfer peer from store 4 to store 1.
-	tc.addRegionStore(1, 1, 0.1)
-	tc.addRegionStore(2, 2, 0.2)
-	tc.addRegionStore(3, 3, 0.3)
 	tc.addRegionStore(4, 4, 0.4)
+	tc.addRegionStore(3, 3, 0.3)
+	tc.addRegionStore(2, 2, 0.2)
+	tc.addRegionStore(1, 1, 0.1)
 	tc.addLeaderRegion(1, 2, 3, 4)
 
 	// Wait for schedule.

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -48,29 +48,30 @@ func (s *testCoordinatorSuite) TestBasic(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	_, opt := newTestScheduleConfig()
 	co := newCoordinator(cluster, opt)
+	l := co.limiter
 
-	op := newTestOperator(1, leaderKind)
-	co.addOperator(op)
-	c.Assert(co.getOperatorCount(op.GetResourceKind()), Equals, 1)
-	c.Assert(co.getOperator(1).GetRegionID(), Equals, op.GetRegionID())
+	op1 := newTestOperator(1, leaderKind)
+	co.addOperator(op1)
+	c.Assert(l.operatorCount(op1.GetResourceKind()), Equals, uint64(1))
+	c.Assert(co.getOperator(1).GetRegionID(), Equals, op1.GetRegionID())
 
 	// Region 1 already has an operator, cannot add another one.
-	op = newTestOperator(1, storageKind)
-	co.addOperator(op)
-	c.Assert(co.getOperatorCount(op.GetResourceKind()), Equals, 0)
+	op2 := newTestOperator(1, regionKind)
+	co.addOperator(op2)
+	c.Assert(l.operatorCount(op2.GetResourceKind()), Equals, uint64(0))
 
 	// Remove the operator manually, then we can add a new operator.
-	co.removeOperator(op)
-	co.addOperator(op)
-	c.Assert(co.getOperatorCount(op.GetResourceKind()), Equals, 1)
-	c.Assert(co.getOperator(1).GetRegionID(), Equals, op.GetRegionID())
+	co.removeOperator(op1)
+	co.addOperator(op2)
+	c.Assert(l.operatorCount(op2.GetResourceKind()), Equals, uint64(1))
+	c.Assert(co.getOperator(1).GetRegionID(), Equals, op2.GetRegionID())
 }
 
-func (s *testCoordinatorSuite) TestSchedule(c *C) {
+func (s *testCoordinatorSuite) TestDispatch(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
 
-	cfg, opt := newTestScheduleConfig()
+	_, opt := newTestScheduleConfig()
 	co := newCoordinator(cluster, opt)
 	co.run()
 	defer co.stop()
@@ -82,83 +83,65 @@ func (s *testCoordinatorSuite) TestSchedule(c *C) {
 	tc.addRegionStore(4, 4, 0.4)
 	tc.addLeaderRegion(1, 2, 3, 4)
 
-	// Transfer leader from store 1 to store 4.
-	tc.updateLeaderCount(1, 4, 10)
-	tc.updateLeaderCount(2, 3, 10)
-	tc.updateLeaderCount(3, 2, 10)
-	tc.updateLeaderCount(4, 1, 10)
-	tc.addLeaderRegion(2, 1, 2, 3, 4)
+	// Transfer leader from store 4 to store 1.
+	tc.updateLeaderCount(1, 1, 10)
+	tc.updateLeaderCount(2, 2, 10)
+	tc.updateLeaderCount(3, 3, 10)
+	tc.updateLeaderCount(4, 4, 10)
+	tc.addLeaderRegion(2, 4, 1, 2, 3)
 
-	// Wait for schedule.
+	// Wait for schedule and turn off balance.
 	time.Sleep(time.Second)
+	co.removeScheduler("balance-leader-scheduler")
+	co.removeScheduler("balance-storage-scheduler")
 	checkTransferPeer(c, co.getOperator(1), 4, 1)
-	checkTransferLeader(c, co.getOperator(2), 1, 4)
+	checkTransferLeader(c, co.getOperator(2), 4, 1)
 
 	// Transfer peer.
 	region := cluster.getRegion(1)
 	resp := co.dispatch(region)
 	checkAddPeerResp(c, resp, 1)
 	region.Peers = append(region.Peers, resp.GetChangePeer().GetPeer())
+	cluster.putRegion(region)
 	resp = co.dispatch(region)
 	checkRemovePeerResp(c, resp, 4)
-	region.Peers = []*metapb.Peer{
-		region.GetStorePeer(1),
-		region.GetStorePeer(2),
-		region.GetStorePeer(3),
-	}
+
+	tc.addLeaderRegion(1, 1, 2, 3)
+	region = cluster.getRegion(1)
 	c.Assert(co.dispatch(region), IsNil)
 	c.Assert(co.getOperator(region.GetId()), IsNil)
 
 	// Transfer leader.
 	region = cluster.getRegion(2)
 	resp = co.dispatch(region)
-	checkTransferLeaderResp(c, resp, 4)
+	checkTransferLeaderResp(c, resp, 1)
 	region.Leader = resp.GetTransferLeader().GetPeer()
+	cluster.putRegion(region)
+	resp = co.dispatch(region)
+	checkRemovePeerResp(c, resp, 4)
+
+	tc.addLeaderRegion(2, 1, 2, 3)
+	region = cluster.getRegion(2)
 	c.Assert(co.dispatch(region), IsNil)
 	c.Assert(co.getOperator(region.GetId()), IsNil)
 
-	// Turn off normal balance.
-	clonecfg := *cfg
-	clonecfg.MinBalanceDiffRatio = 1
-	opt.store(&clonecfg)
-
 	// Test replica checker.
-	// Peer in store 4 is down.
-	tc.addLeaderRegion(4, 2, 3, 4)
-	tc.setStoreDown(4)
+	// Peer in store 3 is down.
+	tc.setStoreDown(3)
+	tc.addLeaderRegion(4, 1, 2, 3)
 	region = cluster.getRegion(4)
 	downPeer := &pdpb.PeerStats{
-		Peer:        region.GetStorePeer(4),
+		Peer:        region.GetStorePeer(3),
 		DownSeconds: proto.Uint64(24 * 60 * 60),
 	}
 	region.DownPeers = append(region.DownPeers, downPeer)
-
-	// Check ReplicaScheduleLimit.
-	opCount := uint64(co.getOperatorCount(storageKind))
-	clonecfg.ReplicaScheduleLimit = opCount
-	opt.store(&clonecfg)
-	c.Assert(co.dispatch(region), IsNil)
-	clonecfg.ReplicaScheduleLimit = opCount + 1
-	opt.store(&clonecfg)
-
-	// Remove peer in store 4.
 	resp = co.dispatch(region)
-	checkRemovePeerResp(c, resp, 4)
-	region.Peers = region.Peers[0 : len(region.Peers)-1]
+	checkRemovePeerResp(c, resp, 3)
+	region.RemoveStorePeer(3)
 	region.DownPeers = nil
-	c.Assert(co.dispatch(region), IsNil)
-
-	// Check ReplicaScheduleInterval.
+	cluster.putRegion(region)
 	resp = co.dispatch(region)
-	c.Assert(co.dispatch(region), IsNil)
-	clonecfg.ReplicaScheduleInterval.Duration = 0
-	opt.store(&clonecfg)
-
-	// Add new peer in store 1.
-	resp = co.dispatch(region)
-	checkAddPeerResp(c, resp, 1)
-	region.Peers = append(region.Peers, resp.GetChangePeer().GetPeer())
-	c.Assert(co.dispatch(region), IsNil)
+	checkAddPeerResp(c, resp, 4)
 }
 
 func (s *testCoordinatorSuite) TestPeerState(c *C) {
@@ -208,7 +191,9 @@ func (s *testCoordinatorSuite) TestAddScheduler(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
 
-	_, opt := newTestScheduleConfig()
+	cfg, opt := newTestScheduleConfig()
+	cfg.ReplicaScheduleLimit = 0
+
 	co := newCoordinator(cluster, opt)
 	co.run()
 	defer co.stop()
@@ -229,59 +214,50 @@ func (s *testCoordinatorSuite) TestAddScheduler(c *C) {
 	// Add regions 3 with leader in store 3 and followers in stores 1,2
 	tc.addLeaderRegion(3, 3, 1, 2)
 
-	gls := newGrantLeaderScheduler(1)
+	gls := newGrantLeaderScheduler(opt, 1)
 	c.Assert(co.removeScheduler(gls.GetName()), IsFalse)
-	c.Assert(co.addScheduler(newLeaderScheduleController(co, gls)), IsTrue)
+	c.Assert(co.addScheduler(gls), IsTrue)
 
 	// Transfer all leaders to store 1.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(time.Second)
 	region2 := cluster.getRegion(2)
 	checkTransferLeaderResp(c, co.dispatch(region2), 1)
 	region2.Leader = region2.GetStorePeer(1)
+	cluster.putRegion(region2)
 	c.Assert(co.dispatch(region2), IsNil)
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(time.Second)
 	region3 := cluster.getRegion(3)
 	checkTransferLeaderResp(c, co.dispatch(region3), 1)
 	region3.Leader = region3.GetStorePeer(1)
+	cluster.putRegion(region3)
 	c.Assert(co.dispatch(region3), IsNil)
 }
 
-var _ = Suite(&testControllerSuite{})
+var _ = Suite(&testScheduleLimiterSuite{})
 
-type testControllerSuite struct{}
+type testScheduleLimiterSuite struct{}
 
-func (s *testControllerSuite) Test(c *C) {
-	cluster := newClusterInfo(newMockIDAllocator())
-	cfg, opt := newTestScheduleConfig()
+func (s *testScheduleLimiterSuite) TestOperatorCount(c *C) {
+	l := newScheduleLimiter()
+	c.Assert(l.operatorCount(leaderKind), Equals, uint64(0))
+	c.Assert(l.operatorCount(regionKind), Equals, uint64(0))
 
-	cfg.LeaderScheduleLimit = 2
-	co := newCoordinator(cluster, opt)
-	s.test(c, co, newLeaderController(co), leaderKind)
+	leaderOP := newTestOperator(1, leaderKind)
+	l.addOperator(leaderOP)
+	c.Assert(l.operatorCount(leaderKind), Equals, uint64(1))
+	l.addOperator(leaderOP)
+	c.Assert(l.operatorCount(leaderKind), Equals, uint64(2))
+	l.removeOperator(leaderOP)
+	c.Assert(l.operatorCount(leaderKind), Equals, uint64(1))
 
-	cfg.StorageScheduleLimit = 2
-	co = newCoordinator(cluster, opt)
-	s.test(c, co, newStorageController(co), storageKind)
-}
-
-func (s *testControllerSuite) test(c *C, co *coordinator, ctrl Controller, kind ResourceKind) {
-	c.Assert(ctrl.AllowSchedule(), IsTrue)
-
-	co.addOperator(newTestOperator(1, kind))
-	c.Assert(ctrl.AllowSchedule(), IsTrue)
-
-	co.addOperator(newTestOperator(2, kind))
-	c.Assert(ctrl.AllowSchedule(), IsFalse)
-
-	co.wg.Add(1)
-	go func() {
-		select {
-		case <-ctrl.Ctx().Done():
-			co.wg.Done()
-		}
-	}()
-
-	co.stop()
+	regionOP := newTestOperator(1, regionKind)
+	l.addOperator(regionOP)
+	c.Assert(l.operatorCount(regionKind), Equals, uint64(1))
+	l.addOperator(regionOP)
+	c.Assert(l.operatorCount(regionKind), Equals, uint64(2))
+	l.removeOperator(regionOP)
+	c.Assert(l.operatorCount(regionKind), Equals, uint64(1))
 }
 
 func checkAddPeerResp(c *C, resp *pdpb.RegionHeartbeatResponse, storeID uint64) {
@@ -298,4 +274,9 @@ func checkRemovePeerResp(c *C, resp *pdpb.RegionHeartbeatResponse, storeID uint6
 
 func checkTransferLeaderResp(c *C, resp *pdpb.RegionHeartbeatResponse, storeID uint64) {
 	c.Assert(resp.GetTransferLeader().GetPeer().GetStoreId(), Equals, storeID)
+}
+
+func checkTransferPeerResp(c *C, resp *pdpb.RegionHeartbeatResponse, sourceID, targetID uint64) {
+	checkAddPeerResp(c, resp, targetID)
+	checkRemovePeerResp(c, resp, sourceID)
 }

--- a/server/event.go
+++ b/server/event.go
@@ -155,7 +155,7 @@ func (op *splitOperator) GetRegionID() uint64 {
 }
 
 func (op *splitOperator) GetResourceKind() ResourceKind {
-	return storageKind
+	return regionKind
 }
 
 // Do implements Operator.Do interface.

--- a/server/operator.go
+++ b/server/operator.go
@@ -130,7 +130,7 @@ func (op *changePeerOperator) GetRegionID() uint64 {
 }
 
 func (op *changePeerOperator) GetResourceKind() ResourceKind {
-	return storageKind
+	return regionKind
 }
 
 func (op *changePeerOperator) Do(region *regionInfo) (*pdpb.RegionHeartbeatResponse, bool) {

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -22,16 +22,18 @@ import (
 type Scheduler interface {
 	GetName() string
 	GetResourceKind() ResourceKind
+	GetResourceLimit() uint64
 	Schedule(cluster *clusterInfo) Operator
 }
 
 // grantLeaderScheduler transfers all leaders to peers in the store.
 type grantLeaderScheduler struct {
+	opt     *scheduleOption
 	StoreID uint64 `json:"store_id"`
 }
 
-func newGrantLeaderScheduler(storeID uint64) *grantLeaderScheduler {
-	return &grantLeaderScheduler{StoreID: storeID}
+func newGrantLeaderScheduler(opt *scheduleOption, storeID uint64) *grantLeaderScheduler {
+	return &grantLeaderScheduler{opt: opt, StoreID: storeID}
 }
 
 func (s *grantLeaderScheduler) GetName() string {
@@ -40,6 +42,10 @@ func (s *grantLeaderScheduler) GetName() string {
 
 func (s *grantLeaderScheduler) GetResourceKind() ResourceKind {
 	return leaderKind
+}
+
+func (s *grantLeaderScheduler) GetResourceLimit() uint64 {
+	return s.opt.GetLeaderScheduleLimit()
 }
 
 func (s *grantLeaderScheduler) Schedule(cluster *clusterInfo) Operator {
@@ -51,12 +57,14 @@ func (s *grantLeaderScheduler) Schedule(cluster *clusterInfo) Operator {
 }
 
 type shuffleLeaderScheduler struct {
+	opt      *scheduleOption
 	selector Selector
 	selected *metapb.Peer
 }
 
-func newShuffleLeaderScheduler() *shuffleLeaderScheduler {
+func newShuffleLeaderScheduler(opt *scheduleOption) *shuffleLeaderScheduler {
 	return &shuffleLeaderScheduler{
+		opt:      opt,
 		selector: newRandomSelector(),
 	}
 }
@@ -67,6 +75,10 @@ func (s *shuffleLeaderScheduler) GetName() string {
 
 func (s *shuffleLeaderScheduler) GetResourceKind() ResourceKind {
 	return leaderKind
+}
+
+func (s *shuffleLeaderScheduler) GetResourceLimit() uint64 {
+	return s.opt.GetLeaderScheduleLimit()
 }
 
 func (s *shuffleLeaderScheduler) Schedule(cluster *clusterInfo) Operator {

--- a/server/scheduler_test.go
+++ b/server/scheduler_test.go
@@ -19,11 +19,12 @@ var _ = Suite(&testShuffleLeaderSuite{})
 
 type testShuffleLeaderSuite struct{}
 
-func (s *testShuffleLeaderSuite) Test(c *C) {
+func (s *testShuffleLeaderSuite) TestShuffle(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
 
-	sl := newShuffleLeaderScheduler()
+	_, opt := newTestScheduleConfig()
+	sl := newShuffleLeaderScheduler(opt)
 	c.Assert(sl.Schedule(cluster), IsNil)
 
 	// Add stores 1,2,3,4

--- a/server/store.go
+++ b/server/store.go
@@ -26,7 +26,7 @@ type ResourceKind int
 
 const (
 	leaderKind ResourceKind = iota + 1
-	storageKind
+	regionKind
 )
 
 // storeInfo contains information about a store.
@@ -84,7 +84,7 @@ func (s *storeInfo) resourceRatio(kind ResourceKind) float64 {
 	switch kind {
 	case leaderKind:
 		return s.leaderRatio()
-	case storageKind:
+	case regionKind:
 		return s.storageRatio()
 	default:
 		return 0


### PR DESCRIPTION
Different schedulers may use different limits in the future, so we should let
the scheduler control its resource limit.