### PR TITLE
server: balance according to region count

### DIFF
--- a/_vendor/vendor/github.com/montanaflynn/stats/LICENSE
+++ b/_vendor/vendor/github.com/montanaflynn/stats/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2015 Montana Flynn (https://anonfunction.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/_vendor/vendor/github.com/montanaflynn/stats/correlation.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/correlation.go
@@ -1,0 +1,33 @@
+package stats
+
+import "math"
+
+// Correlation describes the degree of relationship between two sets of data
+func Correlation(data1, data2 Float64Data) (float64, error) {
+
+	l1 := data1.Len()
+	l2 := data2.Len()
+
+	if l1 == 0 || l2 == 0 {
+		return math.NaN(), EmptyInput
+	}
+
+	if l1 != l2 {
+		return math.NaN(), SizeErr
+	}
+
+	sdev1, _ := StandardDeviationPopulation(data1)
+	sdev2, _ := StandardDeviationPopulation(data2)
+
+	if sdev1 == 0 || sdev2 == 0 {
+		return 0, nil
+	}
+
+	covp, _ := CovariancePopulation(data1, data2)
+	return covp / (sdev1 * sdev2), nil
+}
+
+// Pearson calculates the Pearson product-moment correlation coefficient between two variables.
+func Pearson(data1, data2 Float64Data) (float64, error) {
+	return Correlation(data1, data2)
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/data.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/data.go
@@ -1,0 +1,140 @@
+package stats
+
+// Float64Data is a named type for []float64 with helper methods
+type Float64Data []float64
+
+// Get item in slice
+func (f Float64Data) Get(i int) float64 { return f[i] }
+
+// Len returns length of slice
+func (f Float64Data) Len() int { return len(f) }
+
+// Less returns if one number is less than another
+func (f Float64Data) Less(i, j int) bool { return f[i] < f[j] }
+
+// Swap switches out two numbers in slice
+func (f Float64Data) Swap(i, j int) { f[i], f[j] = f[j], f[i] }
+
+// Min returns the minimum number in the data
+func (f Float64Data) Min() (float64, error) { return Min(f) }
+
+// Max returns the maximum number in the data
+func (f Float64Data) Max() (float64, error) { return Max(f) }
+
+// Sum returns the total of all the numbers in the data
+func (f Float64Data) Sum() (float64, error) { return Sum(f) }
+
+// Mean returns the mean of the data
+func (f Float64Data) Mean() (float64, error) { return Mean(f) }
+
+// Median returns the median of the data
+func (f Float64Data) Median() (float64, error) { return Median(f) }
+
+// Mode returns the mode of the data
+func (f Float64Data) Mode() ([]float64, error) { return Mode(f) }
+
+// GeometricMean returns the median of the data
+func (f Float64Data) GeometricMean() (float64, error) { return GeometricMean(f) }
+
+// HarmonicMean returns the mode of the data
+func (f Float64Data) HarmonicMean() (float64, error) { return HarmonicMean(f) }
+
+// MedianAbsoluteDeviation the median of the absolute deviations from the dataset median
+func (f Float64Data) MedianAbsoluteDeviation() (float64, error) {
+	return MedianAbsoluteDeviation(f)
+}
+
+// MedianAbsoluteDeviationPopulation finds the median of the absolute deviations from the population median
+func (f Float64Data) MedianAbsoluteDeviationPopulation() (float64, error) {
+	return MedianAbsoluteDeviationPopulation(f)
+}
+
+// StandardDeviation the amount of variation in the dataset
+func (f Float64Data) StandardDeviation() (float64, error) {
+	return StandardDeviation(f)
+}
+
+// StandardDeviationPopulation finds the amount of variation from the population
+func (f Float64Data) StandardDeviationPopulation() (float64, error) {
+	return StandardDeviationPopulation(f)
+}
+
+// StandardDeviationSample finds the amount of variation from a sample
+func (f Float64Data) StandardDeviationSample() (float64, error) {
+	return StandardDeviationSample(f)
+}
+
+// QuartileOutliers finds the mild and extreme outliers
+func (f Float64Data) QuartileOutliers() (Outliers, error) {
+	return QuartileOutliers(f)
+}
+
+// Percentile finds the relative standing in a slice of floats
+func (f Float64Data) Percentile(p float64) (float64, error) {
+	return Percentile(f, p)
+}
+
+// PercentileNearestRank finds the relative standing using the Nearest Rank method
+func (f Float64Data) PercentileNearestRank(p float64) (float64, error) {
+	return PercentileNearestRank(f, p)
+}
+
+// Correlation describes the degree of relationship between two sets of data
+func (f Float64Data) Correlation(d Float64Data) (float64, error) {
+	return Correlation(f, d)
+}
+
+// Pearson calculates the Pearson product-moment correlation coefficient between two variables.
+func (f Float64Data) Pearson(d Float64Data) (float64, error) {
+	return Pearson(f, d)
+}
+
+// Quartile returns the three quartile points from a slice of data
+func (f Float64Data) Quartile(d Float64Data) (Quartiles, error) {
+	return Quartile(d)
+}
+
+// InterQuartileRange finds the range between Q1 and Q3
+func (f Float64Data) InterQuartileRange(d Float64Data) (float64, error) {
+	return InterQuartileRange(d)
+}
+
+// Midhinge finds the average of the first and third quartiles
+func (f Float64Data) Midhinge(d Float64Data) (float64, error) {
+	return Midhinge(d)
+}
+
+// Trimean finds the average of the median and the midhinge
+func (f Float64Data) Trimean(d Float64Data) (float64, error) {
+	return Trimean(d)
+}
+
+// Sample returns sample from input with replacement or without
+func (f Float64Data) Sample(n int, r bool) ([]float64, error) {
+	return Sample(f, n, r)
+}
+
+// Variance the amount of variation in the dataset
+func (f Float64Data) Variance() (float64, error) {
+	return Variance(f)
+}
+
+// PopulationVariance finds the amount of variance within a population
+func (f Float64Data) PopulationVariance() (float64, error) {
+	return PopulationVariance(f)
+}
+
+// SampleVariance finds the amount of variance within a sample
+func (f Float64Data) SampleVariance() (float64, error) {
+	return SampleVariance(f)
+}
+
+// Covariance is a measure of how much two sets of data change
+func (f Float64Data) Covariance(d Float64Data) (float64, error) {
+	return Covariance(f, d)
+}
+
+// CovariancePopulation computes covariance for entire population between two variables.
+func (f Float64Data) CovariancePopulation(d Float64Data) (float64, error) {
+	return CovariancePopulation(f, d)
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/deviation.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/deviation.go
@@ -1,0 +1,57 @@
+package stats
+
+import "math"
+
+// MedianAbsoluteDeviation finds the median of the absolute deviations from the dataset median
+func MedianAbsoluteDeviation(input Float64Data) (mad float64, err error) {
+	return MedianAbsoluteDeviationPopulation(input)
+}
+
+// MedianAbsoluteDeviationPopulation finds the median of the absolute deviations from the population median
+func MedianAbsoluteDeviationPopulation(input Float64Data) (mad float64, err error) {
+	if input.Len() == 0 {
+		return math.NaN(), EmptyInput
+	}
+
+	i := copyslice(input)
+	m, _ := Median(i)
+
+	for key, value := range i {
+		i[key] = math.Abs(value - m)
+	}
+
+	return Median(i)
+}
+
+// StandardDeviation the amount of variation in the dataset
+func StandardDeviation(input Float64Data) (sdev float64, err error) {
+	return StandardDeviationPopulation(input)
+}
+
+// StandardDeviationPopulation finds the amount of variation from the population
+func StandardDeviationPopulation(input Float64Data) (sdev float64, err error) {
+
+	if input.Len() == 0 {
+		return math.NaN(), EmptyInput
+	}
+
+	// Get the population variance
+	vp, _ := PopulationVariance(input)
+
+	// Return the population standard deviation
+	return math.Pow(vp, 0.5), nil
+}
+
+// StandardDeviationSample finds the amount of variation from a sample
+func StandardDeviationSample(input Float64Data) (sdev float64, err error) {
+
+	if input.Len() == 0 {
+		return math.NaN(), EmptyInput
+	}
+
+	// Get the sample variance
+	vs, _ := SampleVariance(input)
+
+	// Return the sample standard deviation
+	return math.Pow(vs, 0.5), nil
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/errors.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/errors.go
@@ -1,0 +1,21 @@
+package stats
+
+type statsErr struct {
+	err string
+}
+
+func (s statsErr) Error() string {
+	return s.err
+}
+
+// These are the package-wide error values.
+// All error identification should use these values.
+var (
+	EmptyInput  = statsErr{"Input must not be empty."}
+	SampleSize  = statsErr{"Samples number must be less than input length."}
+	NaNErr      = statsErr{"Not a number"}
+	NegativeErr = statsErr{"Slice must not contain negative values."}
+	ZeroErr     = statsErr{"Slice must not contain zero values."}
+	BoundsErr   = statsErr{"Input is outside of range."}
+	SizeErr     = statsErr{"Slices must be the same length."}
+)

--- a/_vendor/vendor/github.com/montanaflynn/stats/legacy.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/legacy.go
@@ -1,0 +1,36 @@
+package stats
+
+// VarP is a shortcut to PopulationVariance
+func VarP(input Float64Data) (sdev float64, err error) {
+	return PopulationVariance(input)
+}
+
+// VarS is a shortcut to SampleVariance
+func VarS(input Float64Data) (sdev float64, err error) {
+	return SampleVariance(input)
+}
+
+// StdDevP is a shortcut to StandardDeviationPopulation
+func StdDevP(input Float64Data) (sdev float64, err error) {
+	return StandardDeviationPopulation(input)
+}
+
+// StdDevS is a shortcut to StandardDeviationSample
+func StdDevS(input Float64Data) (sdev float64, err error) {
+	return StandardDeviationSample(input)
+}
+
+// LinReg is a shortcut to LinearRegression
+func LinReg(s []Coordinate) (regressions []Coordinate, err error) {
+	return LinearRegression(s)
+}
+
+// ExpReg is a shortcut to ExponentialRegression
+func ExpReg(s []Coordinate) (regressions []Coordinate, err error) {
+	return ExponentialRegression(s)
+}
+
+// LogReg is a shortcut to LogarithmicRegression
+func LogReg(s []Coordinate) (regressions []Coordinate, err error) {
+	return LogarithmicRegression(s)
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/load.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/load.go
@@ -1,0 +1,101 @@
+package stats
+
+import (
+	"strconv"
+	"time"
+)
+
+// LoadRawData parses and converts a slice of mixed data types to floats
+func LoadRawData(raw interface{}) (f Float64Data) {
+	var r []interface{}
+	var s Float64Data
+
+	switch t := raw.(type) {
+	case []interface{}:
+		r = t
+	case []uint:
+		for _, v := range t {
+			s = append(s, float64(v))
+		}
+		return s
+
+	case []bool:
+		for _, v := range t {
+			if v == true {
+				s = append(s, 1.0)
+			} else {
+				s = append(s, 0.0)
+			}
+		}
+		return s
+	case []float64:
+		return Float64Data(t)
+	case []int:
+		for _, v := range t {
+			s = append(s, float64(v))
+		}
+		return s
+	case []string:
+		for _, v := range t {
+			r = append(r, v)
+		}
+	case []time.Duration:
+		for _, v := range t {
+			r = append(r, v)
+		}
+	case map[int]int:
+		for i := 0; i < len(t); i++ {
+			s = append(s, float64(t[i]))
+		}
+		return s
+	case map[int]string:
+		for i := 0; i < len(t); i++ {
+			r = append(r, t[i])
+		}
+	case map[int]uint:
+		for i := 0; i < len(t); i++ {
+			s = append(s, float64(t[i]))
+		}
+		return s
+	case map[int]bool:
+		for i := 0; i < len(t); i++ {
+			if t[i] == true {
+				s = append(s, 1.0)
+			} else {
+				s = append(s, 0.0)
+			}
+		}
+		return s
+	case map[int]float64:
+		for i := 0; i < len(t); i++ {
+			s = append(s, t[i])
+		}
+		return s
+	}
+
+	for _, v := range r {
+		switch t := v.(type) {
+		case int:
+			a := float64(t)
+			f = append(f, a)
+		case uint:
+			f = append(f, float64(t))
+		case float64:
+			f = append(f, t)
+		case string:
+			fl, err := strconv.ParseFloat(t, 64)
+			if err == nil {
+				f = append(f, fl)
+			}
+		case bool:
+			if t == true {
+				f = append(f, 1.0)
+			} else {
+				f = append(f, 0.0)
+			}
+		case time.Duration:
+			f = append(f, float64(t))
+		}
+	}
+	return f
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/max.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/max.go
@@ -1,0 +1,24 @@
+package stats
+
+import "math"
+
+// Max finds the highest number in a slice
+func Max(input Float64Data) (max float64, err error) {
+
+	// Return an error if there are no numbers
+	if input.Len() == 0 {
+		return math.NaN(), EmptyInput
+	}
+
+	// Get the first value as the starting point
+	max = input.Get(0)
+
+	// Loop and replace higher values
+	for i := 1; i < input.Len(); i++ {
+		if input.Get(i) > max {
+			max = input.Get(i)
+		}
+	}
+
+	return max, nil
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/mean.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/mean.go
@@ -1,0 +1,60 @@
+package stats
+
+import "math"
+
+// Mean gets the average of a slice of numbers
+func Mean(input Float64Data) (float64, error) {
+
+	if input.Len() == 0 {
+		return math.NaN(), EmptyInput
+	}
+
+	sum, _ := input.Sum()
+
+	return sum / float64(input.Len()), nil
+}
+
+// GeometricMean gets the geometric mean for a slice of numbers
+func GeometricMean(input Float64Data) (float64, error) {
+
+	l := input.Len()
+	if l == 0 {
+		return math.NaN(), EmptyInput
+	}
+
+	// Get the product of all the numbers
+	var p float64
+	for _, n := range input {
+		if p == 0 {
+			p = n
+		} else {
+			p *= n
+		}
+	}
+
+	// Calculate the geometric mean
+	return math.Pow(p, 1/float64(l)), nil
+}
+
+// HarmonicMean gets the harmonic mean for a slice of numbers
+func HarmonicMean(input Float64Data) (float64, error) {
+
+	l := input.Len()
+	if l == 0 {
+		return math.NaN(), EmptyInput
+	}
+
+	// Get the sum of all the numbers reciprocals and return an
+	// error for values that cannot be included in harmonic mean
+	var p float64
+	for _, n := range input {
+		if n < 0 {
+			return math.NaN(), NegativeErr
+		} else if n == 0 {
+			return math.NaN(), ZeroErr
+		}
+		p += (1 / n)
+	}
+
+	return float64(l) / p, nil
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/median.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/median.go
@@ -1,0 +1,25 @@
+package stats
+
+import "math"
+
+// Median gets the median number in a slice of numbers
+func Median(input Float64Data) (median float64, err error) {
+
+	// Start by sorting a copy of the slice
+	c := sortedCopy(input)
+
+	// No math is needed if there are no numbers
+	// For even numbers we add the two middle numbers
+	// and divide by two using the mean function above
+	// For odd numbers we just use the middle number
+	l := len(c)
+	if l == 0 {
+		return math.NaN(), EmptyInput
+	} else if l%2 == 0 {
+		median, _ = Mean(c[l/2-1 : l/2+1])
+	} else {
+		median = float64(c[l/2])
+	}
+
+	return median, nil
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/min.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/min.go
@@ -1,0 +1,26 @@
+package stats
+
+import "math"
+
+// Min finds the lowest number in a set of data
+func Min(input Float64Data) (min float64, err error) {
+
+	// Get the count of numbers in the slice
+	l := input.Len()
+
+	// Return an error if there are no numbers
+	if l == 0 {
+		return math.NaN(), EmptyInput
+	}
+
+	// Get the first value as the starting point
+	min = input.Get(0)
+
+	// Iterate until done checking for a lower value
+	for i := 1; i < l; i++ {
+		if input.Get(i) < min {
+			min = input.Get(i)
+		}
+	}
+	return min, nil
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/mode.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/mode.go
@@ -1,0 +1,47 @@
+package stats
+
+// Mode gets the mode [most frequent value(s)] of a slice of float64s
+func Mode(input Float64Data) (mode []float64, err error) {
+	// Return the input if there's only one number
+	l := input.Len()
+	if l == 1 {
+		return input, nil
+	} else if l == 0 {
+		return nil, EmptyInput
+	}
+
+	c := sortedCopyDif(input)
+	// Traverse sorted array,
+	// tracking the longest repeating sequence
+	mode = make([]float64, 5)
+	cnt, maxCnt := 1, 1
+	for i := 1; i < l; i++ {
+		switch {
+		case c[i] == c[i-1]:
+			cnt++
+		case cnt == maxCnt && maxCnt != 1:
+			mode = append(mode, c[i-1])
+			cnt = 1
+		case cnt > maxCnt:
+			mode = append(mode[:0], c[i-1])
+			maxCnt, cnt = cnt, 1
+		default:
+			cnt = 1
+		}
+	}
+	switch {
+	case cnt == maxCnt:
+		mode = append(mode, c[l-1])
+	case cnt > maxCnt:
+		mode = append(mode[:0], c[l-1])
+		maxCnt = cnt
+	}
+
+	// Since length must be greater than 1,
+	// check for slices of distinct values
+	if maxCnt == 1 {
+		return Float64Data{}, nil
+	}
+
+	return mode, nil
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/outlier.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/outlier.go
@@ -1,0 +1,44 @@
+package stats
+
+// Outliers holds mild and extreme outliers found in data
+type Outliers struct {
+	Mild    Float64Data
+	Extreme Float64Data
+}
+
+// QuartileOutliers finds the mild and extreme outliers
+func QuartileOutliers(input Float64Data) (Outliers, error) {
+	if input.Len() == 0 {
+		return Outliers{}, EmptyInput
+	}
+
+	// Start by sorting a copy of the slice
+	copy := sortedCopy(input)
+
+	// Calculate the quartiles and interquartile range
+	qs, _ := Quartile(copy)
+	iqr, _ := InterQuartileRange(copy)
+
+	// Calculate the lower and upper inner and outer fences
+	lif := qs.Q1 - (1.5 * iqr)
+	uif := qs.Q3 + (1.5 * iqr)
+	lof := qs.Q1 - (3 * iqr)
+	uof := qs.Q3 + (3 * iqr)
+
+	// Find the data points that are outside of the
+	// inner and upper fences and add them to mild
+	// and extreme outlier slices
+	var mild Float64Data
+	var extreme Float64Data
+	for _, v := range copy {
+
+		if v < lof || v > uof {
+			extreme = append(extreme, v)
+		} else if v < lif || v > uif {
+			mild = append(mild, v)
+		}
+	}
+
+	// Wrap them into our struct
+	return Outliers{mild, extreme}, nil
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/percentile.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/percentile.go
@@ -1,0 +1,76 @@
+package stats
+
+import "math"
+
+// Percentile finds the relative standing in a slice of floats
+func Percentile(input Float64Data, percent float64) (percentile float64, err error) {
+
+	if input.Len() == 0 || percent == 0 {
+		return math.NaN(), EmptyInput
+	}
+
+	// Start by sorting a copy of the slice
+	c := sortedCopy(input)
+
+	// Multiply percent by length of input
+	index := (percent / 100) * float64(len(c))
+
+	// Check if the index is a whole number
+	if index == float64(int64(index)) {
+
+		// Convert float to int
+		i := float64ToInt(index)
+
+		// Find the average of the index and following values
+		percentile, _ = Mean(Float64Data{c[i-1], c[i]})
+
+	} else if index >= 1 {
+
+		// Convert float to int
+		i := float64ToInt(index)
+
+		// Find the value at the index
+		percentile = c[i-1]
+
+	} else {
+		return math.NaN(), BoundsErr
+	}
+
+	return percentile, nil
+
+}
+
+// PercentileNearestRank finds the relative standing in a slice of floats using the Nearest Rank method
+func PercentileNearestRank(input Float64Data, percent float64) (percentile float64, err error) {
+
+	// Find the length of items in the slice
+	il := input.Len()
+
+	// Return an error for empty slices
+	if il == 0 {
+		return math.NaN(), EmptyInput
+	}
+
+	// Return error for less than 0 or greater than 100 percentages
+	if percent < 0 || percent > 100 {
+		return math.NaN(), BoundsErr
+	}
+
+	// Start by sorting a copy of the slice
+	c := sortedCopy(input)
+
+	// Return the last item
+	if percent == 100.0 {
+		return c[il-1], nil
+	}
+
+	// Find ordinal ranking
+	or := int(math.Ceil(float64(il) * percent / 100))
+
+	// Return the item that is in the place of the ordinal rank
+	if or == 0 {
+		return c[0], nil
+	}
+	return c[or-1], nil
+
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/quartile.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/quartile.go
@@ -1,0 +1,74 @@
+package stats
+
+import "math"
+
+// Quartiles holds the three quartile points
+type Quartiles struct {
+	Q1 float64
+	Q2 float64
+	Q3 float64
+}
+
+// Quartile returns the three quartile points from a slice of data
+func Quartile(input Float64Data) (Quartiles, error) {
+
+	il := input.Len()
+	if il == 0 {
+		return Quartiles{}, EmptyInput
+	}
+
+	// Start by sorting a copy of the slice
+	copy := sortedCopy(input)
+
+	// Find the cutoff places depeding on if
+	// the input slice length is even or odd
+	var c1 int
+	var c2 int
+	if il%2 == 0 {
+		c1 = il / 2
+		c2 = il / 2
+	} else {
+		c1 = (il - 1) / 2
+		c2 = c1 + 1
+	}
+
+	// Find the Medians with the cutoff points
+	Q1, _ := Median(copy[:c1])
+	Q2, _ := Median(copy)
+	Q3, _ := Median(copy[c2:])
+
+	return Quartiles{Q1, Q2, Q3}, nil
+
+}
+
+// InterQuartileRange finds the range between Q1 and Q3
+func InterQuartileRange(input Float64Data) (float64, error) {
+	if input.Len() == 0 {
+		return math.NaN(), EmptyInput
+	}
+	qs, _ := Quartile(input)
+	iqr := qs.Q3 - qs.Q1
+	return iqr, nil
+}
+
+// Midhinge finds the average of the first and third quartiles
+func Midhinge(input Float64Data) (float64, error) {
+	if input.Len() == 0 {
+		return math.NaN(), EmptyInput
+	}
+	qs, _ := Quartile(input)
+	mh := (qs.Q1 + qs.Q3) / 2
+	return mh, nil
+}
+
+// Trimean finds the average of the median and the midhinge
+func Trimean(input Float64Data) (float64, error) {
+	if input.Len() == 0 {
+		return math.NaN(), EmptyInput
+	}
+
+	c := sortedCopy(input)
+	q, _ := Quartile(c)
+
+	return (q.Q1 + (q.Q2 * 2) + q.Q3) / 4, nil
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/regression.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/regression.go
@@ -1,0 +1,113 @@
+package stats
+
+import "math"
+
+// Series is a container for a series of data
+type Series []Coordinate
+
+// Coordinate holds the data in a series
+type Coordinate struct {
+	X, Y float64
+}
+
+// LinearRegression finds the least squares linear regression on data series
+func LinearRegression(s Series) (regressions Series, err error) {
+
+	if len(s) == 0 {
+		return nil, EmptyInput
+	}
+
+	// Placeholder for the math to be done
+	var sum [5]float64
+
+	// Loop over data keeping index in place
+	i := 0
+	for ; i < len(s); i++ {
+		sum[0] += s[i].X
+		sum[1] += s[i].Y
+		sum[2] += s[i].X * s[i].X
+		sum[3] += s[i].X * s[i].Y
+		sum[4] += s[i].Y * s[i].Y
+	}
+
+	// Find gradient and intercept
+	f := float64(i)
+	gradient := (f*sum[3] - sum[0]*sum[1]) / (f*sum[2] - sum[0]*sum[0])
+	intercept := (sum[1] / f) - (gradient * sum[0] / f)
+
+	// Create the new regression series
+	for j := 0; j < len(s); j++ {
+		regressions = append(regressions, Coordinate{
+			X: s[j].X,
+			Y: s[j].X*gradient + intercept,
+		})
+	}
+
+	return regressions, nil
+
+}
+
+// ExponentialRegression returns an exponential regression on data series
+func ExponentialRegression(s Series) (regressions Series, err error) {
+
+	if len(s) == 0 {
+		return nil, EmptyInput
+	}
+
+	var sum [6]float64
+
+	for i := 0; i < len(s); i++ {
+		sum[0] += s[i].X
+		sum[1] += s[i].Y
+		sum[2] += s[i].X * s[i].X * s[i].Y
+		sum[3] += s[i].Y * math.Log(s[i].Y)
+		sum[4] += s[i].X * s[i].Y * math.Log(s[i].Y)
+		sum[5] += s[i].X * s[i].Y
+	}
+
+	denominator := (sum[1]*sum[2] - sum[5]*sum[5])
+	a := math.Pow(math.E, (sum[2]*sum[3]-sum[5]*sum[4])/denominator)
+	b := (sum[1]*sum[4] - sum[5]*sum[3]) / denominator
+
+	for j := 0; j < len(s); j++ {
+		regressions = append(regressions, Coordinate{
+			X: s[j].X,
+			Y: a * math.Exp(b*s[j].X),
+		})
+	}
+
+	return regressions, nil
+
+}
+
+// LogarithmicRegression returns an logarithmic regression on data series
+func LogarithmicRegression(s Series) (regressions Series, err error) {
+
+	if len(s) == 0 {
+		return nil, EmptyInput
+	}
+
+	var sum [4]float64
+
+	i := 0
+	for ; i < len(s); i++ {
+		sum[0] += math.Log(s[i].X)
+		sum[1] += s[i].Y * math.Log(s[i].X)
+		sum[2] += s[i].Y
+		sum[3] += math.Pow(math.Log(s[i].X), 2)
+	}
+
+	f := float64(i)
+	a := (f*sum[1] - sum[2]*sum[0]) / (f*sum[3] - sum[0]*sum[0])
+	b := (sum[2] - a*sum[0]) / f
+
+	for j := 0; j < len(s); j++ {
+		regressions = append(regressions, Coordinate{
+			X: s[j].X,
+			Y: b + a*math.Log(s[j].X),
+		})
+	}
+
+	return regressions, nil
+
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/round.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/round.go
@@ -1,0 +1,38 @@
+package stats
+
+import "math"
+
+// Round a float to a specific decimal place or precision
+func Round(input float64, places int) (rounded float64, err error) {
+
+	// If the float is not a number
+	if math.IsNaN(input) {
+		return math.NaN(), NaNErr
+	}
+
+	// Find out the actual sign and correct the input for later
+	sign := 1.0
+	if input < 0 {
+		sign = -1
+		input *= -1
+	}
+
+	// Use the places arg to get the amount of precision wanted
+	precision := math.Pow(10, float64(places))
+
+	// Find the decimal place we are looking to round
+	digit := input * precision
+
+	// Get the actual decimal number as a fraction to be compared
+	_, decimal := math.Modf(digit)
+
+	// If the decimal is less than .5 we round down otherwise up
+	if decimal >= 0.5 {
+		rounded = math.Ceil(digit)
+	} else {
+		rounded = math.Floor(digit)
+	}
+
+	// Finally we do the math to actually create a rounded number
+	return rounded / precision * sign, nil
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/sample.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/sample.go
@@ -1,0 +1,44 @@
+package stats
+
+import "math/rand"
+
+// Sample returns sample from input with replacement or without
+func Sample(input Float64Data, takenum int, replacement bool) ([]float64, error) {
+
+	if input.Len() == 0 {
+		return nil, EmptyInput
+	}
+
+	length := input.Len()
+	if replacement {
+
+		result := Float64Data{}
+		rand.Seed(unixnano())
+
+		// In every step, randomly take the num for
+		for i := 0; i < takenum; i++ {
+			idx := rand.Intn(length)
+			result = append(result, input[idx])
+		}
+
+		return result, nil
+
+	} else if !replacement && takenum <= length {
+
+		rand.Seed(unixnano())
+
+		// Get permutation of number of indexies
+		perm := rand.Perm(length)
+		result := Float64Data{}
+
+		// Get element of input by permutated index
+		for _, idx := range perm[0:takenum] {
+			result = append(result, input[idx])
+		}
+
+		return result, nil
+
+	}
+
+	return nil, BoundsErr
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/sum.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/sum.go
@@ -1,0 +1,18 @@
+package stats
+
+import "math"
+
+// Sum adds all the numbers of a slice together
+func Sum(input Float64Data) (sum float64, err error) {
+
+	if input.Len() == 0 {
+		return math.NaN(), EmptyInput
+	}
+
+	// Add em up
+	for _, n := range input {
+		sum += n
+	}
+
+	return sum, nil
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/util.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/util.go
@@ -1,0 +1,43 @@
+package stats
+
+import (
+	"sort"
+	"time"
+)
+
+// float64ToInt rounds a float64 to an int
+func float64ToInt(input float64) (output int) {
+	r, _ := Round(input, 0)
+	return int(r)
+}
+
+// unixnano returns nanoseconds from UTC epoch
+func unixnano() int64 {
+	return time.Now().UTC().UnixNano()
+}
+
+// copyslice copies a slice of float64s
+func copyslice(input Float64Data) Float64Data {
+	s := make(Float64Data, input.Len())
+	copy(s, input)
+	return s
+}
+
+// sortedCopy returns a sorted copy of float64s
+func sortedCopy(input Float64Data) (copy Float64Data) {
+	copy = copyslice(input)
+	sort.Float64s(copy)
+	return
+}
+
+// sortedCopyDif returns a sorted copy of float64s
+// only if the original data isn't sorted.
+// Only use this if returned slice won't be manipulated!
+func sortedCopyDif(input Float64Data) (copy Float64Data) {
+	if sort.Float64sAreSorted(input) {
+		return input
+	}
+	copy = copyslice(input)
+	sort.Float64s(copy)
+	return
+}

--- a/_vendor/vendor/github.com/montanaflynn/stats/variance.go
+++ b/_vendor/vendor/github.com/montanaflynn/stats/variance.go
@@ -1,0 +1,105 @@
+package stats
+
+import "math"
+
+// _variance finds the variance for both population and sample data
+func _variance(input Float64Data, sample int) (variance float64, err error) {
+
+	if input.Len() == 0 {
+		return math.NaN(), EmptyInput
+	}
+
+	// Sum the square of the mean subtracted from each number
+	m, _ := Mean(input)
+
+	for _, n := range input {
+		variance += (float64(n) - m) * (float64(n) - m)
+	}
+
+	// When getting the mean of the squared differences
+	// "sample" will allow us to know if it's a sample
+	// or population and wether to subtract by one or not
+	return variance / float64((input.Len() - (1 * sample))), nil
+}
+
+// Variance the amount of variation in the dataset
+func Variance(input Float64Data) (sdev float64, err error) {
+	return PopulationVariance(input)
+}
+
+// PopulationVariance finds the amount of variance within a population
+func PopulationVariance(input Float64Data) (pvar float64, err error) {
+
+	v, err := _variance(input, 0)
+	if err != nil {
+		return math.NaN(), err
+	}
+
+	return v, nil
+}
+
+// SampleVariance finds the amount of variance within a sample
+func SampleVariance(input Float64Data) (svar float64, err error) {
+
+	v, err := _variance(input, 1)
+	if err != nil {
+		return math.NaN(), err
+	}
+
+	return v, nil
+}
+
+// Covariance is a measure of how much two sets of data change
+func Covariance(data1, data2 Float64Data) (float64, error) {
+
+	l1 := data1.Len()
+	l2 := data2.Len()
+
+	if l1 == 0 || l2 == 0 {
+		return math.NaN(), EmptyInput
+	}
+
+	if l1 != l2 {
+		return math.NaN(), SizeErr
+	}
+
+	m1, _ := Mean(data1)
+	m2, _ := Mean(data2)
+
+	// Calculate sum of squares
+	var ss float64
+	for i := 0; i < l1; i++ {
+		delta1 := (data1.Get(i) - m1)
+		delta2 := (data2.Get(i) - m2)
+		ss += (delta1*delta2 - ss) / float64(i+1)
+	}
+
+	return ss * float64(l1) / float64(l1-1), nil
+}
+
+// CovariancePopulation computes covariance for entire population between two variables.
+func CovariancePopulation(data1, data2 Float64Data) (float64, error) {
+
+	l1 := data1.Len()
+	l2 := data2.Len()
+
+	if l1 == 0 || l2 == 0 {
+		return math.NaN(), EmptyInput
+	}
+
+	if l1 != l2 {
+		return math.NaN(), SizeErr
+	}
+
+	m1, _ := Mean(data1)
+	m2, _ := Mean(data2)
+
+	var s float64
+	for i := 0; i < l1; i++ {
+		delta1 := (data1.Get(i) - m1)
+		delta2 := (data2.Get(i) - m2)
+		s += delta1 * delta2
+	}
+
+	return s / float64(l1), nil
+}

--- a/conf/config.toml
+++ b/conf/config.toml
@@ -25,15 +25,14 @@ interval = "15s"
 address = ""
 
 [schedule]
-min-region-count = 10
-min-leader-count = 10
+# Control the schedule behavior.
 max-snapshot-count = 3
-min-balance-diff-ratio = 0.01
-max-store-down-duration = "1h"
-schedule-interval = "5s"
-leader-schedule-limit = 16
-region-schedule-limit = 12
-replica-schedule-limit = 16
+max-store-down-time = "1h"
+# Control the schedule speed.
+schedule-interval = "1m"
+leader-schedule-limit = 1024
+region-schedule-limit = 16
+replica-schedule-limit = 24
 
 [replication]
 # The number of replicas for each region.

--- a/conf/config.toml
+++ b/conf/config.toml
@@ -27,7 +27,6 @@ address = ""
 [schedule]
 max-snapshot-count = 3
 max-store-down-time = "1h"
-max-schedule-interval = "1m"
 leader-schedule-limit = 1024
 region-schedule-limit = 16
 replica-schedule-limit = 24

--- a/conf/config.toml
+++ b/conf/config.toml
@@ -25,11 +25,9 @@ interval = "15s"
 address = ""
 
 [schedule]
-# Control the schedule behavior.
 max-snapshot-count = 3
 max-store-down-time = "1h"
-# Control the schedule speed.
-schedule-interval = "1m"
+max-schedule-interval = "1m"
 leader-schedule-limit = 1024
 region-schedule-limit = 16
 replica-schedule-limit = 24

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 76265ce7d49d84dd357a583a75fb5f23c3455d93c24185a90446ba1ed4851fda
-updated: 2017-02-15T17:25:46.565099361+08:00
+hash: 5fbab4a7af3b084e751f9c3277a99b8388f340c45f984e3381f9181bbe477bd6
+updated: 2017-02-20T18:44:54.617161934+08:00
 imports:
 - name: github.com/beorn7/perks
   version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
@@ -126,6 +126,8 @@ imports:
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
+- name: github.com/montanaflynn/stats
+  version: f8cd06f93c6c1b06028caafb88b540fc820f77c1
 - name: github.com/ngaut/deadline
   version: fae8f9dfd7048de16575b9d4c255278e38c28a4f
 - name: github.com/ngaut/log

--- a/glide.yaml
+++ b/glide.yaml
@@ -207,3 +207,5 @@ import:
 - package: github.com/elazarl/go-bindata-assetfs
 - package: github.com/ngaut/systimemon
   version: c2ca1c75c6af5556eb6ce67994120adf12f2ccef
+- package: github.com/montanaflynn/stats
+  version: f8cd06f93c6c1b06028caafb88b540fc820f77c1

--- a/server/api/config_test.go
+++ b/server/api/config_test.go
@@ -75,7 +75,7 @@ func (s *testConfigSuite) TestConfigSchedule(c *C) {
 		err = json.Unmarshal(buf, sc)
 		c.Assert(err, IsNil)
 
-		sc.MaxScheduleInterval.Duration = time.Second
+		sc.MaxStoreDownTime.Duration = time.Second
 		postData, err := json.Marshal(sc)
 		postURL := []string{cfgs[rand.Intn(len(cfgs))].ClientUrls, apiPrefix, "/api/v1/config"}
 		postAddr := mustUnixAddrToHTTPAddr(c, strings.Join(postURL, ""))

--- a/server/api/config_test.go
+++ b/server/api/config_test.go
@@ -20,6 +20,7 @@ import (
 	"math/rand"
 	"net/http"
 	"strings"
+	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/pd/server"
@@ -74,7 +75,7 @@ func (s *testConfigSuite) TestConfigSchedule(c *C) {
 		err = json.Unmarshal(buf, sc)
 		c.Assert(err, IsNil)
 
-		sc.MinRegionCount = 22
+		sc.ScheduleInterval.Duration = time.Second
 		postData, err := json.Marshal(sc)
 		postURL := []string{cfgs[rand.Intn(len(cfgs))].ClientUrls, apiPrefix, "/api/v1/config"}
 		postAddr := mustUnixAddrToHTTPAddr(c, strings.Join(postURL, ""))

--- a/server/api/config_test.go
+++ b/server/api/config_test.go
@@ -75,7 +75,7 @@ func (s *testConfigSuite) TestConfigSchedule(c *C) {
 		err = json.Unmarshal(buf, sc)
 		c.Assert(err, IsNil)
 
-		sc.ScheduleInterval.Duration = time.Second
+		sc.MaxScheduleInterval.Duration = time.Second
 		postData, err := json.Marshal(sc)
 		postURL := []string{cfgs[rand.Intn(len(cfgs))].ClientUrls, apiPrefix, "/api/v1/config"}
 		postAddr := mustUnixAddrToHTTPAddr(c, strings.Join(postURL, ""))

--- a/server/api/label.go
+++ b/server/api/label.go
@@ -84,7 +84,7 @@ func (h *labelsHandler) GetStores(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		storeInfo := newStoreInfo(store, status, cluster.GetScores(store, status))
+		storeInfo := newStoreInfo(store, status)
 		storesInfo.Stores = append(storesInfo.Stores, storeInfo)
 	}
 	storesInfo.Count = len(storesInfo.Stores)

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -26,7 +26,10 @@ var storeCacheInterval = 30 * time.Second
 // minBalanceDiff returns the minimal diff to do balance. The formula is based
 // on experience to let the diff increase alone with the count slowly.
 func minBalanceDiff(count uint64) float64 {
-	return math.Pow(2, math.Log10(float64(count)))
+	if count < 10 {
+		return float64(2)
+	}
+	return math.Sqrt(float64(count))
 }
 
 // adjustBalanceSpeed returns a schedule limit and whether we should balance.
@@ -41,7 +44,7 @@ func adjustBalanceSpeed(sourceCount uint64, sourceScore, targetScore float64) (u
 	}
 	diffRatio := 1 - targetScore/sourceScore
 	diffCount := diffRatio * float64(sourceCount)
-	return uint64(diffCount) / 4, diffCount > minBalanceDiff(sourceCount)
+	return uint64(diffCount) / 4, diffCount >= minBalanceDiff(sourceCount)
 }
 
 type balanceLeaderScheduler struct {

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -40,7 +40,7 @@ func minBalanceDiff(count uint64) float64 {
 // very frequently.
 func adjustBalanceSpeed(sourceCount uint64, sourceScore, targetScore float64) (uint64, bool) {
 	if targetScore >= sourceScore {
-		return 0, false
+		return 1, false
 	}
 	diffRatio := 1 - targetScore/sourceScore
 	diffCount := diffRatio * float64(sourceCount)

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -22,13 +22,17 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 )
 
-var storeCacheInterval = 30 * time.Second
+const (
+	storeCacheInterval    = 30 * time.Second
+	bootstrapBalanceCount = 10
+	bootstrapBalanceDiff  = 2
+)
 
 // minBalanceDiff returns the minimal diff to do balance. The formula is based
 // on experience to let the diff increase alone with the count slowly.
 func minBalanceDiff(count uint64) float64 {
-	if count < 10 {
-		return float64(2)
+	if count < bootstrapBalanceCount {
+		return bootstrapBalanceDiff
 	}
 	return math.Sqrt(float64(count))
 }

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -122,7 +122,6 @@ func (c *testClusterInfo) updateStorageRatio(storeID uint64, storageRatio float6
 func newTestScheduleConfig() (*ScheduleConfig, *scheduleOption) {
 	cfg := NewConfig()
 	cfg.adjust()
-	cfg.Schedule.MaxScheduleInterval.Duration = time.Nanosecond
 	opt := newScheduleOption(cfg)
 	return &cfg.Schedule, opt
 }
@@ -141,16 +140,16 @@ type testBalanceSpeedCase struct {
 func (s *testBalanceSpeedSuite) TestBalanceSpeed(c *C) {
 	testCases := []testBalanceSpeedCase{
 		// diff >= 2
-		{1, 0, 0, false},
-		{2, 0, 0, true},
-		{2, 1, 0, false},
+		{1, 0, 1, false},
+		{2, 0, 1, true},
+		{2, 1, 1, false},
 		{9, 0, 2, true},
-		{9, 6, 0, true},
-		{9, 8, 0, false},
+		{9, 6, 1, true},
+		{9, 8, 1, false},
 		// diff >= sqrt(10) = 3.16
 		{10, 0, 2, true},
 		{10, 6, 1, true},
-		{10, 7, 0, false},
+		{10, 7, 1, false},
 		// diff >= sqrt(100) = 10
 		{100, 89, 2, true},
 		{100, 91, 2, false},

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -58,25 +58,24 @@ func (c *testClusterInfo) setStoreBusy(storeID uint64, busy bool) {
 	c.putStore(store)
 }
 
-func (c *testClusterInfo) addLeaderStore(storeID uint64, leaderCount, regionCount int) {
+func (c *testClusterInfo) addLeaderStore(storeID uint64, leaderCount int) {
 	store := newStoreInfo(&metapb.Store{Id: storeID})
 	store.stats.LastHeartbeatTS = time.Now()
-	store.stats.TotalRegionCount = regionCount
-	store.stats.LeaderRegionCount = leaderCount
+	store.stats.LeaderCount = leaderCount
 	c.putStore(store)
 }
 
-func (c *testClusterInfo) addRegionStore(storeID uint64, regionCount int, storageRatio float64) {
+func (c *testClusterInfo) addRegionStore(storeID uint64, regionCount int) {
 	store := newStoreInfo(&metapb.Store{Id: storeID})
 	store.stats.LastHeartbeatTS = time.Now()
 	store.stats.RegionCount = uint32(regionCount)
-	store.stats.Capacity = 100
-	store.stats.Available = uint64((1 - storageRatio) * float64(store.stats.Capacity))
+	store.stats.Capacity = uint64(1024)
+	store.stats.Available = store.stats.Capacity
 	c.putStore(store)
 }
 
-func (c *testClusterInfo) addLabelsStore(storeID uint64, regionCount int, storageRatio float64, labels map[string]string) {
-	c.addRegionStore(storeID, regionCount, storageRatio)
+func (c *testClusterInfo) addLabelsStore(storeID uint64, regionCount int, labels map[string]string) {
+	c.addRegionStore(storeID, regionCount)
 	store := c.getStore(storeID)
 	for k, v := range labels {
 		store.Labels = append(store.Labels, &metapb.StoreLabel{Key: k, Value: v})
@@ -95,18 +94,15 @@ func (c *testClusterInfo) addLeaderRegion(regionID uint64, leaderID uint64, foll
 	c.putRegion(newRegionInfo(region, leader))
 }
 
-func (c *testClusterInfo) updateLeaderCount(storeID uint64, leaderCount, regionCount int) {
+func (c *testClusterInfo) updateLeaderCount(storeID uint64, leaderCount int) {
 	store := c.getStore(storeID)
-	store.stats.TotalRegionCount = regionCount
-	store.stats.LeaderRegionCount = leaderCount
+	store.stats.LeaderCount = leaderCount
 	c.putStore(store)
 }
 
-func (c *testClusterInfo) updateRegionCount(storeID uint64, regionCount int, storageRatio float64) {
+func (c *testClusterInfo) updateRegionCount(storeID uint64, regionCount int) {
 	store := c.getStore(storeID)
 	store.stats.RegionCount = uint32(regionCount)
-	store.stats.Capacity = 100
-	store.stats.Available = uint64((1 - storageRatio) * float64(store.stats.Capacity))
 	c.putStore(store)
 }
 
@@ -116,14 +112,72 @@ func (c *testClusterInfo) updateSnapshotCount(storeID uint64, snapshotCount int)
 	c.putStore(store)
 }
 
+func (c *testClusterInfo) updateStorageRatio(storeID uint64, storageRatio float64) {
+	store := c.getStore(storeID)
+	store.stats.Capacity = uint64(1024)
+	store.stats.Available = uint64(float64(store.stats.Capacity) * (1 - storageRatio))
+	c.putStore(store)
+}
+
 func newTestScheduleConfig() (*ScheduleConfig, *scheduleOption) {
 	cfg := NewConfig()
 	cfg.adjust()
-	cfg.Schedule.MinLeaderCount = 1
-	cfg.Schedule.MinRegionCount = 1
 	cfg.Schedule.ScheduleInterval.Duration = time.Nanosecond
 	opt := newScheduleOption(cfg)
 	return &cfg.Schedule, opt
+}
+
+var _ = Suite(&testBalanceSpeedSuite{})
+
+type testBalanceSpeedSuite struct{}
+
+type testBalanceSpeedCase struct {
+	sourceCount    uint64
+	targetCount    uint64
+	balanceLimit   uint64
+	expectedResult bool
+}
+
+func (s *testBalanceSpeedSuite) TestBalanceSpeed(c *C) {
+	testCases := []testBalanceSpeedCase{
+		// diff > 1
+		{1, 0, 0, false},
+		{2, 0, 0, true},
+		{4, 0, 1, true},
+		// diff > 2
+		{10, 0, 2, true},
+		{10, 6, 1, true},
+		{10, 7, 0, true},
+		{10, 9, 0, false},
+		// diff > 4
+		{100, 0, 25, true},
+		{100, 95, 1, true},
+		{100, 97, 0, false},
+		// diff > 8
+		{1000, 0, 250, true},
+		{1000, 991, 2, true},
+		{1000, 993, 1, false},
+		// diff > 16
+		{10000, 0, 2500, true},
+		{10000, 9983, 4, true},
+		{10000, 9985, 3, false},
+	}
+
+	s.testBalanceSpeed(c, testCases, 1)
+	s.testBalanceSpeed(c, testCases, 10)
+	s.testBalanceSpeed(c, testCases, 100)
+	s.testBalanceSpeed(c, testCases, 1000)
+}
+
+func (s *testBalanceSpeedSuite) testBalanceSpeed(c *C, tests []testBalanceSpeedCase, capaGB uint64) {
+	for _, t := range tests {
+		sourceCount := t.sourceCount
+		sourceRatio := float64(t.sourceCount) / float64(capaGB)
+		targetRatio := float64(t.targetCount) / float64(capaGB)
+		limit, ok := adjustBalanceSpeed(sourceCount, sourceRatio, targetRatio)
+		c.Assert(limit, Equals, t.balanceLimit)
+		c.Assert(ok, Equals, t.expectedResult)
+	}
 }
 
 var _ = Suite(&testBalanceLeaderSchedulerSuite{})
@@ -134,26 +188,35 @@ func (s *testBalanceLeaderSchedulerSuite) TestBalance(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
 
-	cfg, opt := newTestScheduleConfig()
+	_, opt := newTestScheduleConfig()
 	lb := newBalanceLeaderScheduler(opt)
 
-	cfg.MinLeaderCount = 10
-	cfg.MinBalanceDiffRatio = 0.1
+	// Add stores 1,2,3,4
+	tc.addLeaderStore(1, 1)
+	tc.addLeaderStore(2, 0)
+	tc.addLeaderStore(3, 0)
+	tc.addLeaderStore(4, 0)
+	// Add region 1 with leader in store 1 and followers in stores 2,3,4.
+	tc.addLeaderRegion(1, 1, 2, 3, 4)
+
+	// Test min balance diff (>1).
+	c.Check(lb.Schedule(cluster), IsNil)
+	// 2 - 0 > 1
+	tc.updateLeaderCount(1, 2)
+	c.Check(lb.Schedule(cluster), NotNil)
 
 	// Add stores 1,2,3,4
-	tc.addLeaderStore(1, 6, 30)
-	tc.addLeaderStore(2, 7, 30)
-	tc.addLeaderStore(3, 8, 30)
-	tc.addLeaderStore(4, 9, 30)
+	tc.addLeaderStore(1, 8)
+	tc.addLeaderStore(2, 9)
+	tc.addLeaderStore(3, 10)
+	tc.addLeaderStore(4, 10)
 	// Add region 1 with leader in store 4 and followers in stores 1,2,3.
 	tc.addLeaderRegion(1, 4, 1, 2, 3)
 
-	// Test leaderCountFilter.
-	// When leaderCount < 10, no schedule.
-	c.Assert(lb.Schedule(cluster), IsNil)
-	tc.updateLeaderCount(4, 12, 30)
-	// When leaderCount > 10, transfer leader
-	// from store 4 (with most leaders) to store 1 (with least leaders).
+	// Test min balance diff (>2).
+	c.Check(lb.Schedule(cluster), IsNil)
+	// 13 - 8 > 2
+	tc.addLeaderStore(4, 13)
 	checkTransferLeader(c, lb.Schedule(cluster), 4, 1)
 
 	// Test stateFilter.
@@ -161,52 +224,43 @@ func (s *testBalanceLeaderSchedulerSuite) TestBalance(c *C) {
 	// store 2 becomes the store with least leaders.
 	tc.setStoreDown(1)
 	checkTransferLeader(c, lb.Schedule(cluster), 4, 2)
+
+	// Test healthFilter.
 	// If store 2 is busy, it will be filtered,
 	// store 3 becomes the store with least leaders.
 	tc.setStoreBusy(2, true)
 	checkTransferLeader(c, lb.Schedule(cluster), 4, 3)
-
-	// Test MinBalanceDiffRatio.
-	// When diff leader ratio < MinBalanceDiffRatio, no schedule.
-	tc.updateLeaderCount(2, 10, 30)
-	tc.updateLeaderCount(3, 10, 30)
-	tc.updateLeaderCount(4, 12, 30)
-	c.Assert(lb.Schedule(cluster), IsNil)
 }
 
-var _ = Suite(&testBalanceStorageSchedulerSuite{})
+var _ = Suite(&testBalanceRegionSchedulerSuite{})
 
-type testBalanceStorageSchedulerSuite struct{}
+type testBalanceRegionSchedulerSuite struct{}
 
-func (s *testBalanceStorageSchedulerSuite) TestBalance(c *C) {
+func (s *testBalanceRegionSchedulerSuite) TestBalance(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
 
-	cfg, opt := newTestScheduleConfig()
-	sb := newBalanceStorageScheduler(opt)
+	_, opt := newTestScheduleConfig()
+	sb := newBalanceRegionScheduler(opt)
 
 	opt.SetMaxReplicas(1)
-	cfg.MinRegionCount = 10
-	cfg.MinBalanceDiffRatio = 0.1
 
 	// Add stores 1,2,3,4.
-	tc.addRegionStore(1, 6, 0.1)
-	tc.addRegionStore(2, 7, 0.2)
-	tc.addRegionStore(3, 8, 0.3)
-	tc.addRegionStore(4, 9, 0.4)
+	tc.addRegionStore(1, 8)
+	tc.addRegionStore(2, 9)
+	tc.addRegionStore(3, 10)
+	tc.addRegionStore(4, 11)
 	// Add region 1 with leader in store 4.
 	tc.addLeaderRegion(1, 4)
-
-	// Test regionCountFilter.
-	// When regionCount < 10, no schedule.
-	c.Assert(sb.Schedule(cluster), IsNil)
-	tc.updateRegionCount(4, 11, 0.4)
-	// When regionCount > 11, transfer peer
-	// from store 4 (with most regions) to store 1 (with least regions).
 	checkTransferPeer(c, sb.Schedule(cluster), 4, 1)
 
 	// Test stateFilter.
 	tc.setStoreOffline(1)
+	// Test min balance diff (>2).
+	c.Assert(sb.Schedule(cluster), IsNil)
+	// 12 - 9 > 2
+	tc.updateRegionCount(4, 12)
+	sb.cache.delete(4)
 	// When store 1 is offline, it will be filtered,
 	// store 2 becomes the store with least regions.
 	checkTransferPeer(c, sb.Schedule(cluster), 4, 2)
@@ -216,28 +270,21 @@ func (s *testBalanceStorageSchedulerSuite) TestBalance(c *C) {
 	c.Assert(sb.Schedule(cluster), IsNil)
 	opt.SetMaxReplicas(1)
 	c.Assert(sb.Schedule(cluster), NotNil)
-
-	// Test MinBalanceDiffRatio.
-	// When diff storage ratio < MinBalanceDiffRatio, no schedule.
-	tc.updateRegionCount(2, 6, 0.4)
-	tc.updateRegionCount(3, 7, 0.4)
-	tc.updateRegionCount(4, 8, 0.4)
-	c.Assert(sb.Schedule(cluster), IsNil)
 }
 
-func (s *testBalanceStorageSchedulerSuite) TestReplicas3(c *C) {
+func (s *testBalanceRegionSchedulerSuite) TestReplicas3(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
 
 	_, opt := newTestScheduleConfig()
 	opt.rep = newTestReplication(3, "zone", "rack", "host")
 
-	sb := newBalanceStorageScheduler(opt)
+	sb := newBalanceRegionScheduler(opt)
 
 	// Store 1 has the largest storage ratio, so the balancer try to replace peer in store 1.
-	tc.addLabelsStore(1, 1, 0.5, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
-	tc.addLabelsStore(2, 1, 0.4, map[string]string{"zone": "z1", "rack": "r2", "host": "h1"})
-	tc.addLabelsStore(3, 1, 0.3, map[string]string{"zone": "z1", "rack": "r2", "host": "h2"})
+	tc.addLabelsStore(1, 6, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(2, 5, map[string]string{"zone": "z1", "rack": "r2", "host": "h1"})
+	tc.addLabelsStore(3, 4, map[string]string{"zone": "z1", "rack": "r2", "host": "h2"})
 
 	tc.addLeaderRegion(1, 1, 2, 3)
 	// This schedule try to replace peer in store 1, but we have no other stores,
@@ -245,21 +292,21 @@ func (s *testBalanceStorageSchedulerSuite) TestReplicas3(c *C) {
 	c.Assert(sb.Schedule(cluster), IsNil)
 	c.Assert(sb.cache.get(1), IsTrue)
 
-	// Store 4 has smaller storage ratio than store 2.
-	tc.addLabelsStore(4, 1, 0.1, map[string]string{"zone": "z1", "rack": "r2", "host": "h1"})
+	// Store 4 has smaller region ratio than store 2.
+	tc.addLabelsStore(4, 2, map[string]string{"zone": "z1", "rack": "r2", "host": "h1"})
 	checkTransferPeer(c, sb.Schedule(cluster), 2, 4)
 
-	// Store 5 has smaller storage ratio than store 1.
-	tc.addLabelsStore(5, 1, 0.2, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	// Store 5 has smaller region ratio than store 1.
+	tc.addLabelsStore(5, 2, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
 	sb.cache.delete(1) // Delete store 1 from cache, or it will be skipped.
 	checkTransferPeer(c, sb.Schedule(cluster), 1, 5)
 
-	// Store 6 has smaller storage ratio than store 5.
-	tc.addLabelsStore(6, 1, 0.1, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	// Store 6 has smaller region ratio than store 5.
+	tc.addLabelsStore(6, 1, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
 	checkTransferPeer(c, sb.Schedule(cluster), 1, 6)
 
 	// Store 7 has the same storage ratio with store 6, but in a different host.
-	tc.addLabelsStore(7, 1, 0.2, map[string]string{"zone": "z1", "rack": "r1", "host": "h2"})
+	tc.addLabelsStore(7, 1, map[string]string{"zone": "z1", "rack": "r1", "host": "h2"})
 	checkTransferPeer(c, sb.Schedule(cluster), 1, 7)
 
 	// If store 7 is not available, we wait.
@@ -272,7 +319,7 @@ func (s *testBalanceStorageSchedulerSuite) TestReplicas3(c *C) {
 	checkTransferPeer(c, sb.Schedule(cluster), 1, 7)
 
 	// Store 8 has smaller storage ratio than store 7, but the distinct score decrease.
-	tc.addLabelsStore(8, 1, 0.1, map[string]string{"zone": "z1", "rack": "r2", "host": "h3"})
+	tc.addLabelsStore(8, 1, map[string]string{"zone": "z1", "rack": "r2", "host": "h3"})
 	checkTransferPeer(c, sb.Schedule(cluster), 1, 7)
 
 	// Take down 4,5,6,7
@@ -284,34 +331,34 @@ func (s *testBalanceStorageSchedulerSuite) TestReplicas3(c *C) {
 	c.Assert(sb.cache.get(1), IsTrue)
 	sb.cache.delete(1)
 
-	// Store 7 has different zone with other stores but larger storage ratio than store 1.
-	tc.addLabelsStore(9, 1, 0.6, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"})
+	// Store 9 has different zone with other stores but larger storage ratio than store 1.
+	tc.addLabelsStore(9, 9, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"})
 	c.Assert(sb.Schedule(cluster), IsNil)
 }
 
-func (s *testBalanceStorageSchedulerSuite) TestReplicas5(c *C) {
+func (s *testBalanceRegionSchedulerSuite) TestReplicas5(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
 
 	_, opt := newTestScheduleConfig()
 	opt.rep = newTestReplication(5, "zone", "rack", "host")
 
-	sb := newBalanceStorageScheduler(opt)
+	sb := newBalanceRegionScheduler(opt)
 
-	tc.addLabelsStore(1, 1, 0.1, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
-	tc.addLabelsStore(2, 1, 0.2, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"})
-	tc.addLabelsStore(3, 1, 0.3, map[string]string{"zone": "z3", "rack": "r1", "host": "h1"})
-	tc.addLabelsStore(4, 1, 0.4, map[string]string{"zone": "z4", "rack": "r1", "host": "h1"})
-	tc.addLabelsStore(5, 1, 0.5, map[string]string{"zone": "z5", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(1, 4, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(2, 5, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(3, 6, map[string]string{"zone": "z3", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(4, 7, map[string]string{"zone": "z4", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(5, 8, map[string]string{"zone": "z5", "rack": "r1", "host": "h1"})
 
 	tc.addLeaderRegion(1, 1, 2, 3, 4, 5)
 
 	// Store 6 has smaller ratio.
-	tc.addLabelsStore(6, 1, 0.3, map[string]string{"zone": "z5", "rack": "r2", "host": "h1"})
+	tc.addLabelsStore(6, 1, map[string]string{"zone": "z5", "rack": "r2", "host": "h1"})
 	checkTransferPeer(c, sb.Schedule(cluster), 5, 6)
 
 	// Store 7 has smaller ratio and higher score.
-	tc.addLabelsStore(7, 1, 0.4, map[string]string{"zone": "z6", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(7, 5, map[string]string{"zone": "z6", "rack": "r1", "host": "h1"})
 	checkTransferPeer(c, sb.Schedule(cluster), 5, 7)
 
 	// Store 1 has smaller ratio and higher score.
@@ -319,9 +366,9 @@ func (s *testBalanceStorageSchedulerSuite) TestReplicas5(c *C) {
 	checkTransferPeer(c, sb.Schedule(cluster), 5, 1)
 
 	// Store 6 has smaller ratio and higher score.
-	tc.addLabelsStore(11, 1, 0.9, map[string]string{"zone": "z1", "rack": "r2", "host": "h1"})
-	tc.addLabelsStore(12, 1, 0.8, map[string]string{"zone": "z2", "rack": "r2", "host": "h1"})
-	tc.addLabelsStore(13, 1, 0.7, map[string]string{"zone": "z3", "rack": "r2", "host": "h1"})
+	tc.addLabelsStore(11, 9, map[string]string{"zone": "z1", "rack": "r2", "host": "h1"})
+	tc.addLabelsStore(12, 8, map[string]string{"zone": "z2", "rack": "r2", "host": "h1"})
+	tc.addLabelsStore(13, 7, map[string]string{"zone": "z3", "rack": "r2", "host": "h1"})
 	tc.addLeaderRegion(1, 2, 3, 11, 12, 13)
 	checkTransferPeer(c, sb.Schedule(cluster), 11, 6)
 }
@@ -340,10 +387,10 @@ func (s *testReplicaCheckerSuite) TestBasic(c *C) {
 	cfg.MaxSnapshotCount = 2
 
 	// Add stores 1,2,3,4.
-	tc.addRegionStore(1, 4, 0.4)
-	tc.addRegionStore(2, 3, 0.3)
-	tc.addRegionStore(3, 2, 0.2)
-	tc.addRegionStore(4, 1, 0.1)
+	tc.addRegionStore(1, 4)
+	tc.addRegionStore(2, 3)
+	tc.addRegionStore(3, 2)
+	tc.addRegionStore(4, 1)
 	// Add region 1 with leader in store 1 and follower in store 2.
 	tc.addLeaderRegion(1, 1, 2)
 
@@ -367,11 +414,11 @@ func (s *testReplicaCheckerSuite) TestBasic(c *C) {
 	checkAddPeer(c, rc.Check(region), 4)
 
 	// Test storageThresholdFilter.
-	// If storage ratio > storageRatioThreshold, we add to store 3.
-	tc.addRegionStore(4, 1, 0.9)
+	// If storage ratio > storageRatioThreshold, we can not add peer.
+	tc.updateStorageRatio(4, 0.9)
 	checkAddPeer(c, rc.Check(region), 3)
 	// If storage ratio < storageRatioThreshold, we can add peer again.
-	tc.addRegionStore(4, 1, 0.1)
+	tc.updateStorageRatio(4, 0.7)
 	checkAddPeer(c, rc.Check(region), 4)
 
 	// Add peer in store 4, and we have enough replicas.
@@ -410,10 +457,10 @@ func (s *testReplicaCheckerSuite) TestOffline(c *C) {
 
 	rc := newReplicaChecker(opt, cluster)
 
-	tc.addLabelsStore(1, 1, 0.3, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
-	tc.addLabelsStore(2, 1, 0.4, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"})
-	tc.addLabelsStore(3, 1, 0.5, map[string]string{"zone": "z3", "rack": "r1", "host": "h1"})
-	tc.addLabelsStore(4, 1, 0.6, map[string]string{"zone": "z3", "rack": "r2", "host": "h1"})
+	tc.addLabelsStore(1, 1, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(2, 2, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(3, 3, map[string]string{"zone": "z3", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(4, 4, map[string]string{"zone": "z3", "rack": "r2", "host": "h1"})
 
 	tc.addLeaderRegion(1, 1)
 	region := cluster.getRegion(1)
@@ -423,12 +470,12 @@ func (s *testReplicaCheckerSuite) TestOffline(c *C) {
 	peer2, _ := cluster.allocPeer(2)
 	region.Peers = append(region.Peers, peer2)
 
-	// Store 3 has different zone and smallest storage ratio.
+	// Store 3 has different zone and smallest region ratio.
 	checkAddPeer(c, rc.Check(region), 3)
 	peer3, _ := cluster.allocPeer(3)
 	region.Peers = append(region.Peers, peer3)
 
-	// Store 4 has the same zone with store 3 and larger storage ratio.
+	// Store 4 has the same zone with store 3 and larger region ratio.
 	peer4, _ := cluster.allocPeer(4)
 	region.Peers = append(region.Peers, peer4)
 	checkRemovePeer(c, rc.Check(region), 4)
@@ -445,7 +492,7 @@ func (s *testReplicaCheckerSuite) TestOffline(c *C) {
 	checkTransferPeer(c, rc.Check(region), 3, 4)
 
 	// Store 5 has a different zone, we can keep it safe.
-	tc.addLabelsStore(5, 1, 0.7, map[string]string{"zone": "z4", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(5, 5, map[string]string{"zone": "z4", "rack": "r1", "host": "h1"})
 	checkTransferPeer(c, rc.Check(region), 3, 5)
 	tc.updateSnapshotCount(5, 10)
 	c.Assert(rc.Check(region), IsNil)
@@ -460,8 +507,8 @@ func (s *testReplicaCheckerSuite) TestDistinctScore(c *C) {
 
 	rc := newReplicaChecker(opt, cluster)
 
-	tc.addLabelsStore(1, 1, 0.5, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
-	tc.addLabelsStore(2, 1, 0.4, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(1, 9, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(2, 8, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
 
 	// We need 3 replicas.
 	tc.addLeaderRegion(1, 1)
@@ -471,23 +518,23 @@ func (s *testReplicaCheckerSuite) TestDistinctScore(c *C) {
 	region.Peers = append(region.Peers, peer2)
 
 	// Store 1,2,3 have the same zone, rack, and host.
-	tc.addLabelsStore(3, 1, 0.5, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(3, 5, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
 	checkAddPeer(c, rc.Check(region), 3)
 
-	// Store 4 has smaller storage ratio.
-	tc.addLabelsStore(4, 1, 0.4, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	// Store 4 has smaller region ratio.
+	tc.addLabelsStore(4, 4, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
 	checkAddPeer(c, rc.Check(region), 4)
 
 	// Store 5 has a different host.
-	tc.addLabelsStore(5, 1, 0.5, map[string]string{"zone": "z1", "rack": "r1", "host": "h2"})
+	tc.addLabelsStore(5, 5, map[string]string{"zone": "z1", "rack": "r1", "host": "h2"})
 	checkAddPeer(c, rc.Check(region), 5)
 
 	// Store 6 has a different rack.
-	tc.addLabelsStore(6, 1, 0.3, map[string]string{"zone": "z1", "rack": "r2", "host": "h1"})
+	tc.addLabelsStore(6, 6, map[string]string{"zone": "z1", "rack": "r2", "host": "h1"})
 	checkAddPeer(c, rc.Check(region), 6)
 
 	// Store 7 has a different zone.
-	tc.addLabelsStore(7, 1, 0.5, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(7, 7, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"})
 	checkAddPeer(c, rc.Check(region), 7)
 
 	// Test stateFilter.
@@ -511,17 +558,18 @@ func (s *testReplicaCheckerSuite) TestDistinctScore(c *C) {
 	// Store 8 has the same zone and different rack with store 7.
 	// Store 1 has the same zone and different rack with store 6.
 	// So store 8 and store 1 are equivalent.
-	tc.addLabelsStore(8, 1, 0.4, map[string]string{"zone": "z2", "rack": "r2", "host": "h1"})
+	tc.addLabelsStore(8, 1, map[string]string{"zone": "z2", "rack": "r2", "host": "h1"})
 	c.Assert(rc.Check(region), IsNil)
 
 	// Store 9 has a different zone, but it is almost full.
-	tc.addLabelsStore(9, 1, 0.9, map[string]string{"zone": "z3", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(9, 1, map[string]string{"zone": "z3", "rack": "r1", "host": "h1"})
+	tc.updateStorageRatio(9, 0.9)
 	c.Assert(rc.Check(region), IsNil)
 
 	// Store 10 has a different zone.
-	// Store 2 and 6 have the same distinct score, but store 2 has larger storage ratio.
+	// Store 2 and 6 have the same distinct score, but store 2 has larger region ratio.
 	// So replace peer in store 2 with store 10.
-	tc.addLabelsStore(10, 1, 0.5, map[string]string{"zone": "z3", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(10, 1, map[string]string{"zone": "z3", "rack": "r1", "host": "h1"})
 	checkTransferPeer(c, rc.Check(region), 2, 10)
 	peer10, _ := cluster.allocPeer(10)
 	region.Peers = append(region.Peers, peer10)
@@ -539,12 +587,12 @@ func (s *testReplicaCheckerSuite) TestDistinctScore2(c *C) {
 
 	rc := newReplicaChecker(opt, cluster)
 
-	tc.addLabelsStore(1, 1, 0.5, map[string]string{"zone": "z1", "host": "h1"})
-	tc.addLabelsStore(2, 1, 0.5, map[string]string{"zone": "z1", "host": "h2"})
-	tc.addLabelsStore(3, 1, 0.3, map[string]string{"zone": "z1", "host": "h3"})
-	tc.addLabelsStore(4, 1, 0.5, map[string]string{"zone": "z2", "host": "h1"})
-	tc.addLabelsStore(5, 1, 0.4, map[string]string{"zone": "z2", "host": "h2"})
-	tc.addLabelsStore(6, 1, 0.5, map[string]string{"zone": "z3", "host": "h1"})
+	tc.addLabelsStore(1, 1, map[string]string{"zone": "z1", "host": "h1"})
+	tc.addLabelsStore(2, 1, map[string]string{"zone": "z1", "host": "h2"})
+	tc.addLabelsStore(3, 1, map[string]string{"zone": "z1", "host": "h3"})
+	tc.addLabelsStore(4, 1, map[string]string{"zone": "z2", "host": "h1"})
+	tc.addLabelsStore(5, 1, map[string]string{"zone": "z2", "host": "h2"})
+	tc.addLabelsStore(6, 1, map[string]string{"zone": "z3", "host": "h1"})
 
 	tc.addLeaderRegion(1, 1, 2, 4)
 	region := cluster.getRegion(1)

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -61,7 +61,7 @@ func (c *testClusterInfo) setStoreBusy(storeID uint64, busy bool) {
 func (c *testClusterInfo) addLeaderStore(storeID uint64, leaderCount int) {
 	store := newStoreInfo(&metapb.Store{Id: storeID})
 	store.stats.LastHeartbeatTS = time.Now()
-	store.stats.LeaderCount = leaderCount
+	store.stats.LeaderCount = uint32(leaderCount)
 	c.putStore(store)
 }
 
@@ -96,7 +96,7 @@ func (c *testClusterInfo) addLeaderRegion(regionID uint64, leaderID uint64, foll
 
 func (c *testClusterInfo) updateLeaderCount(storeID uint64, leaderCount int) {
 	store := c.getStore(storeID)
-	store.stats.LeaderCount = leaderCount
+	store.stats.LeaderCount = uint32(leaderCount)
 	c.putStore(store)
 }
 

--- a/server/cache.go
+++ b/server/cache.go
@@ -495,9 +495,8 @@ func (c *clusterInfo) handleStoreHeartbeat(stats *pdpb.StoreStats) error {
 	}
 
 	store.stats.StoreStats = proto.Clone(stats).(*pdpb.StoreStats)
+	store.stats.LeaderCount = c.regions.getStoreLeaderCount(storeID)
 	store.stats.LastHeartbeatTS = time.Now()
-	store.stats.TotalRegionCount = c.regions.getRegionCount()
-	store.stats.LeaderRegionCount = c.regions.getStoreLeaderCount(storeID)
 
 	c.stores.setStore(store)
 	return nil

--- a/server/cache.go
+++ b/server/cache.go
@@ -495,7 +495,7 @@ func (c *clusterInfo) handleStoreHeartbeat(stats *pdpb.StoreStats) error {
 	}
 
 	store.stats.StoreStats = proto.Clone(stats).(*pdpb.StoreStats)
-	store.stats.LeaderCount = c.regions.getStoreLeaderCount(storeID)
+	store.stats.LeaderCount = uint32(c.regions.getStoreLeaderCount(storeID))
 	store.stats.LastHeartbeatTS = time.Now()
 
 	c.stores.setStore(store)

--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -279,13 +279,13 @@ func (s *testClusterInfoSuite) testStoreHeartbeat(c *C, cache *clusterInfo) {
 		c.Assert(cache.getStoreCount(), Equals, int(i+1))
 
 		stats := store.stats
-		c.Assert(stats.LeaderCount, Equals, 0)
+		c.Assert(stats.LeaderCount, Equals, uint32(0))
 		c.Assert(stats.LastHeartbeatTS.IsZero(), IsTrue)
 
 		c.Assert(cache.handleStoreHeartbeat(storeStats), IsNil)
 
 		stats = cache.getStore(store.GetId()).stats
-		c.Assert(stats.LeaderCount, Equals, 1)
+		c.Assert(stats.LeaderCount, Equals, uint32(1))
 		c.Assert(stats.LastHeartbeatTS.IsZero(), IsFalse)
 	}
 

--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -279,19 +279,14 @@ func (s *testClusterInfoSuite) testStoreHeartbeat(c *C, cache *clusterInfo) {
 		c.Assert(cache.getStoreCount(), Equals, int(i+1))
 
 		stats := store.stats
-		startTS := stats.StartTS
-		c.Assert(stats.StartTS.IsZero(), IsFalse)
+		c.Assert(stats.LeaderCount, Equals, 0)
 		c.Assert(stats.LastHeartbeatTS.IsZero(), IsTrue)
-		c.Assert(stats.TotalRegionCount, Equals, 0)
-		c.Assert(stats.LeaderRegionCount, Equals, 0)
 
 		c.Assert(cache.handleStoreHeartbeat(storeStats), IsNil)
 
 		stats = cache.getStore(store.GetId()).stats
-		c.Assert(stats.StartTS, Equals, startTS)
+		c.Assert(stats.LeaderCount, Equals, 1)
 		c.Assert(stats.LastHeartbeatTS.IsZero(), IsFalse)
-		c.Assert(stats.TotalRegionCount, Equals, int(n))
-		c.Assert(stats.LeaderRegionCount, Equals, 1)
 	}
 
 	c.Assert(cache.getStoreCount(), Equals, int(n))

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -465,7 +465,7 @@ func (c *RaftCluster) collectMetrics() {
 			minRegionScore = s.regionScore()
 		}
 		if maxRegionScore < s.regionScore() {
-			minRegionScore = s.regionScore()
+			maxRegionScore = s.regionScore()
 		}
 	}
 

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -455,10 +455,10 @@ func (c *RaftCluster) collectMetrics() {
 		storageCapacity += s.stats.GetCapacity()
 
 		// Balance score.
-		minLeaderScore = minFloat64(minLeaderScore, s.leaderScore())
-		maxLeaderScore = maxFloat64(maxLeaderScore, s.leaderScore())
-		minRegionScore = minFloat64(minRegionScore, s.regionScore())
-		maxRegionScore = maxFloat64(maxRegionScore, s.regionScore())
+		minLeaderScore = math.Min(minLeaderScore, s.leaderScore())
+		maxLeaderScore = math.Max(maxLeaderScore, s.leaderScore())
+		minRegionScore = math.Min(minRegionScore, s.regionScore())
+		maxRegionScore = math.Max(maxRegionScore, s.regionScore())
 	}
 
 	metrics := make(map[string]float64)

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -455,18 +455,10 @@ func (c *RaftCluster) collectMetrics() {
 		storageCapacity += s.stats.GetCapacity()
 
 		// Balance score.
-		if minLeaderScore > s.leaderScore() {
-			minLeaderScore = s.leaderScore()
-		}
-		if maxLeaderScore < s.leaderScore() {
-			maxLeaderScore = s.leaderScore()
-		}
-		if minRegionScore > s.regionScore() {
-			minRegionScore = s.regionScore()
-		}
-		if maxRegionScore < s.regionScore() {
-			maxRegionScore = s.regionScore()
-		}
+		minLeaderScore = minFloat64(minLeaderScore, s.leaderScore())
+		maxLeaderScore = maxFloat64(maxLeaderScore, s.leaderScore())
+		minRegionScore = minFloat64(minRegionScore, s.regionScore())
+		maxRegionScore = maxFloat64(maxRegionScore, s.regionScore())
 	}
 
 	metrics := make(map[string]float64)

--- a/server/config.go
+++ b/server/config.go
@@ -272,8 +272,6 @@ type ScheduleConfig struct {
 	// MaxStoreDownTime is the max duration after which
 	// a store will be considered to be down if it hasn't reported heartbeats.
 	MaxStoreDownTime typeutil.Duration `toml:"max-store-down-time" json:"max-store-down-time"`
-	// MaxScheduleInterval is the max interval to schedule.
-	MaxScheduleInterval typeutil.Duration `toml:"max-schedule-interval" json:"max-schedule-interval"`
 	// LeaderScheduleLimit is the max coexist leader schedules.
 	LeaderScheduleLimit uint64 `toml:"leader-schedule-limit" json:"leader-schedule-limit"`
 	// RegionScheduleLimit is the max coexist region schedules.
@@ -286,7 +284,6 @@ const (
 	defaultMaxReplicas          = 3
 	defaultMaxSnapshotCount     = 3
 	defaultMaxStoreDownTime     = time.Hour
-	defaultMaxScheduleInterval  = time.Minute
 	defaultLeaderScheduleLimit  = 16
 	defaultRegionScheduleLimit  = 12
 	defaultReplicaScheduleLimit = 16
@@ -295,7 +292,6 @@ const (
 func (c *ScheduleConfig) adjust() {
 	adjustUint64(&c.MaxSnapshotCount, defaultMaxSnapshotCount)
 	adjustDuration(&c.MaxStoreDownTime, defaultMaxStoreDownTime)
-	adjustDuration(&c.MaxScheduleInterval, defaultMaxScheduleInterval)
 	adjustUint64(&c.LeaderScheduleLimit, defaultLeaderScheduleLimit)
 	adjustUint64(&c.RegionScheduleLimit, defaultRegionScheduleLimit)
 	adjustUint64(&c.ReplicaScheduleLimit, defaultReplicaScheduleLimit)
@@ -356,10 +352,6 @@ func (o *scheduleOption) GetMaxSnapshotCount() uint64 {
 
 func (o *scheduleOption) GetMaxStoreDownTime() time.Duration {
 	return o.load().MaxStoreDownTime.Duration
-}
-
-func (o *scheduleOption) GetMaxScheduleInterval() time.Duration {
-	return o.load().MaxScheduleInterval.Duration
 }
 
 func (o *scheduleOption) GetLeaderScheduleLimit() uint64 {

--- a/server/config.go
+++ b/server/config.go
@@ -272,8 +272,8 @@ type ScheduleConfig struct {
 	// MaxStoreDownTime is the max duration after which
 	// a store will be considered to be down if it hasn't reported heartbeats.
 	MaxStoreDownTime typeutil.Duration `toml:"max-store-down-time" json:"max-store-down-time"`
-	// ScheduleInterval is the interval to schedule.
-	ScheduleInterval typeutil.Duration `toml:"schedule-interval" json:"schedule-interval"`
+	// MaxScheduleInterval is the max interval to schedule.
+	MaxScheduleInterval typeutil.Duration `toml:"max-schedule-interval" json:"max-schedule-interval"`
 	// LeaderScheduleLimit is the max coexist leader schedules.
 	LeaderScheduleLimit uint64 `toml:"leader-schedule-limit" json:"leader-schedule-limit"`
 	// RegionScheduleLimit is the max coexist region schedules.
@@ -286,7 +286,7 @@ const (
 	defaultMaxReplicas          = 3
 	defaultMaxSnapshotCount     = 3
 	defaultMaxStoreDownTime     = time.Hour
-	defaultScheduleInterval     = time.Minute
+	defaultMaxScheduleInterval  = time.Minute
 	defaultLeaderScheduleLimit  = 16
 	defaultRegionScheduleLimit  = 12
 	defaultReplicaScheduleLimit = 16
@@ -295,7 +295,7 @@ const (
 func (c *ScheduleConfig) adjust() {
 	adjustUint64(&c.MaxSnapshotCount, defaultMaxSnapshotCount)
 	adjustDuration(&c.MaxStoreDownTime, defaultMaxStoreDownTime)
-	adjustDuration(&c.ScheduleInterval, defaultScheduleInterval)
+	adjustDuration(&c.MaxScheduleInterval, defaultMaxScheduleInterval)
 	adjustUint64(&c.LeaderScheduleLimit, defaultLeaderScheduleLimit)
 	adjustUint64(&c.RegionScheduleLimit, defaultRegionScheduleLimit)
 	adjustUint64(&c.ReplicaScheduleLimit, defaultReplicaScheduleLimit)
@@ -358,8 +358,8 @@ func (o *scheduleOption) GetMaxStoreDownTime() time.Duration {
 	return o.load().MaxStoreDownTime.Duration
 }
 
-func (o *scheduleOption) GetScheduleInterval() time.Duration {
-	return o.load().ScheduleInterval.Duration
+func (o *scheduleOption) GetMaxScheduleInterval() time.Duration {
+	return o.load().MaxScheduleInterval.Duration
 }
 
 func (o *scheduleOption) GetLeaderScheduleLimit() uint64 {

--- a/server/config.go
+++ b/server/config.go
@@ -266,26 +266,12 @@ func (c *Config) configFromFile(path string) error {
 
 // ScheduleConfig is the schedule configuration.
 type ScheduleConfig struct {
-	// If the region count of one store is less than this value,
-	// it will never be used as a source store.
-	MinRegionCount uint64 `toml:"min-region-count" json:"min-region-count"`
-
-	// If the leader count of one store is less than this value,
-	// it will never be used as a source store.
-	MinLeaderCount uint64 `toml:"min-leader-count" json:"min-leader-count"`
-
 	// If the snapshot count of one store is greater than this value,
 	// it will never be used as a source or target store.
 	MaxSnapshotCount uint64 `toml:"max-snapshot-count" json:"max-snapshot-count"`
-
-	// If the source and target store's diff score is less than this value,
-	// the schedule will be canceled.
-	MinBalanceDiffRatio float64 `toml:"min-balance-diff-ratio" json:"min-balance-diff-ratio"`
-
-	// MaxStoreDownDuration is the max duration at which
+	// MaxStoreDownTime is the max duration after which
 	// a store will be considered to be down if it hasn't reported heartbeats.
-	MaxStoreDownDuration typeutil.Duration `toml:"max-store-down-duration" json:"max-store-down-duration"`
-
+	MaxStoreDownTime typeutil.Duration `toml:"max-store-down-time" json:"max-store-down-time"`
 	// ScheduleInterval is the interval to schedule.
 	ScheduleInterval typeutil.Duration `toml:"schedule-interval" json:"schedule-interval"`
 	// LeaderScheduleLimit is the max coexist leader schedules.
@@ -297,12 +283,9 @@ type ScheduleConfig struct {
 }
 
 const (
-	defaultMaxReplicas          = uint64(3)
-	defaultMinRegionCount       = uint64(10)
-	defaultMinLeaderCount       = uint64(10)
-	defaultMaxSnapshotCount     = uint64(3)
-	defaultMinBalanceDiffRatio  = float64(0.01)
-	defaultMaxStoreDownDuration = time.Hour
+	defaultMaxReplicas          = 3
+	defaultMaxSnapshotCount     = 3
+	defaultMaxStoreDownTime     = time.Hour
 	defaultScheduleInterval     = time.Minute
 	defaultLeaderScheduleLimit  = 16
 	defaultRegionScheduleLimit  = 12
@@ -310,11 +293,8 @@ const (
 )
 
 func (c *ScheduleConfig) adjust() {
-	adjustUint64(&c.MinRegionCount, defaultMinRegionCount)
-	adjustUint64(&c.MinLeaderCount, defaultMinLeaderCount)
 	adjustUint64(&c.MaxSnapshotCount, defaultMaxSnapshotCount)
-	adjustFloat64(&c.MinBalanceDiffRatio, defaultMinBalanceDiffRatio)
-	adjustDuration(&c.MaxStoreDownDuration, defaultMaxStoreDownDuration)
+	adjustDuration(&c.MaxStoreDownTime, defaultMaxStoreDownTime)
 	adjustDuration(&c.ScheduleInterval, defaultScheduleInterval)
 	adjustUint64(&c.LeaderScheduleLimit, defaultLeaderScheduleLimit)
 	adjustUint64(&c.RegionScheduleLimit, defaultRegionScheduleLimit)
@@ -370,24 +350,12 @@ func (o *scheduleOption) SetMaxReplicas(replicas int) {
 	o.rep.cfg.MaxReplicas = uint64(replicas)
 }
 
-func (o *scheduleOption) GetMinRegionCount() uint64 {
-	return o.load().MinRegionCount
-}
-
-func (o *scheduleOption) GetMinLeaderCount() uint64 {
-	return o.load().MinLeaderCount
-}
-
 func (o *scheduleOption) GetMaxSnapshotCount() uint64 {
 	return o.load().MaxSnapshotCount
 }
 
-func (o *scheduleOption) GetMinBalanceDiffRatio() float64 {
-	return o.load().MinBalanceDiffRatio
-}
-
 func (o *scheduleOption) GetMaxStoreDownTime() time.Duration {
-	return o.load().MaxStoreDownDuration.Duration
+	return o.load().MaxStoreDownTime.Duration
 }
 
 func (o *scheduleOption) GetScheduleInterval() time.Duration {

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -94,7 +94,7 @@ func (c *coordinator) dispatch(region *regionInfo) *pdpb.RegionHeartbeatResponse
 
 func (c *coordinator) run() {
 	c.addScheduler(newBalanceLeaderScheduler(c.opt))
-	c.addScheduler(newBalanceStorageScheduler(c.opt))
+	c.addScheduler(newBalanceRegionScheduler(c.opt))
 }
 
 func (c *coordinator) stop() {

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -27,6 +27,7 @@ const (
 	historiesCacheSize  = 1000
 	eventsCacheSize     = 1000
 	maxScheduleRetries  = 10
+	maxScheduleInterval = time.Minute
 	minScheduleInterval = time.Millisecond * 10
 )
 
@@ -306,10 +307,7 @@ func (s *scheduleController) Schedule(cluster *clusterInfo) Operator {
 	}
 
 	// If we have no schedule, increase the interval exponentially.
-	s.interval *= 2
-	if s.interval > s.opt.GetMaxScheduleInterval() {
-		s.interval = s.opt.GetMaxScheduleInterval()
-	}
+	s.interval = minDuration(s.interval*2, maxScheduleInterval)
 	return nil
 }
 

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -24,9 +24,10 @@ import (
 )
 
 const (
-	historiesCacheSize = 1000
-	eventsCacheSize    = 1000
-	maxScheduleRetries = 10
+	historiesCacheSize  = 1000
+	eventsCacheSize     = 1000
+	maxScheduleRetries  = 10
+	minScheduleInterval = time.Millisecond * 10
 )
 
 var (
@@ -270,10 +271,11 @@ func (l *scheduleLimiter) operatorCount(kind ResourceKind) uint64 {
 
 type scheduleController struct {
 	Scheduler
-	opt     *scheduleOption
-	limiter *scheduleLimiter
-	ctx     context.Context
-	cancel  context.CancelFunc
+	opt      *scheduleOption
+	limiter  *scheduleLimiter
+	interval time.Duration
+	ctx      context.Context
+	cancel   context.CancelFunc
 }
 
 func newScheduleController(c *coordinator, s Scheduler) *scheduleController {
@@ -282,6 +284,7 @@ func newScheduleController(c *coordinator, s Scheduler) *scheduleController {
 		Scheduler: s,
 		opt:       c.opt,
 		limiter:   c.limiter,
+		interval:  minScheduleInterval,
 		ctx:       ctx,
 		cancel:    cancel,
 	}
@@ -295,13 +298,23 @@ func (s *scheduleController) Stop() {
 	s.cancel()
 }
 
-func (s *scheduleController) GetInterval() time.Duration {
-	limit := s.GetResourceLimit()
-	interval := s.opt.GetScheduleInterval()
-	if limit == 0 {
-		return interval
+func (s *scheduleController) Schedule(cluster *clusterInfo) Operator {
+	// If we have schedule, reset interval to the minimal interval.
+	if op := s.Scheduler.Schedule(cluster); op != nil {
+		s.interval = minScheduleInterval
+		return op
 	}
-	return time.Duration(uint64(interval.Nanoseconds())/limit) * time.Nanosecond
+
+	// If we have no schedule, increase the interval exponentially.
+	s.interval *= 2
+	if s.interval > s.opt.GetMaxScheduleInterval() {
+		s.interval = s.opt.GetMaxScheduleInterval()
+	}
+	return nil
+}
+
+func (s *scheduleController) GetInterval() time.Duration {
+	return s.interval
 }
 
 func (s *scheduleController) AllowSchedule() bool {

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -301,11 +301,9 @@ func (s *scheduleController) Stop() {
 
 func (s *scheduleController) Schedule(cluster *clusterInfo) Operator {
 	// If we have schedule, reset interval to the minimal interval.
-	for i := 0; i < maxScheduleRetries; i++ {
-		if op := s.Scheduler.Schedule(cluster); op != nil {
-			s.interval = minScheduleInterval
-			return op
-		}
+	if op := s.Scheduler.Schedule(cluster); op != nil {
+		s.interval = minScheduleInterval
+		return op
 	}
 
 	// If we have no schedule, increase the interval exponentially.

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -301,9 +301,11 @@ func (s *scheduleController) Stop() {
 
 func (s *scheduleController) Schedule(cluster *clusterInfo) Operator {
 	// If we have schedule, reset interval to the minimal interval.
-	if op := s.Scheduler.Schedule(cluster); op != nil {
-		s.interval = minScheduleInterval
-		return op
+	for i := 0; i < maxScheduleRetries; i++ {
+		if op := s.Scheduler.Schedule(cluster); op != nil {
+			s.interval = minScheduleInterval
+			return op
+		}
 	}
 
 	// If we have no schedule, increase the interval exponentially.

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -84,10 +84,10 @@ func (s *testCoordinatorSuite) TestDispatch(c *C) {
 	tc.addLeaderRegion(1, 2, 3, 4)
 
 	// Transfer leader from store 4 to store 2.
-	tc.updateLeaderCount(4, 4, 10)
-	tc.updateLeaderCount(3, 3, 10)
-	tc.updateLeaderCount(2, 2, 10)
-	tc.updateLeaderCount(1, 1, 10)
+	tc.updateLeaderCount(4, 4)
+	tc.updateLeaderCount(3, 3)
+	tc.updateLeaderCount(2, 2)
+	tc.updateLeaderCount(1, 1)
 	tc.addLeaderRegion(2, 4, 3, 2)
 
 	// Wait for schedule and turn off balance.
@@ -131,10 +131,10 @@ func (s *testCoordinatorSuite) TestReplica(c *C) {
 	co.run()
 	defer co.stop()
 
-	tc.addRegionStore(1, 1, 0.1)
-	tc.addRegionStore(2, 2, 0.2)
-	tc.addRegionStore(3, 3, 0.3)
-	tc.addRegionStore(4, 4, 0.4)
+	tc.addRegionStore(1, 1)
+	tc.addRegionStore(2, 2)
+	tc.addRegionStore(3, 3)
+	tc.addRegionStore(4, 4)
 
 	// Add peer to store 1.
 	tc.addLeaderRegion(1, 2, 3)
@@ -224,8 +224,8 @@ func (s *testCoordinatorSuite) TestAddScheduler(c *C) {
 	defer co.stop()
 
 	c.Assert(co.schedulers, HasLen, 2)
-	c.Assert(co.removeScheduler("balance-leader-scheduler"), IsTrue)
-	c.Assert(co.removeScheduler("balance-region-scheduler"), IsTrue)
+	c.Assert(co.removeScheduler("balance-leader-scheduler"), IsNil)
+	c.Assert(co.removeScheduler("balance-region-scheduler"), IsNil)
 	c.Assert(co.schedulers, HasLen, 0)
 
 	// Add stores 1,2,3
@@ -297,12 +297,12 @@ func (s *testScheduleControllerSuite) TestController(c *C) {
 	cfg, opt := newTestScheduleConfig()
 	cfg.ScheduleInterval.Duration = time.Minute
 	co := newCoordinator(cluster, opt)
-	sc := newScheduleController(co, newBalanceLeaderScheduler(opt))
+	lb := newBalanceLeaderScheduler(opt)
+	sc := newScheduleController(co, lb)
 
-	cfg.LeaderScheduleLimit = 0
+	lb.limit = 0
 	c.Assert(sc.GetInterval(), Equals, time.Minute)
-
-	cfg.LeaderScheduleLimit = 2
+	lb.limit = 2
 	c.Assert(sc.GetInterval(), Equals, time.Second*30)
 
 	// limit = 2

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -77,10 +77,10 @@ func (s *testCoordinatorSuite) TestDispatch(c *C) {
 	defer co.stop()
 
 	// Transfer peer from store 4 to store 1.
-	tc.addRegionStore(4, 4, 0.4)
-	tc.addRegionStore(3, 3, 0.3)
-	tc.addRegionStore(2, 2, 0.2)
-	tc.addRegionStore(1, 1, 0.1)
+	tc.addRegionStore(4, 4)
+	tc.addRegionStore(3, 3)
+	tc.addRegionStore(2, 2)
+	tc.addRegionStore(1, 1)
 	tc.addLeaderRegion(1, 2, 3, 4)
 
 	// Transfer leader from store 4 to store 2.
@@ -93,7 +93,7 @@ func (s *testCoordinatorSuite) TestDispatch(c *C) {
 	// Wait for schedule and turn off balance.
 	time.Sleep(time.Second)
 	c.Assert(co.removeScheduler("balance-leader-scheduler"), IsNil)
-	c.Assert(co.removeScheduler("balance-storage-scheduler"), IsNil)
+	c.Assert(co.removeScheduler("balance-region-scheduler"), IsNil)
 	checkTransferPeer(c, co.getOperator(1), 4, 1)
 	checkTransferLeader(c, co.getOperator(2), 4, 2)
 
@@ -179,10 +179,10 @@ func (s *testCoordinatorSuite) TestPeerState(c *C) {
 	defer co.stop()
 
 	// Transfer peer from store 4 to store 1.
-	tc.addRegionStore(4, 4, 0.4)
-	tc.addRegionStore(3, 3, 0.3)
-	tc.addRegionStore(2, 2, 0.2)
-	tc.addRegionStore(1, 1, 0.1)
+	tc.addRegionStore(1, 1)
+	tc.addRegionStore(2, 2)
+	tc.addRegionStore(3, 3)
+	tc.addRegionStore(4, 4)
 	tc.addLeaderRegion(1, 2, 3, 4)
 
 	// Wait for schedule.
@@ -224,14 +224,14 @@ func (s *testCoordinatorSuite) TestAddScheduler(c *C) {
 	defer co.stop()
 
 	c.Assert(co.schedulers, HasLen, 2)
-	c.Assert(co.removeScheduler("balance-leader-scheduler"), IsNil)
-	c.Assert(co.removeScheduler("balance-storage-scheduler"), IsNil)
+	c.Assert(co.removeScheduler("balance-leader-scheduler"), IsTrue)
+	c.Assert(co.removeScheduler("balance-region-scheduler"), IsTrue)
 	c.Assert(co.schedulers, HasLen, 0)
 
 	// Add stores 1,2,3
-	tc.addLeaderStore(1, 1, 1)
-	tc.addLeaderStore(2, 1, 1)
-	tc.addLeaderStore(3, 1, 1)
+	tc.addLeaderStore(1, 1)
+	tc.addLeaderStore(2, 1)
+	tc.addLeaderStore(3, 1)
 	// Add regions 1 with leader in store 1 and followers in stores 2,3
 	tc.addLeaderRegion(1, 1, 2, 3)
 	// Add regions 2 with leader in store 2 and followers in stores 1,3

--- a/server/filter.go
+++ b/server/filter.go
@@ -134,38 +134,6 @@ func (f *healthFilter) FilterTarget(store *storeInfo) bool {
 	return f.filter(store)
 }
 
-type regionCountFilter struct {
-	opt *scheduleOption
-}
-
-func newRegionCountFilter(opt *scheduleOption) *regionCountFilter {
-	return &regionCountFilter{opt: opt}
-}
-
-func (f *regionCountFilter) FilterSource(store *storeInfo) bool {
-	return uint64(store.stats.RegionCount) < f.opt.GetMinRegionCount()
-}
-
-func (f *regionCountFilter) FilterTarget(store *storeInfo) bool {
-	return false
-}
-
-type leaderCountFilter struct {
-	opt *scheduleOption
-}
-
-func newLeaderCountFilter(opt *scheduleOption) *leaderCountFilter {
-	return &leaderCountFilter{opt: opt}
-}
-
-func (f *leaderCountFilter) FilterSource(store *storeInfo) bool {
-	return uint64(store.stats.LeaderRegionCount) < f.opt.GetMinLeaderCount()
-}
-
-func (f *leaderCountFilter) FilterTarget(store *storeInfo) bool {
-	return false
-}
-
 type snapshotCountFilter struct {
 	opt *scheduleOption
 }

--- a/server/replication.go
+++ b/server/replication.go
@@ -74,11 +74,11 @@ func compareStoreScore(storeA *storeInfo, scoreA float64, storeB *storeInfo, sco
 	if scoreA < scoreB {
 		return -1
 	}
-	// The store with lower storage ratio is better.
-	if storeA.storageRatio() < storeB.storageRatio() {
+	// The store with lower region ratio is better.
+	if storeA.regionRatio() < storeB.regionRatio() {
 		return 1
 	}
-	if storeA.storageRatio() > storeB.storageRatio() {
+	if storeA.regionRatio() > storeB.regionRatio() {
 		return -1
 	}
 	return 0

--- a/server/replication.go
+++ b/server/replication.go
@@ -74,11 +74,11 @@ func compareStoreScore(storeA *storeInfo, scoreA float64, storeB *storeInfo, sco
 	if scoreA < scoreB {
 		return -1
 	}
-	// The store with lower region ratio is better.
-	if storeA.regionRatio() < storeB.regionRatio() {
+	// The store with lower region score is better.
+	if storeA.regionScore() < storeB.regionScore() {
 		return 1
 	}
-	if storeA.regionRatio() > storeB.regionRatio() {
+	if storeA.regionScore() > storeB.regionScore() {
 		return -1
 	}
 	return 0

--- a/server/replication_test.go
+++ b/server/replication_test.go
@@ -46,7 +46,7 @@ func (s *testReplicationSuite) TestDistinctScore(c *C) {
 					"rack": rack,
 					"host": host,
 				}
-				tc.addLabelsStore(storeID, 1, 0.1, labels)
+				tc.addLabelsStore(storeID, 1, labels)
 				store := cluster.getStore(storeID)
 				stores = append(stores, store)
 
@@ -62,7 +62,7 @@ func (s *testReplicationSuite) TestDistinctScore(c *C) {
 		}
 	}
 
-	tc.addLabelsStore(100, 1, 0.1, map[string]string{})
+	tc.addLabelsStore(100, 1, map[string]string{})
 	store := cluster.getStore(100)
 	c.Assert(rep.GetDistinctScore(stores, store), Equals, float64(0))
 }
@@ -71,9 +71,9 @@ func (s *testReplicationSuite) TestCompareStoreScore(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
 
-	tc.addRegionStore(1, 1, 0.1)
-	tc.addRegionStore(2, 1, 0.1)
-	tc.addRegionStore(3, 1, 0.2)
+	tc.addRegionStore(1, 1)
+	tc.addRegionStore(2, 1)
+	tc.addRegionStore(3, 3)
 
 	store1 := cluster.getStore(1)
 	store2 := cluster.getStore(2)

--- a/server/scheduler_test.go
+++ b/server/scheduler_test.go
@@ -28,10 +28,10 @@ func (s *testShuffleLeaderSuite) TestShuffle(c *C) {
 	c.Assert(sl.Schedule(cluster), IsNil)
 
 	// Add stores 1,2,3,4
-	tc.addLeaderStore(1, 6, 30)
-	tc.addLeaderStore(2, 7, 30)
-	tc.addLeaderStore(3, 8, 30)
-	tc.addLeaderStore(4, 9, 30)
+	tc.addLeaderStore(1, 6)
+	tc.addLeaderStore(2, 7)
+	tc.addLeaderStore(3, 8)
+	tc.addLeaderStore(4, 9)
 	// Add regions 1,2,3,4 with leaders in stores 1,2,3,4
 	tc.addLeaderRegion(1, 1, 2, 3, 4)
 	tc.addLeaderRegion(1, 2, 3, 4, 1)

--- a/server/selector.go
+++ b/server/selector.go
@@ -41,7 +41,7 @@ func (s *balanceSelector) SelectSource(stores []*storeInfo, filters ...Filter) *
 		if filterSource(store, filters) {
 			continue
 		}
-		if result == nil || result.resourceRatio(s.kind) < store.resourceRatio(s.kind) {
+		if result == nil || result.resourceScore(s.kind) < store.resourceScore(s.kind) {
 			result = store
 		}
 	}
@@ -56,7 +56,7 @@ func (s *balanceSelector) SelectTarget(stores []*storeInfo, filters ...Filter) *
 		if filterTarget(store, filters) {
 			continue
 		}
-		if result == nil || result.resourceRatio(s.kind) > store.resourceRatio(s.kind) {
+		if result == nil || result.resourceScore(s.kind) > store.resourceScore(s.kind) {
 			result = store
 		}
 	}

--- a/server/store.go
+++ b/server/store.go
@@ -79,18 +79,35 @@ func (s *storeInfo) downTime() time.Duration {
 	return time.Since(s.stats.LastHeartbeatTS)
 }
 
+func (s *storeInfo) leaderCount() uint64 {
+	return uint64(s.stats.LeaderCount)
+}
+
 func (s *storeInfo) leaderRatio() float64 {
-	if s.stats.TotalRegionCount == 0 {
+	return float64(s.stats.LeaderCount)
+}
+
+func (s *storeInfo) regionCount() uint64 {
+	return uint64(s.stats.RegionCount)
+}
+
+func (s *storeInfo) regionRatio() float64 {
+	if s.stats.GetCapacity() == 0 {
 		return 0
 	}
-	return float64(s.stats.LeaderRegionCount) / float64(s.stats.TotalRegionCount)
+	capaGB := float64(s.stats.GetCapacity()) / float64(1024*1024*1024)
+	return float64(s.stats.RegionCount) / capaGB
+}
+
+func (s *storeInfo) storageSize() uint64 {
+	return s.stats.GetCapacity() - s.stats.GetAvailable()
 }
 
 func (s *storeInfo) storageRatio() float64 {
 	if s.stats.GetCapacity() == 0 {
 		return 0
 	}
-	return float64(s.stats.GetUsedSize()) / float64(s.stats.GetCapacity())
+	return float64(s.storageSize()) / float64(s.stats.GetCapacity())
 }
 
 func (s *storeInfo) resourceRatio(kind ResourceKind) float64 {
@@ -98,7 +115,7 @@ func (s *storeInfo) resourceRatio(kind ResourceKind) float64 {
 	case leaderKind:
 		return s.leaderRatio()
 	case regionKind:
-		return s.storageRatio()
+		return s.regionRatio()
 	default:
 		return 0
 	}
@@ -106,8 +123,8 @@ func (s *storeInfo) resourceRatio(kind ResourceKind) float64 {
 
 func (s *storeInfo) resourceScores() []int {
 	var scores []int
-	scores = append(scores, int(s.leaderRatio()*100))
-	scores = append(scores, int(s.storageRatio()*100))
+	scores = append(scores, int(s.leaderRatio()))
+	scores = append(scores, int(s.regionRatio()))
 	return scores
 }
 
@@ -137,41 +154,36 @@ type StoreStatus struct {
 	*pdpb.StoreStats
 
 	// Blocked means that the store is blocked from balance.
-	blocked           bool
-	StartTS           time.Time `json:"start_ts"`
-	LastHeartbeatTS   time.Time `json:"last_heartbeat_ts"`
-	TotalRegionCount  int       `json:"total_region_count"`
-	LeaderRegionCount int       `json:"leader_region_count"`
+	blocked         bool
+	LeaderCount     int       `json:"leader_count"`
+	LastHeartbeatTS time.Time `json:"last_heartbeat_ts"`
 }
 
 func newStoreStatus() *StoreStatus {
 	return &StoreStatus{
 		StoreStats: &pdpb.StoreStats{},
-		StartTS:    time.Now(),
 	}
 }
 
 func (s *StoreStatus) clone() *StoreStatus {
 	return &StoreStatus{
-		StoreStats:        proto.Clone(s.StoreStats).(*pdpb.StoreStats),
-		blocked:           s.blocked,
-		StartTS:           s.StartTS,
-		LastHeartbeatTS:   s.LastHeartbeatTS,
-		TotalRegionCount:  s.TotalRegionCount,
-		LeaderRegionCount: s.LeaderRegionCount,
+		StoreStats:      proto.Clone(s.StoreStats).(*pdpb.StoreStats),
+		blocked:         s.blocked,
+		LeaderCount:     s.LeaderCount,
+		LastHeartbeatTS: s.LastHeartbeatTS,
 	}
 }
 
-// GetUptime returns the uptime of the store.
+// GetStartTS returns the start timestamp.
+func (s *StoreStatus) GetStartTS() time.Time {
+	return time.Unix(int64(s.GetStartTime()), 0)
+}
+
+// GetUptime returns the uptime.
 func (s *StoreStatus) GetUptime() time.Duration {
-	uptime := s.LastHeartbeatTS.Sub(s.StartTS)
+	uptime := s.LastHeartbeatTS.Sub(s.GetStartTS())
 	if uptime > 0 {
 		return uptime
 	}
 	return 0
-}
-
-// GetUsedSize returns the used storage size.
-func (s *StoreStatus) GetUsedSize() uint64 {
-	return s.GetCapacity() - s.GetAvailable()
 }

--- a/server/store.go
+++ b/server/store.go
@@ -109,6 +109,17 @@ func (s *storeInfo) storageRatio() float64 {
 	return float64(s.storageSize()) / float64(s.stats.GetCapacity())
 }
 
+func (s *storeInfo) resourceCount(kind ResourceKind) uint64 {
+	switch kind {
+	case leaderKind:
+		return s.leaderCount()
+	case regionKind:
+		return s.regionCount()
+	default:
+		return 0
+	}
+}
+
 func (s *storeInfo) resourceScore(kind ResourceKind) float64 {
 	switch kind {
 	case leaderKind:

--- a/server/store.go
+++ b/server/store.go
@@ -83,7 +83,7 @@ func (s *storeInfo) leaderCount() uint64 {
 	return uint64(s.stats.LeaderCount)
 }
 
-func (s *storeInfo) leaderRatio() float64 {
+func (s *storeInfo) leaderScore() float64 {
 	return float64(s.stats.LeaderCount)
 }
 
@@ -91,12 +91,11 @@ func (s *storeInfo) regionCount() uint64 {
 	return uint64(s.stats.RegionCount)
 }
 
-func (s *storeInfo) regionRatio() float64 {
+func (s *storeInfo) regionScore() float64 {
 	if s.stats.GetCapacity() == 0 {
 		return 0
 	}
-	capaGB := float64(s.stats.GetCapacity()) / float64(1024*1024*1024)
-	return float64(s.stats.RegionCount) / capaGB
+	return float64(s.stats.RegionCount) / float64(s.stats.GetCapacity())
 }
 
 func (s *storeInfo) storageSize() uint64 {
@@ -110,22 +109,15 @@ func (s *storeInfo) storageRatio() float64 {
 	return float64(s.storageSize()) / float64(s.stats.GetCapacity())
 }
 
-func (s *storeInfo) resourceRatio(kind ResourceKind) float64 {
+func (s *storeInfo) resourceScore(kind ResourceKind) float64 {
 	switch kind {
 	case leaderKind:
-		return s.leaderRatio()
+		return s.leaderScore()
 	case regionKind:
-		return s.regionRatio()
+		return s.regionScore()
 	default:
 		return 0
 	}
-}
-
-func (s *storeInfo) resourceScores() []int {
-	var scores []int
-	scores = append(scores, int(s.leaderRatio()))
-	scores = append(scores, int(s.regionRatio()))
-	return scores
 }
 
 func (s *storeInfo) getLabelValue(key string) string {
@@ -155,7 +147,7 @@ type StoreStatus struct {
 
 	// Blocked means that the store is blocked from balance.
 	blocked         bool
-	LeaderCount     int       `json:"leader_count"`
+	LeaderCount     uint32    `json:"leader_count"`
 	LastHeartbeatTS time.Time `json:"last_heartbeat_ts"`
 }
 

--- a/server/util.go
+++ b/server/util.go
@@ -350,3 +350,13 @@ func GetPDMembers(etcdClient *clientv3.Client) ([]*pdpb.PDMember, error) {
 
 	return members, nil
 }
+
+func roundUint64(value, min, max uint64) uint64 {
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}

--- a/server/util.go
+++ b/server/util.go
@@ -351,7 +351,7 @@ func GetPDMembers(etcdClient *clientv3.Client) ([]*pdpb.PDMember, error) {
 	return members, nil
 }
 
-func roundUint64(value, min, max uint64) uint64 {
+func ensureRangeUint64(value, min, max uint64) uint64 {
 	if value < min {
 		return min
 	}

--- a/server/util.go
+++ b/server/util.go
@@ -351,12 +351,23 @@ func GetPDMembers(etcdClient *clientv3.Client) ([]*pdpb.PDMember, error) {
 	return members, nil
 }
 
-func ensureRangeUint64(value, min, max uint64) uint64 {
-	if value < min {
-		return min
+func minUint64(a, b uint64) uint64 {
+	if a < b {
+		return a
 	}
-	if value > max {
-		return max
+	return b
+}
+
+func maxUint64(a, b uint64) uint64 {
+	if a > b {
+		return a
 	}
-	return value
+	return b
+}
+
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/server/util.go
+++ b/server/util.go
@@ -365,20 +365,6 @@ func maxUint64(a, b uint64) uint64 {
 	return b
 }
 
-func minFloat64(a, b float64) float64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func maxFloat64(a, b float64) float64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func minDuration(a, b time.Duration) time.Duration {
 	if a < b {
 		return a

--- a/server/util.go
+++ b/server/util.go
@@ -365,6 +365,20 @@ func maxUint64(a, b uint64) uint64 {
 	return b
 }
 
+func minFloat64(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxFloat64(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
 func minDuration(a, b time.Duration) time.Duration {
 	if a < b {
 		return a

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -14,29 +14,29 @@
 package server
 
 import (
+	"time"
+
 	. "github.com/pingcap/check"
 )
 
-var _ = Suite(&testEnsureRangeSuite{})
+var _ = Suite(&testMinMaxSuite{})
 
-type testEnsureRangeSuite struct{}
+type testMinMaxSuite struct{}
 
-type testEnsureRangeCase struct {
-	v        uint64
-	min      uint64
-	max      uint64
-	expected uint64
+func (s *testMinMaxSuite) TestMinUint64(c *C) {
+	c.Assert(minUint64(1, 2), Equals, uint64(1))
+	c.Assert(minUint64(2, 1), Equals, uint64(1))
+	c.Assert(minUint64(1, 1), Equals, uint64(1))
 }
 
-func (s *testEnsureRangeSuite) TestUint64(c *C) {
-	tests := []*testEnsureRangeCase{
-		{0, 1, 3, 1},
-		{1, 1, 3, 1},
-		{2, 1, 3, 2},
-		{3, 1, 3, 3},
-		{4, 1, 3, 3},
-	}
-	for _, t := range tests {
-		c.Assert(ensureRangeUint64(t.v, t.min, t.max), Equals, t.expected)
-	}
+func (s *testMinMaxSuite) TestMaxUint64(c *C) {
+	c.Assert(maxUint64(1, 2), Equals, uint64(2))
+	c.Assert(maxUint64(2, 1), Equals, uint64(2))
+	c.Assert(maxUint64(1, 1), Equals, uint64(1))
+}
+
+func (s *testMinMaxSuite) TestMinDuration(c *C) {
+	c.Assert(minDuration(time.Minute, time.Second), Equals, time.Second)
+	c.Assert(minDuration(time.Second, time.Minute), Equals, time.Second)
+	c.Assert(minDuration(time.Second, time.Second), Equals, time.Second)
 }

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -1,0 +1,42 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testEnsureRangeSuite{})
+
+type testEnsureRangeSuite struct{}
+
+type testEnsureRangeCase struct {
+	v        uint64
+	min      uint64
+	max      uint64
+	expected uint64
+}
+
+func (s *testEnsureRangeSuite) TestUint64(c *C) {
+	tests := []*testEnsureRangeCase{
+		{0, 1, 3, 1},
+		{1, 1, 3, 1},
+		{2, 1, 3, 2},
+		{3, 1, 3, 3},
+		{4, 1, 3, 3},
+	}
+	for _, t := range tests {
+		c.Assert(ensureRangeUint64(t.v, t.min, t.max), Equals, t.expected)
+	}
+}

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -35,18 +35,6 @@ func (s *testMinMaxSuite) TestMaxUint64(c *C) {
 	c.Assert(maxUint64(1, 1), Equals, uint64(1))
 }
 
-func (s *testMinMaxSuite) TestMinFloat64(c *C) {
-	c.Assert(minFloat64(1, 2), Equals, float64(1))
-	c.Assert(minFloat64(2, 1), Equals, float64(1))
-	c.Assert(minFloat64(1, 1), Equals, float64(1))
-}
-
-func (s *testMinMaxSuite) TestMaxFloat64(c *C) {
-	c.Assert(maxFloat64(1, 2), Equals, float64(2))
-	c.Assert(maxFloat64(2, 1), Equals, float64(2))
-	c.Assert(maxFloat64(1, 1), Equals, float64(1))
-}
-
 func (s *testMinMaxSuite) TestMinDuration(c *C) {
 	c.Assert(minDuration(time.Minute, time.Second), Equals, time.Second)
 	c.Assert(minDuration(time.Second, time.Minute), Equals, time.Second)

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -35,6 +35,18 @@ func (s *testMinMaxSuite) TestMaxUint64(c *C) {
 	c.Assert(maxUint64(1, 1), Equals, uint64(1))
 }
 
+func (s *testMinMaxSuite) TestMinFloat64(c *C) {
+	c.Assert(minFloat64(1, 2), Equals, float64(1))
+	c.Assert(minFloat64(2, 1), Equals, float64(1))
+	c.Assert(minFloat64(1, 1), Equals, float64(1))
+}
+
+func (s *testMinMaxSuite) TestMaxFloat64(c *C) {
+	c.Assert(maxFloat64(1, 2), Equals, float64(2))
+	c.Assert(maxFloat64(2, 1), Equals, float64(2))
+	c.Assert(maxFloat64(1, 1), Equals, float64(1))
+}
+
 func (s *testMinMaxSuite) TestMinDuration(c *C) {
 	c.Assert(minDuration(time.Minute, time.Second), Equals, time.Second)
 	c.Assert(minDuration(time.Second, time.Minute), Equals, time.Second)


### PR DESCRIPTION
We will adjust the balance speed and threshold according to the leader count and
region count, so that we can remove some dumb configurations.
Close #444 .