### PR TITLE
server: fix join a member with the empty name

### DIFF
--- a/cmd/pd-server/main.go
+++ b/cmd/pd-server/main.go
@@ -40,18 +40,22 @@ func main() {
 	case flag.ErrHelp:
 		os.Exit(0)
 	default:
-		log.Fatalf("parse cmd flags err %s\n", err)
+		log.Fatalf("parse cmd flags error %s\n", err)
 	}
 
 	err = server.InitLogger(cfg)
 	if err != nil {
-		log.Fatalf("initalize logger err %s\n", err)
+		log.Fatalf("initalize logger error %s\n", err)
 	}
 
 	server.LogPDInfo()
 
 	metricutil.Push(&cfg.Metric)
 
+	err = server.PrepareJoinCluster(cfg)
+	if err != nil {
+		log.Fatal("join error ", err)
+	}
 	svr := server.CreateServer(cfg)
 	err = svr.StartEtcd(api.NewHandler(svr))
 	if err != nil {

--- a/server/config.go
+++ b/server/config.go
@@ -212,15 +212,6 @@ func (c *Config) adjust() error {
 	adjustString(&c.PeerUrls, defaultPeerUrls)
 	adjustString(&c.AdvertisePeerUrls, c.PeerUrls)
 
-	if c.Join != "" {
-		initialCluster, state, err := prepareJoinCluster(c)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		c.InitialCluster = initialCluster
-		c.InitialClusterState = state
-	}
-
 	if len(c.InitialCluster) == 0 {
 		// The advertise peer urls may be http://127.0.0.1:2380,http://127.0.0.1:2381
 		// so the initial cluster is pd=http://127.0.0.1:2380,pd=http://127.0.0.1:2381

--- a/server/join_test.go
+++ b/server/join_test.go
@@ -90,7 +90,6 @@ func startPdWith(cfg *Config) (*Server, error) {
 	abortCh := make(chan struct{}, 1)
 
 	go func() {
-		// TODO: Decouple join from cfg.adjust().
 		err := cfg.adjust()
 		if err != nil {
 			errCh <- errors.Trace(err)

--- a/server/join_test.go
+++ b/server/join_test.go
@@ -91,9 +91,18 @@ func startPdWith(cfg *Config) (*Server, error) {
 
 	go func() {
 		// TODO: Decouple join from cfg.adjust().
-		cfg.adjust()
+		err := cfg.adjust()
+		if err != nil {
+			errCh <- errors.Trace(err)
+			return
+		}
+		err = PrepareJoinCluster(cfg)
+		if err != nil {
+			errCh <- errors.Trace(err)
+			return
+		}
 		svr := CreateServer(cfg)
-		err := svr.StartEtcd(nil)
+		err = svr.StartEtcd(nil)
 		if err != nil {
 			errCh <- errors.Trace(err)
 			svr.Close()

--- a/server/util.go
+++ b/server/util.go
@@ -43,8 +43,7 @@ const (
 	requestTimeout  = etcdutil.DefaultRequestTimeout
 	slowRequestTime = etcdutil.DefaultSlowRequestTime
 
-	// PrivateDirMode grants owner to make/remove files inside the directory.
-	PrivateDirMode = 0700
+	publicDirMode = 0755
 )
 
 // Version information.
@@ -312,7 +311,7 @@ func (rf *redirectFormatter) Flush() {}
 func setLogOutput(logFile string) error {
 	// PD log.
 	dir, _ := path.Split(logFile)
-	err := os.MkdirAll(dir, PrivateDirMode)
+	err := os.MkdirAll(dir, publicDirMode)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/server/util.go
+++ b/server/util.go
@@ -310,7 +310,7 @@ func (rf *redirectFormatter) Flush() {}
 // setLogOutput sets output path for all logs.
 func setLogOutput(logFile string) error {
 	// PD log.
-	dir, _ := path.Split(logFile)
+	dir := path.Dir(logFile)
 	err := os.MkdirAll(dir, logDirMode)
 	if err != nil {
 		return errors.Trace(err)

--- a/server/util.go
+++ b/server/util.go
@@ -43,7 +43,7 @@ const (
 	requestTimeout  = etcdutil.DefaultRequestTimeout
 	slowRequestTime = etcdutil.DefaultSlowRequestTime
 
-	publicDirMode = 0755
+	logDirMode = 0755
 )
 
 // Version information.
@@ -311,7 +311,7 @@ func (rf *redirectFormatter) Flush() {}
 func setLogOutput(logFile string) error {
 	// PD log.
 	dir, _ := path.Split(logFile)
-	err := os.MkdirAll(dir, publicDirMode)
+	err := os.MkdirAll(dir, logDirMode)
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
prepareJoin will add a member firstly, if before startNode meet an error and return. It will add an empty name member. result in the inability to successfully join new members
PTAL @siddontang @overvenus @disksing 
close https://github.com/pingcap/pd/issues/557