### PR TITLE
clusterInfo: calculate leaderCount/regionCount from cache.

### DIFF
--- a/server/api/store.go
+++ b/server/api/store.go
@@ -36,8 +36,8 @@ type storeStatus struct {
 	StoreID            uint64            `json:"store_id"`
 	Capacity           typeutil.ByteSize `json:"capacity"`
 	Available          typeutil.ByteSize `json:"available"`
-	LeaderCount        uint32            `json:"leader_count"`
-	RegionCount        uint32            `json:"region_count"`
+	LeaderCount        int               `json:"leader_count"`
+	RegionCount        int               `json:"region_count"`
 	SendingSnapCount   uint32            `json:"sending_snap_count"`
 	ReceivingSnapCount uint32            `json:"receiving_snap_count"`
 	ApplyingSnapCount  uint32            `json:"applying_snap_count"`

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -61,14 +61,14 @@ func (c *testClusterInfo) setStoreBusy(storeID uint64, busy bool) {
 func (c *testClusterInfo) addLeaderStore(storeID uint64, leaderCount int) {
 	store := newStoreInfo(&metapb.Store{Id: storeID})
 	store.status.LastHeartbeatTS = time.Now()
-	store.status.LeaderCount = uint32(leaderCount)
+	store.status.LeaderCount = leaderCount
 	c.putStore(store)
 }
 
 func (c *testClusterInfo) addRegionStore(storeID uint64, regionCount int) {
 	store := newStoreInfo(&metapb.Store{Id: storeID})
 	store.status.LastHeartbeatTS = time.Now()
-	store.status.RegionCount = uint32(regionCount)
+	store.status.RegionCount = regionCount
 	store.status.Capacity = uint64(1024)
 	store.status.Available = store.status.Capacity
 	c.putStore(store)
@@ -96,13 +96,13 @@ func (c *testClusterInfo) addLeaderRegion(regionID uint64, leaderID uint64, foll
 
 func (c *testClusterInfo) updateLeaderCount(storeID uint64, leaderCount int) {
 	store := c.getStore(storeID)
-	store.status.LeaderCount = uint32(leaderCount)
+	store.status.LeaderCount = leaderCount
 	c.putStore(store)
 }
 
 func (c *testClusterInfo) updateRegionCount(storeID uint64, regionCount int) {
 	store := c.getStore(storeID)
-	store.status.RegionCount = uint32(regionCount)
+	store.status.RegionCount = regionCount
 	c.putStore(store)
 }
 

--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -315,7 +315,13 @@ func (s *testClusterInfoSuite) testStoreHeartbeat(c *C, cache *clusterInfo) {
 
 func (s *testClusterInfoSuite) testRegionHeartbeat(c *C, cache *clusterInfo) {
 	n, np := uint64(3), uint64(3)
+
+	stores := newTestStores(3)
 	regions := newTestRegions(n, np)
+
+	for _, store := range stores {
+		cache.putStore(store)
+	}
 
 	for i, region := range regions {
 		// region does not exist.
@@ -385,6 +391,11 @@ func (s *testClusterInfoSuite) testRegionHeartbeat(c *C, cache *clusterInfo) {
 			peer := region.GetStorePeer(store.GetId())
 			c.Assert(peer.GetId(), Not(Equals), region.Leader.GetId())
 		}
+	}
+
+	for _, store := range cache.stores.getStores() {
+		c.Assert(store.status.LeaderCount, Equals, cache.regions.getStoreLeaderCount(store.GetId()))
+		c.Assert(store.status.RegionCount, Equals, cache.regions.getStoreRegionCount(store.GetId()))
 	}
 
 	// Test with kv.

--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -291,13 +291,11 @@ func (s *testClusterInfoSuite) testStoreHeartbeat(c *C, cache *clusterInfo) {
 		c.Assert(cache.getStoreCount(), Equals, int(i+1))
 
 		stats := store.status
-		c.Assert(stats.LeaderCount, Equals, uint32(0))
 		c.Assert(stats.LastHeartbeatTS.IsZero(), IsTrue)
 
 		c.Assert(cache.handleStoreHeartbeat(storeStats), IsNil)
 
 		stats = cache.getStore(store.GetId()).status
-		c.Assert(stats.LeaderCount, Equals, uint32(1))
 		c.Assert(stats.LastHeartbeatTS.IsZero(), IsFalse)
 	}
 

--- a/server/cluster_worker_test.go
+++ b/server/cluster_worker_test.go
@@ -368,8 +368,7 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit(c *C) {
 
 	leaderPeer1 := s.chooseRegionLeader(c, r1)
 
-	resp := heartbeatRegion(c, conn, s.clusterID, 0, r1, leaderPeer1)
-	c.Assert(resp, IsNil)
+	heartbeatRegion(c, conn, s.clusterID, 0, r1, leaderPeer1)
 	checkSearchRegions(c, cluster, []byte{})
 
 	mustGetRegion(c, cluster, []byte("a"), r1)
@@ -377,8 +376,7 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit(c *C) {
 	mustGetRegion(c, cluster, []byte("z"), nil)
 
 	leaderPeer2 := s.chooseRegionLeader(c, r2)
-	resp = heartbeatRegion(c, conn, s.clusterID, 0, r2, leaderPeer2)
-	c.Assert(resp, IsNil)
+	heartbeatRegion(c, conn, s.clusterID, 0, r2, leaderPeer2)
 	checkSearchRegions(c, cluster, []byte{}, []byte("m"))
 
 	mustGetRegion(c, cluster, []byte("z"), r2)
@@ -389,8 +387,7 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit(c *C) {
 
 	leaderPeer3 := s.chooseRegionLeader(c, r3)
 
-	resp = heartbeatRegion(c, conn, s.clusterID, 0, r3, leaderPeer3)
-	c.Assert(resp, IsNil)
+	heartbeatRegion(c, conn, s.clusterID, 0, r3, leaderPeer3)
 	checkSearchRegions(c, cluster, []byte{}, []byte("q"))
 
 	mustGetRegion(c, cluster, []byte("z"), r3)
@@ -398,8 +395,7 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit(c *C) {
 	// [m, q) is missing before r2's heartbeat.
 	mustGetRegion(c, cluster, []byte("n"), nil)
 
-	resp = heartbeatRegion(c, conn, s.clusterID, 0, r2, leaderPeer2)
-	c.Assert(resp, IsNil)
+	heartbeatRegion(c, conn, s.clusterID, 0, r2, leaderPeer2)
 	checkSearchRegions(c, cluster, []byte{}, []byte("m"), []byte("q"))
 
 	mustGetRegion(c, cluster, []byte("n"), r2)

--- a/server/store.go
+++ b/server/store.go
@@ -158,7 +158,8 @@ type StoreStatus struct {
 
 	// Blocked means that the store is blocked from balance.
 	blocked         bool
-	LeaderCount     uint32    `json:"leader_count"`
+	LeaderCount     int
+	RegionCount     int
 	LastHeartbeatTS time.Time `json:"last_heartbeat_ts"`
 }
 
@@ -173,6 +174,7 @@ func (s *StoreStatus) clone() *StoreStatus {
 		StoreStats:      proto.Clone(s.StoreStats).(*pdpb.StoreStats),
 		blocked:         s.blocked,
 		LeaderCount:     s.LeaderCount,
+		RegionCount:     s.RegionCount,
 		LastHeartbeatTS: s.LastHeartbeatTS,
 	}
 }


### PR DESCRIPTION
cc @nolouch 

This PR aims to optimize balance speed by always using region cache to calculate a store's leaderCount and regionCount, which will be more up to date compared to reading it from StoreHeartbeat.

The main modify is whenever we get a `storeInfo` from `clusterInfo`, we setup its leaderCount and regionCount by calculating them from region cache.

However, some tests rely on manually setting leaderCount/regionCount, so `setFakeLeaderCount` and `setFakeRegionCont` are introduced to keep them working properly.