### PR TITLE
server: make testClusterWorkerSuite stable.

### DIFF
--- a/server/cluster_worker_test.go
+++ b/server/cluster_worker_test.go
@@ -178,7 +178,7 @@ func (s *testClusterWorkerSuite) SetUpTest(c *C) {
 
 	s.svr, s.cleanup = newTestServer(c)
 	s.svr.cfg.nextRetryDelay = 50 * time.Millisecond
-	s.svr.scheduleOpt.SetMaxReplicas(5)
+	s.svr.scheduleOpt.SetMaxReplicas(1)
 
 	s.client = s.svr.client
 	s.clusterID = s.svr.clusterID
@@ -353,8 +353,6 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit(c *C) {
 	cluster := s.svr.GetRaftCluster()
 	c.Assert(cluster, NotNil)
 
-	s.svr.scheduleOpt.SetMaxReplicas(1)
-
 	leaderPD := mustGetLeader(c, s.client, s.svr.getLeaderPath())
 	conn, err := rpcConnect(leaderPD.GetAddr())
 	c.Assert(err, IsNil)
@@ -408,6 +406,8 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit(c *C) {
 }
 
 func (s *testClusterWorkerSuite) TestHeartbeatSplit2(c *C) {
+	s.svr.scheduleOpt.SetMaxReplicas(5)
+
 	cluster := s.svr.GetRaftCluster()
 	c.Assert(cluster, NotNil)
 
@@ -444,6 +444,8 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit2(c *C) {
 }
 
 func (s *testClusterWorkerSuite) TestHeartbeatChangePeer(c *C) {
+	s.svr.scheduleOpt.SetMaxReplicas(5)
+
 	opt := s.svr.scheduleOpt
 
 	cluster := s.svr.GetRaftCluster()
@@ -503,10 +505,10 @@ func (s *testClusterWorkerSuite) TestHeartbeatChangePeer(c *C) {
 }
 
 func (s *testClusterWorkerSuite) TestHeartbeatSplitAddPeer(c *C) {
+	s.svr.scheduleOpt.SetMaxReplicas(2)
+
 	cluster := s.svr.GetRaftCluster()
 	c.Assert(cluster, NotNil)
-
-	s.svr.scheduleOpt.SetMaxReplicas(2)
 
 	leaderPD := mustGetLeader(c, s.client, s.svr.getLeaderPath())
 	conn, err := rpcConnect(leaderPD.GetAddr())


### PR DESCRIPTION
In the suite, some test need replica 1. There is a chance that an AddNode is already scheduled before change the config value in test case. See: https://travis-ci.org/pingcap/pd/jobs/213261398#L1968
The fix is to set replica as 1 in `SetUpTest()` then adjust it in test cases.

cc @nolouch @siddontang 