### PR TITLE
server: transfer leader when move leader peer.

### DIFF
--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -633,7 +633,14 @@ func checkRemovePeer(c *C, bop Operator, storeID uint64) {
 	case *changePeerOperator:
 		op = bop.(*changePeerOperator)
 	case *regionOperator:
-		op = bop.(*regionOperator).Ops[0].(*changePeerOperator)
+		regionOp := bop.(*regionOperator)
+		if len(regionOp.Ops) == 1 {
+			op = regionOp.Ops[0].(*changePeerOperator)
+		} else {
+			transferLeader := regionOp.Ops[0].(*transferLeaderOperator)
+			c.Assert(transferLeader.OldLeader.GetStoreId(), Equals, storeID)
+			op = bop.(*regionOperator).Ops[1].(*changePeerOperator)
+		}
 	}
 	c.Assert(op.ChangePeer.GetChangeType(), Equals, raftpb.ConfChangeType_RemoveNode)
 	c.Assert(op.ChangePeer.GetPeer().GetStoreId(), Equals, storeID)

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -654,7 +654,8 @@ func checkTransferPeer(c *C, bop Operator, sourceID, targetID uint64) {
 	} else {
 		c.Assert(op.Ops, HasLen, 3)
 		checkAddPeer(c, op.Ops[0], targetID)
-		checkTransferLeader(c, op.Ops[1], sourceID, targetID)
+		transferLeader := op.Ops[1].(*transferLeaderOperator)
+		c.Assert(transferLeader.OldLeader.GetStoreId(), Equals, sourceID)
 		checkRemovePeer(c, op.Ops[2], sourceID)
 	}
 }

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -642,12 +642,14 @@ func checkRemovePeer(c *C, bop Operator, storeID uint64) {
 			op = t.Ops[1].(*changePeerOperator)
 		}
 	}
+	c.Assert(op, NotNil)
 	c.Assert(op.ChangePeer.GetChangeType(), Equals, raftpb.ConfChangeType_RemoveNode)
 	c.Assert(op.ChangePeer.GetPeer().GetStoreId(), Equals, storeID)
 }
 
 func checkTransferPeer(c *C, bop Operator, sourceID, targetID uint64) {
 	op := bop.(*regionOperator)
+	c.Assert(op, NotNil)
 	if len(op.Ops) == 2 {
 		checkAddPeer(c, op.Ops[0], targetID)
 		checkRemovePeer(c, op.Ops[1], sourceID)
@@ -668,6 +670,7 @@ func checkTransferLeader(c *C, bop Operator, sourceID, targetID uint64) {
 	case *regionOperator:
 		op = t.Ops[0].(*transferLeaderOperator)
 	}
+	c.Assert(op, NotNil)
 	c.Assert(op.OldLeader.GetStoreId(), Equals, sourceID)
 	c.Assert(op.NewLeader.GetStoreId(), Equals, targetID)
 }

--- a/server/cluster_worker_test.go
+++ b/server/cluster_worker_test.go
@@ -290,7 +290,7 @@ func splitRegion(c *C, old *metapb.Region, splitKey []byte, newRegionID uint64, 
 	return newRegion
 }
 
-func heartbeatRegion(c *C, conn net.Conn, clusterID uint64, msgID uint64, region *metapb.Region, leader *metapb.Peer) *pdpb.ChangePeer {
+func heartbeatRegion(c *C, conn net.Conn, clusterID uint64, msgID uint64, region *metapb.Region, leader *metapb.Peer) *pdpb.RegionHeartbeatResponse {
 	req := &pdpb.Request{
 		Header:  newRequestHeader(clusterID),
 		CmdType: pdpb.CommandType_RegionHeartbeat,
@@ -302,7 +302,7 @@ func heartbeatRegion(c *C, conn net.Conn, clusterID uint64, msgID uint64, region
 	sendRequest(c, conn, msgID, req)
 	_, resp := recvResponse(c, conn)
 	c.Assert(resp.GetCmdType(), Equals, pdpb.CommandType_RegionHeartbeat)
-	return resp.GetRegionHeartbeat().GetChangePeer()
+	return resp.GetRegionHeartbeat()
 }
 
 func (s *testClusterWorkerSuite) heartbeatStore(c *C, conn net.Conn, msgID uint64, stats *pdpb.StoreStats) *pdpb.StoreHeartbeatResponse {
@@ -369,7 +369,8 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit(c *C) {
 	leaderPeer1 := s.chooseRegionLeader(c, r1)
 
 	resp := heartbeatRegion(c, conn, s.clusterID, 0, r1, leaderPeer1)
-	c.Assert(resp, IsNil)
+	c.Assert(resp.GetChangePeer(), IsNil)
+	c.Assert(resp.GetTransferLeader(), IsNil)
 	checkSearchRegions(c, cluster, []byte{})
 
 	mustGetRegion(c, cluster, []byte("a"), r1)
@@ -378,7 +379,8 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit(c *C) {
 
 	leaderPeer2 := s.chooseRegionLeader(c, r2)
 	resp = heartbeatRegion(c, conn, s.clusterID, 0, r2, leaderPeer2)
-	c.Assert(resp, IsNil)
+	c.Assert(resp.GetChangePeer(), IsNil)
+	c.Assert(resp.GetTransferLeader(), IsNil)
 	checkSearchRegions(c, cluster, []byte{}, []byte("m"))
 
 	mustGetRegion(c, cluster, []byte("z"), r2)
@@ -390,7 +392,8 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit(c *C) {
 	leaderPeer3 := s.chooseRegionLeader(c, r3)
 
 	resp = heartbeatRegion(c, conn, s.clusterID, 0, r3, leaderPeer3)
-	c.Assert(resp, IsNil)
+	c.Assert(resp.GetChangePeer(), IsNil)
+	c.Assert(resp.GetTransferLeader(), IsNil)
 	checkSearchRegions(c, cluster, []byte{}, []byte("q"))
 
 	mustGetRegion(c, cluster, []byte("z"), r3)
@@ -399,7 +402,8 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit(c *C) {
 	mustGetRegion(c, cluster, []byte("n"), nil)
 
 	resp = heartbeatRegion(c, conn, s.clusterID, 0, r2, leaderPeer2)
-	c.Assert(resp, IsNil)
+	c.Assert(resp.GetChangePeer(), IsNil)
+	c.Assert(resp.GetTransferLeader(), IsNil)
 	checkSearchRegions(c, cluster, []byte{}, []byte("m"), []byte("q"))
 
 	mustGetRegion(c, cluster, []byte("n"), r2)
@@ -427,10 +431,10 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit2(c *C) {
 	// Add Peers util all stores are used up.
 	for {
 		resp := heartbeatRegion(c, conn, s.clusterID, 0, r1, leaderPeer)
-		if resp == nil {
+		if resp.GetChangePeer() == nil {
 			break
 		}
-		s.checkChangePeerRes(c, resp, raftpb.ConfChangeType_AddNode, r1)
+		s.checkChangePeerRes(c, resp.GetChangePeer(), raftpb.ConfChangeType_AddNode, r1)
 	}
 
 	// Split.
@@ -438,7 +442,8 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit2(c *C) {
 	r2 := splitRegion(c, r1, []byte("m"), r2ID, r2PeerIDs)
 	leaderPeer2 := s.chooseRegionLeader(c, r2)
 	resp := heartbeatRegion(c, conn, s.clusterID, 0, r2, leaderPeer2)
-	c.Assert(resp, IsNil)
+	c.Assert(resp.GetChangePeer(), IsNil)
+	c.Assert(resp.GetTransferLeader(), IsNil)
 
 	mustGetRegion(c, cluster, []byte("m"), r2)
 }
@@ -472,7 +477,7 @@ func (s *testClusterWorkerSuite) TestHeartbeatChangePeer(c *C) {
 	for i := 0; i < 4; i++ {
 		resp := heartbeatRegion(c, conn, s.clusterID, 0, region, leaderPeer)
 		// Check RegionHeartbeat response.
-		s.checkChangePeerRes(c, resp, raftpb.ConfChangeType_AddNode, region)
+		s.checkChangePeerRes(c, resp.GetChangePeer(), raftpb.ConfChangeType_AddNode, region)
 		c.Logf("[add peer][region]:%v", region)
 
 		// Update region epoch and check region info.
@@ -488,17 +493,27 @@ func (s *testClusterWorkerSuite) TestHeartbeatChangePeer(c *C) {
 	opt.SetMaxReplicas(3)
 
 	// Remove 2 peers
-	for i := 0; i < 2; i++ {
+	peerCount := 5
+	for {
 		resp := heartbeatRegion(c, conn, s.clusterID, 0, region, leaderPeer)
+		if resp.GetTransferLeader() != nil {
+			leaderPeer = resp.GetTransferLeader().GetPeer()
+			continue
+		}
+		if resp.GetChangePeer() == nil {
+			break
+		}
+
 		// Check RegionHeartbeat response.
-		s.checkChangePeerRes(c, resp, raftpb.ConfChangeType_RemoveNode, region)
+		s.checkChangePeerRes(c, resp.GetChangePeer(), raftpb.ConfChangeType_RemoveNode, region)
 
 		// Update region epoch and check region info.
 		region.RegionEpoch.ConfVer = region.GetRegionEpoch().GetConfVer() + 1
 		heartbeatRegion(c, conn, s.clusterID, 0, region, leaderPeer)
 
 		// Check region peer count.
-		region = s.checkRegionPeerCount(c, regionKey, 4-i)
+		peerCount--
+		region = s.checkRegionPeerCount(c, regionKey, peerCount)
 	}
 
 	region = s.checkRegionPeerCount(c, regionKey, 3)
@@ -521,14 +536,15 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplitAddPeer(c *C) {
 	// First sync, pd-server will return a AddPeer.
 	resp := heartbeatRegion(c, conn, s.clusterID, 0, r1, leaderPeer1)
 	// Apply the AddPeer ConfChange, but with no sync.
-	s.checkChangePeerRes(c, resp, raftpb.ConfChangeType_AddNode, r1)
+	s.checkChangePeerRes(c, resp.GetChangePeer(), raftpb.ConfChangeType_AddNode, r1)
 	// Split 1 to 1: [nil, m) 2: [m, nil).
 	r2ID, r2PeerIDs := s.askSplit(c, conn, 0, r1)
 	r2 := splitRegion(c, r1, []byte("m"), r2ID, r2PeerIDs)
 
 	// Sync r1 with both ConfVer and Version updated.
 	resp = heartbeatRegion(c, conn, s.clusterID, 0, r1, leaderPeer1)
-	c.Assert(resp, IsNil)
+	c.Assert(resp.GetChangePeer(), IsNil)
+	c.Assert(resp.GetTransferLeader(), IsNil)
 
 	mustGetRegion(c, cluster, []byte("a"), r1)
 	mustGetRegion(c, cluster, []byte("z"), nil)
@@ -536,7 +552,8 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplitAddPeer(c *C) {
 	// Sync r2.
 	leaderPeer2 := s.chooseRegionLeader(c, r2)
 	resp = heartbeatRegion(c, conn, s.clusterID, 0, r2, leaderPeer2)
-	c.Assert(resp, IsNil)
+	c.Assert(resp.GetChangePeer(), IsNil)
+	c.Assert(resp.GetTransferLeader(), IsNil)
 }
 
 func (s *testClusterWorkerSuite) TestStoreHeartbeat(c *C) {

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -31,7 +31,7 @@ type testOperator struct {
 func newTestOperator(regionID uint64, kind ResourceKind) Operator {
 	region := newRegionInfo(&metapb.Region{Id: regionID}, nil)
 	op := &testOperator{RegionID: regionID, Kind: kind}
-	return newRegionOperator(region, op)
+	return newRegionOperator(region, kind, op)
 }
 
 func (op *testOperator) GetRegionID() uint64           { return op.RegionID }

--- a/server/operator.go
+++ b/server/operator.go
@@ -76,14 +76,15 @@ func (op *adminOperator) Do(region *regionInfo) (*pdpb.RegionHeartbeatResponse, 
 }
 
 type regionOperator struct {
-	Region *regionInfo `json:"region"`
-	Start  time.Time   `json:"start"`
-	End    time.Time   `json:"end"`
-	Index  int         `json:"index"`
-	Ops    []Operator  `json:"ops"`
+	Region *regionInfo  `json:"region"`
+	Start  time.Time    `json:"start"`
+	End    time.Time    `json:"end"`
+	Index  int          `json:"index"`
+	Ops    []Operator   `json:"ops"`
+	Kind   ResourceKind `json:"kind"`
 }
 
-func newRegionOperator(region *regionInfo, ops ...Operator) *regionOperator {
+func newRegionOperator(region *regionInfo, kind ResourceKind, ops ...Operator) *regionOperator {
 	// Do some check here, just fatal because it must be bug.
 	if len(ops) == 0 {
 		log.Fatalf("[region %d] new region operator with no ops", region.GetId())
@@ -93,6 +94,7 @@ func newRegionOperator(region *regionInfo, ops ...Operator) *regionOperator {
 		Region: region,
 		Start:  time.Now(),
 		Ops:    ops,
+		Kind:   kind,
 	}
 }
 
@@ -105,7 +107,7 @@ func (op *regionOperator) GetRegionID() uint64 {
 }
 
 func (op *regionOperator) GetResourceKind() ResourceKind {
-	return op.Ops[0].GetResourceKind()
+	return op.Kind
 }
 
 func (op *regionOperator) Do(region *regionInfo) (*pdpb.RegionHeartbeatResponse, bool) {

--- a/server/operator.go
+++ b/server/operator.go
@@ -88,12 +88,6 @@ func newRegionOperator(region *regionInfo, ops ...Operator) *regionOperator {
 	if len(ops) == 0 {
 		log.Fatalf("[region %d] new region operator with no ops", region.GetId())
 	}
-	kind := ops[0].GetResourceKind()
-	for _, op := range ops {
-		if op.GetResourceKind() != kind {
-			log.Fatalf("[region %d] new region operator with ops of different kinds %v and %v", region.GetId(), op.GetResourceKind(), kind)
-		}
-	}
 
 	return &regionOperator{
 		Region: region,

--- a/server/region.go
+++ b/server/region.go
@@ -119,6 +119,15 @@ func (r *regionInfo) GetFollowers() map[uint64]*metapb.Peer {
 	return followers
 }
 
+func (r *regionInfo) GetFollower() *metapb.Peer {
+	for _, peer := range r.GetPeers() {
+		if r.Leader == nil || r.Leader.GetId() != peer.GetId() {
+			return peer
+		}
+	}
+	return nil
+}
+
 var _ btree.Item = &regionItem{}
 
 type regionItem struct {

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -249,6 +249,10 @@ func newRemovePeer(region *regionInfo, peer *metapb.Peer) Operator {
 func newTransferPeer(region *regionInfo, oldPeer, newPeer *metapb.Peer) Operator {
 	addPeer := newAddPeerOperator(region.GetId(), newPeer)
 	removePeer := newRemovePeerOperator(region.GetId(), oldPeer)
+	if region.Leader != nil && region.Leader.GetId() == oldPeer.GetId() {
+		transferLeader := newTransferLeaderOperator(region.GetId(), region.Leader, newPeer)
+		return newRegionOperator(region, addPeer, transferLeader, removePeer)
+	}
 	return newRegionOperator(region, addPeer, removePeer)
 }
 

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -238,12 +238,12 @@ func (s *shuffleRegionScheduler) Schedule(cluster *clusterInfo) Operator {
 
 func newAddPeer(region *regionInfo, peer *metapb.Peer) Operator {
 	addPeer := newAddPeerOperator(region.GetId(), peer)
-	return newRegionOperator(region, addPeer)
+	return newRegionOperator(region, regionKind, addPeer)
 }
 
 func newRemovePeer(region *regionInfo, peer *metapb.Peer) Operator {
 	removePeer := newRemovePeerOperator(region.GetId(), peer)
-	return newRegionOperator(region, removePeer)
+	return newRegionOperator(region, regionKind, removePeer)
 }
 
 func newTransferPeer(region *regionInfo, oldPeer, newPeer *metapb.Peer) Operator {
@@ -251,14 +251,14 @@ func newTransferPeer(region *regionInfo, oldPeer, newPeer *metapb.Peer) Operator
 	removePeer := newRemovePeerOperator(region.GetId(), oldPeer)
 	if region.Leader != nil && region.Leader.GetId() == oldPeer.GetId() {
 		transferLeader := newTransferLeaderOperator(region.GetId(), region.Leader, newPeer)
-		return newRegionOperator(region, addPeer, transferLeader, removePeer)
+		return newRegionOperator(region, regionKind, addPeer, transferLeader, removePeer)
 	}
-	return newRegionOperator(region, addPeer, removePeer)
+	return newRegionOperator(region, regionKind, addPeer, removePeer)
 }
 
 func newTransferLeader(region *regionInfo, newLeader *metapb.Peer) Operator {
 	transferLeader := newTransferLeaderOperator(region.GetId(), region.Leader, newLeader)
-	return newRegionOperator(region, transferLeader)
+	return newRegionOperator(region, leaderKind, transferLeader)
 }
 
 // scheduleAddPeer schedules a new peer.

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -244,8 +244,8 @@ func newAddPeer(region *regionInfo, peer *metapb.Peer) Operator {
 func newRemovePeer(region *regionInfo, peer *metapb.Peer) Operator {
 	removePeer := newRemovePeerOperator(region.GetId(), peer)
 	if region.Leader != nil && region.Leader.GetId() == peer.GetId() {
-		if followers := region.GetFollowers(); len(followers) > 0 {
-			transferLeader := newTransferLeaderOperator(region.GetId(), region.Leader, followers[0])
+		if follower := region.GetFollower(); follower != nil {
+			transferLeader := newTransferLeaderOperator(region.GetId(), region.Leader, follower)
 			return newRegionOperator(region, regionKind, transferLeader, removePeer)
 		}
 		return nil
@@ -258,8 +258,8 @@ func newTransferPeer(region *regionInfo, oldPeer, newPeer *metapb.Peer) Operator
 	removePeer := newRemovePeerOperator(region.GetId(), oldPeer)
 	if region.Leader != nil && region.Leader.GetId() == oldPeer.GetId() {
 		newLeader := newPeer
-		if followers := region.GetFollowers(); len(followers) > 0 {
-			newLeader = followers[0]
+		if follower := region.GetFollower(); follower != nil {
+			newLeader = follower
 		}
 		transferLeader := newTransferLeaderOperator(region.GetId(), region.Leader, newLeader)
 		return newRegionOperator(region, regionKind, addPeer, transferLeader, removePeer)

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -243,6 +243,15 @@ func newAddPeer(region *regionInfo, peer *metapb.Peer) Operator {
 
 func newRemovePeer(region *regionInfo, peer *metapb.Peer) Operator {
 	removePeer := newRemovePeerOperator(region.GetId(), peer)
+	if region.Leader != nil && region.Leader.GetId() == peer.GetId() {
+		for _, newLeader := range region.Peers {
+			if newLeader.GetId() != region.Leader.GetId() {
+				transferLeader := newTransferLeaderOperator(region.GetId(), region.Leader, newLeader)
+				return newRegionOperator(region, regionKind, transferLeader, removePeer)
+			}
+		}
+		return nil
+	}
 	return newRegionOperator(region, regionKind, removePeer)
 }
 


### PR DESCRIPTION
Fix #579 
Avoid removing a peer when it is the leader:
When move a leader peer, [add B, remove A] becomes [add  B, transfer A to B, remove A].
When remove a leader peer, [remove A] becomes [transfer A to B, remove A].