### PR TITLE
pkg: no use system ports

### DIFF
--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -18,7 +18,7 @@ import (
 	"sync/atomic"
 )
 
-var unixURLCount uint64
+var unixURLCount uint64 = 1024
 
 // UnixURL returns a unique unix socket url, used for test only.
 func UnixURL() string {


### PR DESCRIPTION
the test will block in some situation because unix schema will convert to http schema and the port seems not work when etcd server start. now use port number exclude system ports.
PTAL @andelf @disksing @siddontang 