### PR TITLE
docs(README): update pd-server startup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ you can let PD listen on the host IP.
 # Set correct HostIP here. 
 export HostIP="192.168.199.105"
 
-pd-server --cluster-id=1 \
-          --name="pd" \
+pd-server --name="pd" \
+          --data-dir="pd" \
           --client-urls="http://${HostIP}:2379" \
-          --peer-urls="http://${HostIP}:2380"
+          --peer-urls="http://${HostIP}:2380" \
+          --log-file=pd.log
 ```
 
 Using `curl` to see PD member:
@@ -90,12 +91,13 @@ Run a single node with Docker:
 export HostIP="192.168.199.105"
 
 docker run -d -p 2379:2379 -p 2380:2380 --name pd pingcap/pd \
-          --cluster-id=1 \
           --name="pd" \
+          --data-dir="pd" \
           --client-urls="http://0.0.0.0:2379" \
           --advertise-client-urls="http://${HostIP}:2379" \
           --peer-urls="http://0.0.0.0:2380" \
-          --advertise-peer-urls="http://${HostIP}:2380"
+          --advertise-peer-urls="http://${HostIP}:2380" \
+          --log-file=pd.log
 ```
 
 ### Cluster


### PR DESCRIPTION
remove `cluster-id` as it has been removed and will cause pd-server fail to start,
and add `data-dir` & `log-file` which will be helpful