### PR TITLE
balance hot regions by peer && by leader

### DIFF
--- a/server/balancer.go
+++ b/server/balancer.go
@@ -30,11 +30,12 @@ const (
 	bootstrapBalanceDiff  = 2
 )
 
+// BalanceType : the perspective of balance
 type BalanceType int
 
 const (
-	ByPeer BalanceType = iota
-	ByLeader
+	byPeer BalanceType = iota
+	byLeader
 )
 
 // minBalanceDiff returns the minimal diff to do balance. The formula is based
@@ -567,7 +568,7 @@ func (h *balanceHotRegionScheduler) balanceByPeer(cluster *clusterInfo) (*Region
 		destStoreID = h.selectDestStoreByPeer(destStoreIDs, srcRegion, srcStoreID)
 		if destStoreID != 0 {
 			srcRegion.WrittenBytes = rs.WrittenBytes
-			h.adjustBalanceLimit(srcStoreID, ByPeer)
+			h.adjustBalanceLimit(srcStoreID, byPeer)
 
 			var srcPeer *metapb.Peer
 			for _, peer := range srcRegion.GetPeers() {
@@ -629,10 +630,10 @@ func (h *balanceHotRegionScheduler) adjustBalanceLimit(storeID uint64, t Balance
 	var srcStatistics *HotRegionsStat
 	var allStatistics map[uint64]*HotRegionsStat
 	switch t {
-	case ByPeer:
+	case byPeer:
 		srcStatistics = h.statisticsAsPeer[storeID]
 		allStatistics = h.statisticsAsPeer
-	case ByLeader:
+	case byLeader:
 		srcStatistics = h.statisticsAsLeader[storeID]
 		allStatistics = h.statisticsAsLeader
 	}
@@ -687,7 +688,7 @@ func (h *balanceHotRegionScheduler) balanceByLeader(cluster *clusterInfo) (*Regi
 
 		destPeer := h.selectDestStoreByLeader(srcRegion)
 		if destPeer != nil {
-			h.adjustBalanceLimit(srcStoreID, ByLeader)
+			h.adjustBalanceLimit(srcStoreID, byLeader)
 			return srcRegion, destPeer
 		}
 	}
@@ -725,6 +726,7 @@ func (h *balanceHotRegionScheduler) selectDestStoreByLeader(srcRegion *RegionInf
 	return destPeer
 }
 
+// StoreHotRegionInfos : used to get human readable description for hot regions.
 type StoreHotRegionInfos struct {
 	AsPeer   map[uint64]*HotRegionsStat `json:"as_peer"`
 	AsLeader map[uint64]*HotRegionsStat `json:"as_leader"`

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -397,12 +397,12 @@ func (m RegionsStat) Less(i, j int) bool { return m[i].WrittenBytes < m[j].Writt
 
 // StoreHotRegions records all hot regions in one store with sequence
 type StoreHotRegions struct {
-	// Hot regions in this store as the role of Leader
+	// Hot regions in this store as the role of leader
 	WrittenBytesAsLeader uint64      `json:"total_written_bytes_as_leader"`
 	RegionsCountAsLeader int         `json:"regions_count_as_leader"`
 	RegionsStatAsLeader  RegionsStat `json:"statistics_as_leader"`
 
-	// Hot regions in this store as the role of Follower or Follower
+	// Hot regions in this store as the role of replica
 	WrittenBytesAsPeer uint64      `json:"total_written_bytes_as_peer"`
 	RegionsCountAsPeer int         `json:"regions_count_as_peer"`
 	RegionsStatAsPeer  RegionsStat `json:"statistics_as_peer"`

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -470,10 +470,10 @@ func (h *balanceHotRegionScheduler) Schedule(cluster *clusterInfo) Operator {
 	//	return newPriorityTransferPeer(srcRegionMinor, srcPeerMinor, destPeerMinor)
 	//}
 	//
-	//srcRegionMinor, newLeaderMinor := h.balanceByLeader(cluster, minor)
-	//if srcRegionMinor != nil {
-	//	return newPriorityTransferLeader(srcRegionMinor, newLeaderMinor)
-	//}
+	srcRegionMinor, newLeaderMinor := h.balanceByLeader(cluster, minor)
+	if srcRegionMinor != nil {
+		return newPriorityTransferLeader(srcRegionMinor, newLeaderMinor)
+	}
 
 	return nil
 }

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -442,7 +442,7 @@ func (h *balanceHotRegionScheduler) Prepare(cluster *clusterInfo) error { return
 func (h *balanceHotRegionScheduler) Cleanup(cluster *clusterInfo) {}
 
 func (h *balanceHotRegionScheduler) Schedule(cluster *clusterInfo) Operator {
-	h.calculateScores(cluster)
+	h.calcScore(cluster)
 
 	// balance by peer
 	srcRegion, srcPeer, destPeer := h.balanceByPeer(cluster)
@@ -459,9 +459,10 @@ func (h *balanceHotRegionScheduler) Schedule(cluster *clusterInfo) Operator {
 	return nil
 }
 
-func (h *balanceHotRegionScheduler) calculateScores(cluster *clusterInfo) {
+func (h *balanceHotRegionScheduler) calcScore(cluster *clusterInfo) {
 	h.Lock()
 	defer h.Unlock()
+
 	h.scoreStatus = make(map[uint64]*StoreHotRegions)
 	items := cluster.writeStatistics.elems()
 	for _, item := range items {

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -407,12 +407,12 @@ type StoreHotRegions struct {
 	// Hot regions in this store as the role of Leader
 	WrittenBytesAsLeader uint64      `json:"total_written_bytes_as_leader"`
 	RegionsCountAsLeader int         `json:"regions_count_as_leader"`
-	RegionsStatAsLeader  RegionsStat `json:"statistics_as_leader"`
+	RegionsStatAsLeader  RegionsStat
 
 	// Hot regions in this store as the role of Follower or Follower
 	WrittenBytesAsPeer uint64      `json:"total_written_bytes_as_peer"`
 	RegionsCountAsPeer int         `json:"regions_count_as_peer"`
-	RegionsStatAsPeer  RegionsStat `json:"statistics_as_peer"`
+	RegionsStatAsPeer  RegionsStat
 }
 
 type balanceHotRegionScheduler struct {

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -482,11 +482,11 @@ func (h *balanceHotRegionScheduler) calculateScores(cluster *clusterInfo) {
 	h.Lock()
 	defer h.Unlock()
 
-	h.calculateScoresImpl(cluster, major)
-	h.calculateScoresImpl(cluster, minor)
+	h.calculateScoresImpl(cluster, major, majorHotRegionDegreeLowThreshold)
+	h.calculateScoresImpl(cluster, minor, minorHotRegionDegreeLowThreshold)
 }
 
-func (h *balanceHotRegionScheduler) calculateScoresImpl(cluster *clusterInfo, t HotRegionType) {
+func (h *balanceHotRegionScheduler) calculateScoresImpl(cluster *clusterInfo, t HotRegionType, degreeThreshold int) {
 	scoreStatus := make(map[uint64]*StoreHotRegions)
 	var items []*cacheItem
 	switch t {
@@ -503,7 +503,7 @@ func (h *balanceHotRegionScheduler) calculateScoresImpl(cluster *clusterInfo, t 
 		if !ok {
 			continue
 		}
-		if r.HotDegree < hotRegionLowThreshold {
+		if r.HotDegree < degreeThreshold {
 			continue
 		}
 

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -22,7 +22,6 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/montanaflynn/stats"
 	"github.com/pingcap/kvproto/pkg/metapb"
-	"github.com/pingcap/tidb/statistics"
 )
 
 const (

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -464,16 +464,16 @@ func (h *balanceHotRegionScheduler) Schedule(cluster *clusterInfo) Operator {
 		return newPriorityTransferLeader(srcRegionMajor, newLeaderMajor)
 	}
 
-	// balance minor hot regions
-	srcRegionMinor, srcPeerMinor, destPeerMinor := h.balanceByPeer(cluster, minor)
-	if srcRegionMinor != nil {
-		return newPriorityTransferPeer(srcRegionMinor, srcPeerMinor, destPeerMinor)
-	}
-
-	srcRegionMinor, newLeaderMinor := h.balanceByLeader(cluster, minor)
-	if srcRegionMinor != nil {
-		return newPriorityTransferLeader(srcRegionMinor, newLeaderMinor)
-	}
+	//// balance minor hot regions
+	//srcRegionMinor, srcPeerMinor, destPeerMinor := h.balanceByPeer(cluster, minor)
+	//if srcRegionMinor != nil {
+	//	return newPriorityTransferPeer(srcRegionMinor, srcPeerMinor, destPeerMinor)
+	//}
+	//
+	//srcRegionMinor, newLeaderMinor := h.balanceByLeader(cluster, minor)
+	//if srcRegionMinor != nil {
+	//	return newPriorityTransferLeader(srcRegionMinor, newLeaderMinor)
+	//}
 
 	return nil
 }

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -805,7 +805,7 @@ func (s *testBalanceHotRegionSchedulerSuite) TestBalance(c *C) {
 	// for test follow just 1 peer here
 	tc.addLeaderRegionWithWriteInfo(2, 1, 419115*regionHeartBeatReportInterval, 2)
 	tc.addLeaderRegionWithWriteInfo(3, 1, 0, 2, 3)
-	majorHotRegionDegreeLowThreshold = 0
+	hotRegionLowThreshold = 0
 	checkTransferLeader(c, hb.Schedule(cluster), 1, 2)
 
 	// add 2 region , total 5 region

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -815,7 +815,7 @@ func (s *testBalanceHotRegionSchedulerSuite) TestBalance(c *C) {
 	// Region 1, 2 and 3 are hot regions.
 	//| region_id | leader_sotre | follower_store | follower_store | written_bytes |
 	//|-----------|--------------|----------------|----------------|---------------|
-	//|     1     |       1      |        2       |       3        |      256KB    |
+	//|     1     |       1      |        2       |       3        |      512KB    |
 	//|     2     |       1      |        3       |       4        |      512KB    |
 	//|     3     |       1      |        2       |       4        |      512KB    |
 	tc.addLeaderRegionWithWriteInfo(1, 1, 512*1024*regionHeartBeatReportInterval, 2, 3)
@@ -827,15 +827,20 @@ func (s *testBalanceHotRegionSchedulerSuite) TestBalance(c *C) {
 	// which is hot for store 1 is more larger than other stores.
 	checkTransferPeer(c, hb.Schedule(cluster), 1, 5)
 
-	// After transfer a hot region from store 1 to store 4, update store written
-	// bytes and written bytes.
+	// After transfer a hot region from store 1 to store 5
+	//| region_id | leader_sotre | follower_store | follower_store | written_bytes |
+	//|-----------|--------------|----------------|----------------|---------------|
+	//|     1     |       1      |        2       |       3        |      512KB    |
+	//|     2     |       1      |        3       |       4        |      512KB    |
+	//|     3     |       5      |        2       |       4        |      512KB    |
 	tc.updateStorageWrittenBytes(1, 60*1024*1024)
 	tc.updateStorageWrittenBytes(2, 30*1024*1024)
 	tc.updateStorageWrittenBytes(3, 60*1024*1024)
 	tc.updateStorageWrittenBytes(4, 30*1024*1024)
-	tc.addLeaderRegionWithWriteInfo(1, 1, 512*1024*regionHeartBeatReportInterval, 2, 4)
-	tc.addLeaderRegionWithWriteInfo(2, 1, 512*1024*regionHeartBeatReportInterval, 2, 3)
-	tc.addLeaderRegionWithWriteInfo(3, 1, 512*1024*regionHeartBeatReportInterval, 2, 3)
+	tc.updateStorageWrittenBytes(5, 30*1024*1024)
+	tc.addLeaderRegionWithWriteInfo(1, 1, 512*1024*regionHeartBeatReportInterval, 2, 3)
+	tc.addLeaderRegionWithWriteInfo(2, 1, 512*1024*regionHeartBeatReportInterval, 3, 4)
+	tc.addLeaderRegionWithWriteInfo(3, 5, 512*1024*regionHeartBeatReportInterval, 2, 4)
 
 	// We can find that the leader of all hot regions are on store 1,
 	// so one of the leader will transfer to another store.

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -818,7 +818,7 @@ func (s *testBalanceHotRegionSchedulerSuite) TestBalance(c *C) {
 	//|     1     |       1      |        2       |       3        |      256KB    |
 	//|     2     |       1      |        3       |       4        |      512KB    |
 	//|     3     |       1      |        2       |       4        |      512KB    |
-	tc.addLeaderRegionWithWriteInfo(1, 1, 256*1024*regionHeartBeatReportInterval, 2, 3)
+	tc.addLeaderRegionWithWriteInfo(1, 1, 512*1024*regionHeartBeatReportInterval, 2, 3)
 	tc.addLeaderRegionWithWriteInfo(2, 1, 512*1024*regionHeartBeatReportInterval, 3, 4)
 	tc.addLeaderRegionWithWriteInfo(3, 1, 512*1024*regionHeartBeatReportInterval, 2, 4)
 	hotRegionLowThreshold = 0
@@ -835,7 +835,7 @@ func (s *testBalanceHotRegionSchedulerSuite) TestBalance(c *C) {
 	tc.updateStorageWrittenBytes(4, 30*1024*1024)
 	tc.addLeaderRegionWithWriteInfo(1, 1, 512*1024*regionHeartBeatReportInterval, 2, 4)
 	tc.addLeaderRegionWithWriteInfo(2, 1, 512*1024*regionHeartBeatReportInterval, 2, 3)
-	tc.addLeaderRegionWithWriteInfo(3, 1, 0, 2, 3)
+	tc.addLeaderRegionWithWriteInfo(3, 1, 512*1024*regionHeartBeatReportInterval, 2, 3)
 
 	// We can find that the leader of all hot regions are on store 1,
 	// so one of the leader will transfer to another store.

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -775,6 +775,18 @@ func checkTransferLeader(c *C, bop Operator, sourceID, targetID uint64) {
 	c.Assert(op.NewLeader.GetStoreId(), Equals, targetID)
 }
 
+func checkTransferLeaderFrom(c *C, bop Operator, sourceID uint64) {
+	var op *transferLeaderOperator
+	switch t := bop.(type) {
+	case *transferLeaderOperator:
+		op = t
+	case *regionOperator:
+		op = t.Ops[0].(*transferLeaderOperator)
+	}
+	c.Assert(op, NotNil)
+	c.Assert(op.OldLeader.GetStoreId(), Equals, sourceID)
+}
+
 var _ = Suite(&testBalanceHotRegionSchedulerSuite{})
 
 type testBalanceHotRegionSchedulerSuite struct{}
@@ -785,86 +797,40 @@ func (s *testBalanceHotRegionSchedulerSuite) TestBalance(c *C) {
 
 	_, opt := newTestScheduleConfig()
 	hb := newBalanceHotRegionScheduler(opt)
-	// Add stores 1,2,3,4
+
+	// Add stores 1, 2, 3, 4 with region counts 3, 3, 3, 0.
 	tc.addRegionStore(1, 3)
 	tc.addRegionStore(2, 3)
 	tc.addRegionStore(3, 3)
 	tc.addRegionStore(4, 0)
-	tc.updateStorageWrittenBytes(1, 165062213)
-	tc.updateStorageWrittenBytes(2, 0)
-	tc.updateStorageWrittenBytes(3, 0)
 
-	// Add 3 regions
-	//| region_id | leader_sotre | follower_store | follower_store | written_bytes |
-	//|-----------|--------------|----------------|----------------|---------------|
-	//|     1     |       1      |        2       |       3        |     479516    |
-	//|     2     |       1      |        2       |       -        |     418115    |
-	//|     3     |       1      |        2       |       3        |       0       |
+	// Report store written bytes.
+	tc.updateStorageWrittenBytes(1, 60*1024*1024)
+	tc.updateStorageWrittenBytes(2, 61*1024*1024)
+	tc.updateStorageWrittenBytes(3, 60*1024*1024)
+	tc.updateStorageWrittenBytes(4, 0)
 
-	tc.addLeaderRegionWithWriteInfo(1, 1, 479516*regionHeartBeatReportInterval, 2, 3)
-	// for test follow just 1 peer here
-	tc.addLeaderRegionWithWriteInfo(2, 1, 419115*regionHeartBeatReportInterval, 2)
+	// Region 1 and 2 are hot regions, region 3 is not.
+	tc.addLeaderRegionWithWriteInfo(1, 1, 512*1024*regionHeartBeatReportInterval, 2, 3)
+	tc.addLeaderRegionWithWriteInfo(2, 1, 512*1024*regionHeartBeatReportInterval, 2, 3)
 	tc.addLeaderRegionWithWriteInfo(3, 1, 0, 2, 3)
 	hotRegionLowThreshold = 0
-	checkTransferLeader(c, hb.Schedule(cluster), 1, 2)
 
-	// add 2 region , total 5 region
-	//| region_id | leader_sotre | follower_store | follower_store | written_bytes |
-	//|-----------|--------------|----------------|----------------|---------------|
-	//|     1     |       1      |        2       |       3        |     479516    |
-	//|     2     |       1      |        2       |       -        |     418115    |
-	//|     3     |       1      |        2       |       3        |       0       |
-	//|     4     |       2      |        1       |       3        |     115451    |
-	//|     5     |       3      |        1       |       2        |     120314    |
+	// Will transfer a hot regions from store 2 to store 4, because store 2 has the
+	// largest written bytes.
+	checkTransferPeer(c, hb.Schedule(cluster), 2, 4)
 
-	tc.updateStorageWrittenBytes(2, 890345153)
-	tc.updateStorageWrittenBytes(3, 1090345153)
-	tc.addLeaderRegionWithWriteInfo(4, 2, 115451*regionHeartBeatReportInterval, 1, 3)
-	tc.addLeaderRegionWithWriteInfo(5, 3, 120314*regionHeartBeatReportInterval, 1, 2)
-	checkTransferPeer(c, hb.Schedule(cluster), 1, 4)
+	// After transfer a hot region from store 1 to store 4, update store written
+	// bytes and written bytes.
+	tc.updateStorageWrittenBytes(1, 60*1024*1024)
+	tc.updateStorageWrittenBytes(2, 30*1024*1024)
+	tc.updateStorageWrittenBytes(3, 60*1024*1024)
+	tc.updateStorageWrittenBytes(4, 30*1024*1024)
+	tc.addLeaderRegionWithWriteInfo(1, 1, 512*1024*regionHeartBeatReportInterval, 2, 4)
+	tc.addLeaderRegionWithWriteInfo(2, 1, 512*1024*regionHeartBeatReportInterval, 2, 3)
+	tc.addLeaderRegionWithWriteInfo(3, 1, 0, 2, 3)
 
-	// Test calculateScore.
-	// hot region in store like
-	//| store_id | hot_region_numbers |
-	//|----------|--------------------|
-	//|     1    |          2         |
-	//|     2    |          1         |
-	//|     3    |          1         |
-
-	expect := []struct {
-		streID          int
-		hotRegionNumber int
-	}{
-		{1, 2},
-		{2, 1},
-		{3, 1},
-	}
-	hb.calculateScore(tc.clusterInfo)
-	for _, e := range expect {
-		c.Assert(hb.scoreStatus[uint64(e.streID)].RegionCount, Equals, e.hotRegionNumber)
-	}
-
-	// Test adjustLimit
-	// add 3 regions, and add 2 store. then total 7 regions
-	// hot region in store like
-	//| store_id | hot_region_numbers |
-	//|----------|--------------------|
-	//|     1    |          7         |
-	//|     2    |          1         |
-	//|     3    |          1         |
-
-	tc.addRegionStore(5, 0)
-	tc.addRegionStore(6, 0)
-	tc.addLeaderRegionWithWriteInfo(6, 1, 122451*regionHeartBeatReportInterval, 2, 3)
-	tc.addLeaderRegionWithWriteInfo(7, 1, 120314*regionHeartBeatReportInterval, 2, 3)
-	tc.addLeaderRegionWithWriteInfo(8, 1, 122154*regionHeartBeatReportInterval, 2, 3)
-	tc.addLeaderRegionWithWriteInfo(9, 1, 122345*regionHeartBeatReportInterval, 2, 3)
-	tc.addLeaderRegionWithWriteInfo(10, 1, 132254*regionHeartBeatReportInterval, 2, 3)
-	hb.calculateScore(tc.clusterInfo)
-
-	// Select a source region and will ajust limit according to source
-	r := hb.SelectSourceRegion(tc.clusterInfo)
-	c.Assert(r.Leader.GetStoreId(), Equals, uint64(1))
-	// limit = ( 7- 9/3)*0.75
-	c.Assert(hb.limit, Equals, uint64(3))
+	// We can find that the leader of hot region 1 and hot region 2 are both on store 1,
+	// so one of the leader will transfer to another store.
+	checkTransferLeaderFrom(c, hb.Schedule(cluster), 1)
 }

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -841,7 +841,7 @@ func (s *testBalanceHotRegionSchedulerSuite) TestBalance(c *C) {
 	}
 	hb.calculateScore(tc.clusterInfo)
 	for _, e := range expect {
-		c.Assert(hb.scoreStatus[uint64(e.streID)].RegionCount, Equals, e.hotRegionNumber)
+		c.Assert(hb.majorScoreStatus[uint64(e.streID)].RegionCount, Equals, e.hotRegionNumber)
 	}
 
 	// Test adjustLimit

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -805,7 +805,7 @@ func (s *testBalanceHotRegionSchedulerSuite) TestBalance(c *C) {
 	// for test follow just 1 peer here
 	tc.addLeaderRegionWithWriteInfo(2, 1, 419115*regionHeartBeatReportInterval, 2)
 	tc.addLeaderRegionWithWriteInfo(3, 1, 0, 2, 3)
-	hotRegionLowThreshold = 0
+	majorHotRegionDegreeLowThreshold = 0
 	checkTransferLeader(c, hb.Schedule(cluster), 1, 2)
 
 	// add 2 region , total 5 region

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -841,7 +841,7 @@ func (s *testBalanceHotRegionSchedulerSuite) TestBalance(c *C) {
 	}
 	hb.calculateScore(tc.clusterInfo)
 	for _, e := range expect {
-		c.Assert(hb.majorScoreStatus[uint64(e.streID)].RegionCount, Equals, e.hotRegionNumber)
+		c.Assert(hb.scoreStatus[uint64(e.streID)].RegionCount, Equals, e.hotRegionNumber)
 	}
 
 	// Test adjustLimit

--- a/server/cache.go
+++ b/server/cache.go
@@ -790,5 +790,9 @@ func (c *clusterInfo) updateWriteStatus(region *RegionInfo) {
 	if majorHotRegionThreshold < majorHotRegionMinWriteRate {
 		majorHotRegionThreshold = majorHotRegionMinWriteRate
 	}
-	c.updateWriteStatCache(region, majorHotRegionThreshold, minorHotRegionMinWriteRate)
+	minorHotRegionThreshold := majorHotRegionThreshold / 16
+	if minorHotRegionThreshold < minorHotRegionMinWriteRate {
+		minorHotRegionThreshold = minorHotRegionMinWriteRate
+	}
+	c.updateWriteStatCache(region, majorHotRegionThreshold, minorHotRegionThreshold)
 }

--- a/server/cache.go
+++ b/server/cache.go
@@ -790,7 +790,7 @@ func (c *clusterInfo) updateWriteStatus(region *RegionInfo) {
 	if majorHotRegionThreshold < majorHotRegionMinWriteRate {
 		majorHotRegionThreshold = majorHotRegionMinWriteRate
 	}
-	minorHotRegionThreshold := majorHotRegionThreshold / 4
+	minorHotRegionThreshold := majorHotRegionThreshold / 8
 	if minorHotRegionThreshold < minorHotRegionMinWriteRate {
 		minorHotRegionThreshold = minorHotRegionMinWriteRate
 	}

--- a/server/cache.go
+++ b/server/cache.go
@@ -344,7 +344,7 @@ func newClusterInfo(id IDAllocator) *clusterInfo {
 		stores:               newStoresInfo(),
 		regions:              newRegionsInfo(),
 		majorWriteStatistics: newLRUCache(writeStatLRUMaxLen),
-		minorWriteStatistics: newLRUCache(writeStatLRUMaxLen),
+		minorWriteStatistics: newLRUCache(writeStatLRUMaxLen * 8),
 	}
 }
 

--- a/server/cache.go
+++ b/server/cache.go
@@ -790,7 +790,7 @@ func (c *clusterInfo) updateWriteStatus(region *RegionInfo) {
 	if majorHotRegionThreshold < majorHotRegionMinWriteRate {
 		majorHotRegionThreshold = majorHotRegionMinWriteRate
 	}
-	minorHotRegionThreshold := majorHotRegionThreshold / 16
+	minorHotRegionThreshold := majorHotRegionThreshold / 4
 	if minorHotRegionThreshold < minorHotRegionMinWriteRate {
 		minorHotRegionThreshold = minorHotRegionMinWriteRate
 	}

--- a/server/cache.go
+++ b/server/cache.go
@@ -790,9 +790,5 @@ func (c *clusterInfo) updateWriteStatus(region *RegionInfo) {
 	if majorHotRegionThreshold < majorHotRegionMinWriteRate {
 		majorHotRegionThreshold = majorHotRegionMinWriteRate
 	}
-	minorHotRegionThreshold := majorHotRegionThreshold / 8
-	if minorHotRegionThreshold < minorHotRegionMinWriteRate {
-		minorHotRegionThreshold = minorHotRegionMinWriteRate
-	}
-	c.updateWriteStatCache(region, majorHotRegionThreshold, minorHotRegionThreshold)
+	c.updateWriteStatCache(region, majorHotRegionThreshold, minorHotRegionMinWriteRate)
 }

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -48,7 +48,8 @@ const (
 )
 
 var (
-	hotRegionLowThreshold = 3
+	majorHotRegionDegreeLowThreshold = 3
+	minorHotRegionDegreeLowThreshold = 5
 	errSchedulerExisted   = errors.New("scheduler existed")
 	errSchedulerNotFound  = errors.New("scheduler not found")
 )

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -137,7 +137,7 @@ func (c *coordinator) stop() {
 	c.wg.Wait()
 }
 
-func (c *coordinator) getHotWriteRegions() map[uint64]*StoreHotRegions {
+func (c *coordinator) getHotWriteRegions() StoreHotRegionInfos {
 	c.RLock()
 	defer c.RUnlock()
 	s, ok := c.schedulers[hotRegionScheduleName]

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -38,7 +38,8 @@ const (
 	storeHotRegionsDefaultLen     = 100
 	hotRegionLimitFactor          = 0.75
 	hotRegionScheduleFactor       = 0.9
-	hotRegionMinWriteRate         = 16 * 1024
+	majorHotRegionMinWriteRate    = 16 * 1024
+	minorHotRegionMinWriteRate    = 1 * 1024
 	regionHeartBeatReportInterval = 60
 	storeHeartBeatReportInterval  = 10
 	minHotRegionReportInterval    = 3

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -39,7 +39,7 @@ const (
 	hotRegionLimitFactor          = 0.75
 	hotRegionScheduleFactor       = 0.9
 	majorHotRegionMinWriteRate    = 16 * 1024
-	minorHotRegionMinWriteRate    = 4 * 1024
+	minorHotRegionMinWriteRate    = 2 * 1024
 	regionHeartBeatReportInterval = 60
 	storeHeartBeatReportInterval  = 10
 	minHotRegionReportInterval    = 3

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -39,7 +39,7 @@ const (
 	hotRegionLimitFactor          = 0.75
 	hotRegionScheduleFactor       = 0.9
 	majorHotRegionMinWriteRate    = 16 * 1024
-	minorHotRegionMinWriteRate    = 2 * 1024
+	minorHotRegionMinWriteRate    = 3 * 1024
 	regionHeartBeatReportInterval = 60
 	storeHeartBeatReportInterval  = 10
 	minHotRegionReportInterval    = 3

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -137,7 +137,7 @@ func (c *coordinator) stop() {
 	c.wg.Wait()
 }
 
-func (c *coordinator) getHotWriteRegions() StoreHotRegionInfos {
+func (c *coordinator) getHotWriteRegions() *StoreHotRegionInfos {
 	c.RLock()
 	defer c.RUnlock()
 	s, ok := c.schedulers[hotRegionScheduleName]

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -183,13 +183,21 @@ func (c *coordinator) collectHotSpotMetrics() {
 		return
 	}
 	status := s.Scheduler.(*balanceHotRegionScheduler).GetStatus()
-	for storeID, stat := range status {
+	for storeID, stat := range status.AsPeer {
 		store := fmt.Sprintf("store_%d", storeID)
-		totalWriteBytes := float64(stat.TotalWrittenBytes)
-		hotWriteRegionCount := float64(stat.RegionCount)
+		totalWriteBytes := float64(stat.WrittenBytes)
+		hotWriteRegionCount := float64(stat.RegionsCount)
 
-		hotSpotStatusGauge.WithLabelValues(store, "total_written_bytes").Set(totalWriteBytes)
-		hotSpotStatusGauge.WithLabelValues(store, "hot_write_region").Set(hotWriteRegionCount)
+		hotSpotStatusGauge.WithLabelValues(store, "total_written_bytes_as_peer").Set(totalWriteBytes)
+		hotSpotStatusGauge.WithLabelValues(store, "hot_write_region_as_peer").Set(hotWriteRegionCount)
+	}
+	for storeID, stat := range status.AsLeader {
+		store := fmt.Sprintf("store_%d", storeID)
+		totalWriteBytes := float64(stat.WrittenBytes)
+		hotWriteRegionCount := float64(stat.RegionsCount)
+
+		hotSpotStatusGauge.WithLabelValues(store, "total_written_bytes_as_leader").Set(totalWriteBytes)
+		hotSpotStatusGauge.WithLabelValues(store, "hot_write_region_as_leader").Set(hotWriteRegionCount)
 	}
 }
 

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -38,8 +38,7 @@ const (
 	storeHotRegionsDefaultLen     = 100
 	hotRegionLimitFactor          = 0.75
 	hotRegionScheduleFactor       = 0.9
-	majorHotRegionMinWriteRate    = 16 * 1024
-	minorHotRegionMinWriteRate    = 3 * 1024
+	hotRegionMinWriteRate         = 16 * 1024
 	regionHeartBeatReportInterval = 60
 	storeHeartBeatReportInterval  = 10
 	minHotRegionReportInterval    = 3
@@ -48,8 +47,7 @@ const (
 )
 
 var (
-	majorHotRegionDegreeLowThreshold = 3
-	minorHotRegionDegreeLowThreshold = 5
+	hotRegionLowThreshold = 3
 	errSchedulerExisted   = errors.New("scheduler existed")
 	errSchedulerNotFound  = errors.New("scheduler not found")
 )

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -39,7 +39,7 @@ const (
 	hotRegionLimitFactor          = 0.75
 	hotRegionScheduleFactor       = 0.9
 	majorHotRegionMinWriteRate    = 16 * 1024
-	minorHotRegionMinWriteRate    = 1 * 1024
+	minorHotRegionMinWriteRate    = 4 * 1024
 	regionHeartBeatReportInterval = 60
 	storeHeartBeatReportInterval  = 10
 	minHotRegionReportInterval    = 3

--- a/server/handler.go
+++ b/server/handler.go
@@ -48,7 +48,7 @@ func (h *Handler) GetSchedulers() ([]string, error) {
 }
 
 // GetHotWriteRegions gets all hot regions status
-func (h *Handler) GetHotWriteRegions() map[uint64]*StoreHotRegions {
+func (h *Handler) GetHotWriteRegions() *StoreHotRegionInfos {
 	c, err := h.getCoordinator()
 	if err != nil {
 		return nil


### PR DESCRIPTION
We just consider the leader when do "hot regions" balance,  this will lead to a bad situation that a store contains many hot regions’ peer, and TiKV nodes load various from each other.
@nolouch @disksing @siddontang PTAL