### PR TITLE
server: offline checker directly remove extra peer

### DIFF
--- a/server/balancer.go
+++ b/server/balancer.go
@@ -348,6 +348,12 @@ func (r *replicaChecker) checkOfflinePeer(region *RegionInfo) Operator {
 		if store.isUp() {
 			continue
 		}
+
+		// check the number of replicas firstly
+		if len(region.GetPeers()) > r.opt.GetMaxReplicas() {
+			return newRemovePeer(region, peer)
+		}
+
 		newPeer, _ := r.selectBestPeer(region)
 		if newPeer == nil {
 			return nil

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -592,10 +592,15 @@ func (s *testReplicaCheckerSuite) TestOffline(c *C) {
 	c.Assert(rc.Check(region), IsNil)
 	tc.setStoreBusy(4, false)
 	checkRemovePeer(c, rc.Check(region), 4)
-	region.RemoveStorePeer(4)
 
-	// Transfer peer to store 4.
+	// Test offline
+	// the number of region peers more than the maxReplicas
+	// remove the peer
 	tc.setStoreOffline(3)
+	checkRemovePeer(c, rc.Check(region), 3)
+	region.RemoveStorePeer(4)
+	// the number of region peers equals the maxReplicas
+	// Transfer peer to store 4.
 	checkTransferPeer(c, rc.Check(region), 3, 4)
 
 	// Store 5 has a different zone, we can keep it safe.

--- a/server/operator.go
+++ b/server/operator.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	maxOperatorWaitTime = 3 * time.Minute
+	maxOperatorWaitTime = 5 * time.Minute
 )
 
 // Operator is an interface to schedule region.


### PR DESCRIPTION
when we offline one store,  the scheduler will do the operator {add peer in another health store, remove peer in the offline store}. if operator timeout and just finish add peer, we will remove this operator and new an operator {add peer, remove peer}.Which cause the loop add a peer. we need to check the number of the peers and remove directly extra peer in the offline store.