### PR TITLE
pkg: use iec size for ByteSize

### DIFF
--- a/pkg/typeutil/size.go
+++ b/pkg/typeutil/size.go
@@ -25,7 +25,7 @@ type ByteSize uint64
 
 // MarshalJSON returns the size as a JSON string.
 func (b ByteSize) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + gh.Bytes(uint64(b)) + `"`), nil
+	return []byte(`"` + gh.IBytes(uint64(b)) + `"`), nil
 }
 
 // UnmarshalJSON parses a JSON string into the bytesize.


### PR DESCRIPTION
use iec size, will marshal to "B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB".
PTAL @disksing @siddontang 