### PR TITLE
balance: prevent access nil store when recovering cluster

### DIFF
--- a/server/balancer.go
+++ b/server/balancer.go
@@ -330,6 +330,9 @@ func (r *replicaChecker) checkDownPeer(region *RegionInfo) Operator {
 			continue
 		}
 		store := r.cluster.getStore(peer.GetStoreId())
+		if store == nil {
+			return nil
+		}
 		if store.downTime() < r.opt.GetMaxStoreDownTime() {
 			continue
 		}
@@ -344,6 +347,9 @@ func (r *replicaChecker) checkDownPeer(region *RegionInfo) Operator {
 func (r *replicaChecker) checkOfflinePeer(region *RegionInfo) Operator {
 	for _, peer := range region.GetPeers() {
 		store := r.cluster.getStore(peer.GetStoreId())
+		if store == nil {
+			return nil
+		}
 		if store.isUp() {
 			continue
 		}

--- a/server/balancer.go
+++ b/server/balancer.go
@@ -331,6 +331,7 @@ func (r *replicaChecker) checkDownPeer(region *RegionInfo) Operator {
 		}
 		store := r.cluster.getStore(peer.GetStoreId())
 		if store == nil {
+			log.Infof("lost the store %d,maybe you are recovering the PD cluster.", peer.GetStoreId())
 			return nil
 		}
 		if store.downTime() < r.opt.GetMaxStoreDownTime() {
@@ -348,6 +349,7 @@ func (r *replicaChecker) checkOfflinePeer(region *RegionInfo) Operator {
 	for _, peer := range region.GetPeers() {
 		store := r.cluster.getStore(peer.GetStoreId())
 		if store == nil {
+			log.Infof("lost the store %d,maybe you are recovering the PD cluster.", peer.GetStoreId())
 			return nil
 		}
 		if store.isUp() {

--- a/server/balancer_test.go
+++ b/server/balancer_test.go
@@ -555,6 +555,24 @@ func (s *testReplicaCheckerSuite) TestBasic(c *C) {
 	checkTransferPeer(c, rc.Check(region), 3, 1)
 }
 
+func (s *testReplicaCheckerSuite) TestLostStore(c *C) {
+	cluster := newClusterInfo(newMockIDAllocator())
+	tc := newTestClusterInfo(cluster)
+	tc.addRegionStore(1, 1)
+	tc.addRegionStore(2, 1)
+	_, opt := newTestScheduleConfig()
+
+	rc := newReplicaChecker(opt, cluster)
+
+	// now region peer in store 1,2,3.but we just have store 1,2
+	// This happens only in recovering the PD cluster
+	// should not panic
+	tc.addLeaderRegion(1, 1, 2, 3)
+	region := cluster.getRegion(1)
+	op := rc.Check(region)
+	c.Assert(op, IsNil)
+}
+
 func (s *testReplicaCheckerSuite) TestOffline(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)


### PR DESCRIPTION
we may access nil store when recovering cluster. this PR fix it.
PTAL @disksing @siddontang 
