### PR TITLE
test: fix flakey TestParseTimestamp

### DIFF
--- a/server/util_test.go
+++ b/server/util_test.go
@@ -52,7 +52,7 @@ func (s *testUtilSuite) TestParseTimestap(c *C) {
 		data := uint64ToBytes(uint64(t.UnixNano()))
 		nt, err := parseTimestamp(data)
 		c.Assert(err, IsNil)
-		c.Assert(nt, Equals, t)
+		c.Assert(nt.Equal(t), IsTrue)
 	}
 	data := []byte("pd")
 	nt, err := parseTimestamp(data)


### PR DESCRIPTION
`t` and `nt` represent the same time instant, yet are not deep equal. `nt` don't have monotonic clock imformation.

Fix #665 

@siddontang PTAL

Signed-off-by: Cholerae Hu <huyingqian@pingcap.com>