### PR TITLE
server push schedule commands.

### DIFF
--- a/pd-client/client_test.go
+++ b/pd-client/client_test.go
@@ -86,14 +86,13 @@ func (s *testClientSuite) SetUpSuite(c *C) {
 	s.srv, s.cleanup = newServer(c)
 	s.grpcPDClient = mustNewGrpcClient(c, s.srv.GetAddr())
 
-	var err error
-	s.regionHeartbeat, err = s.grpcPDClient.RegionHeartbeat(context.Background())
-	c.Assert(err, IsNil)
-
 	mustWaitLeader(c, map[string]*server.Server{s.srv.GetAddr(): s.srv})
 	bootstrapServer(c, newHeader(s.srv), s.grpcPDClient)
 
+	var err error
 	s.client, err = NewClient(s.srv.GetEndpoints())
+	c.Assert(err, IsNil)
+	s.regionHeartbeat, err = s.grpcPDClient.RegionHeartbeat(context.Background())
 	c.Assert(err, IsNil)
 }
 

--- a/server/cache.go
+++ b/server/cache.go
@@ -391,6 +391,12 @@ func (c *clusterInfo) allocPeer(storeID uint64) (*metapb.Peer, error) {
 	return peer, nil
 }
 
+func (c *clusterInfo) getClusterID() uint64 {
+	c.RLock()
+	defer c.RUnlock()
+	return c.meta.GetId()
+}
+
 func (c *clusterInfo) getMeta() *metapb.Cluster {
 	c.RLock()
 	defer c.RUnlock()

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -438,7 +438,7 @@ func (s *testClusterSuite) testCheckStores(c *C, clusterID uint64) {
 	leader := &metapb.Peer{StoreId: store.GetId()}
 	region := s.newRegion(c, 0, []byte{'a'}, []byte{'b'}, []*metapb.Peer{leader}, nil)
 	regionInfo := newRegionInfo(region, leader)
-	_, err := cluster.handleRegionHeartbeat(regionInfo)
+	err := cluster.handleRegionHeartbeat(regionInfo)
 	c.Assert(err, IsNil)
 	c.Assert(cluster.cachedCluster.getStoreRegionCount(store.GetId()), Equals, 1)
 
@@ -460,7 +460,7 @@ func (s *testClusterSuite) testCheckStores(c *C, clusterID uint64) {
 	// Clear store's region peers.
 	leader.StoreId = 0
 	region.Peers = []*metapb.Peer{leader}
-	_, err = cluster.handleRegionHeartbeat(regionInfo)
+	err = cluster.handleRegionHeartbeat(regionInfo)
 	c.Assert(err, IsNil)
 	c.Assert(cluster.cachedCluster.getStoreRegionCount(store.GetId()), Equals, 0)
 

--- a/server/cluster_worker.go
+++ b/server/cluster_worker.go
@@ -23,14 +23,15 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 )
 
-func (c *RaftCluster) handleRegionHeartbeat(region *RegionInfo) (*pdpb.RegionHeartbeatResponse, error) {
+func (c *RaftCluster) handleRegionHeartbeat(region *RegionInfo) error {
 	// If the region peer count is 0, then we should not handle this.
 	if len(region.GetPeers()) == 0 {
 		log.Warnf("invalid region, zero region peer count - %v", region)
-		return nil, errors.Errorf("invalid region, zero region peer count - %v", region)
+		return errors.Errorf("invalid region, zero region peer count - %v", region)
 	}
 
-	return c.coordinator.dispatch(region), nil
+	c.coordinator.dispatch(region)
+	return nil
 }
 
 func (c *RaftCluster) handleAskSplit(request *pdpb.AskSplitRequest) (*pdpb.AskSplitResponse, error) {

--- a/server/cluster_worker_test.go
+++ b/server/cluster_worker_test.go
@@ -98,10 +98,46 @@ type testClusterWorkerSuite struct {
 
 	regionLeaderLock sync.Mutex
 	// regionID -> Peer
-	regionLeaders map[uint64]metapb.Peer
+	regionLeaders    map[uint64]metapb.Peer
+	heartbeatClients map[uint64]*regionHeartbeatClient
+}
 
-	regionHeartbeat pdpb.PD_RegionHeartbeatClient
-	heartbeatRespCh chan *pdpb.RegionHeartbeatResponse
+type regionHeartbeatClient struct {
+	stream pdpb.PD_RegionHeartbeatClient
+	respCh chan *pdpb.RegionHeartbeatResponse
+}
+
+func newRegionheartbeatClient(c *C, grpcClient pdpb.PDClient) *regionHeartbeatClient {
+	stream, err := grpcClient.RegionHeartbeat(context.Background())
+	c.Assert(err, IsNil)
+	ch := make(chan *pdpb.RegionHeartbeatResponse)
+	go func() {
+		for {
+			res, err := stream.Recv()
+			if err != nil {
+				return
+			}
+			ch <- res
+		}
+	}()
+	return &regionHeartbeatClient{
+		stream: stream,
+		respCh: ch,
+	}
+}
+
+func (c *regionHeartbeatClient) close() {
+	c.stream.CloseSend()
+}
+
+func (c *regionHeartbeatClient) SendRecv(msg *pdpb.RegionHeartbeatRequest) *pdpb.RegionHeartbeatResponse {
+	c.stream.Send(msg)
+	select {
+	case <-time.After(time.Millisecond * 200):
+		return nil
+	case res := <-c.respCh:
+		return res
+	}
 }
 
 func (s *testClusterWorkerSuite) clearRegionLeader(c *C, regionID uint64) {
@@ -193,8 +229,6 @@ func (s *testClusterWorkerSuite) SetUpTest(c *C) {
 	mustWaitLeader(c, []*Server{s.svr})
 	s.grpcPDClient = mustNewGrpcClient(c, s.svr.GetAddr())
 
-	s.regionHeartbeat, s.heartbeatRespCh = s.runHeartbeatReceiver(c)
-
 	// Build raft cluster with 5 stores.
 	s.bootstrap(c)
 	s.newMockRaftStore(c, nil)
@@ -213,6 +247,11 @@ func (s *testClusterWorkerSuite) SetUpTest(c *C) {
 
 	stores := cluster.GetStores()
 	c.Assert(stores, HasLen, 5)
+
+	s.heartbeatClients = make(map[uint64]*regionHeartbeatClient)
+	for _, store := range stores {
+		s.heartbeatClients[store.GetId()] = newRegionheartbeatClient(c, s.grpcPDClient)
+	}
 }
 
 func (s *testClusterWorkerSuite) runHeartbeatReceiver(c *C) (pdpb.PD_RegionHeartbeatClient, chan *pdpb.RegionHeartbeatResponse) {
@@ -233,7 +272,9 @@ func (s *testClusterWorkerSuite) runHeartbeatReceiver(c *C) (pdpb.PD_RegionHeart
 
 func (s *testClusterWorkerSuite) TearDownTest(c *C) {
 	s.cleanup()
-	s.regionHeartbeat.CloseSend()
+	for _, client := range s.heartbeatClients {
+		client.close()
+	}
 }
 
 func (s *testClusterWorkerSuite) checkRegionPeerCount(c *C, regionKey []byte, expectCount int) *metapb.Region {
@@ -314,16 +355,8 @@ func (s *testClusterWorkerSuite) heartbeatRegion(c *C, clusterID uint64, msgID u
 		Region: region,
 	}
 
-	// FIXME: it may out of order in the future.
-	err := s.regionHeartbeat.Send(req)
-	c.Assert(err, IsNil)
-
-	select {
-	case <-time.After(time.Millisecond * 200):
-		return nil
-	case res := <-s.heartbeatRespCh:
-		return res
-	}
+	heartbeatClient := s.heartbeatClients[leader.GetStoreId()]
+	return heartbeatClient.SendRecv(req)
 }
 
 func (s *testClusterWorkerSuite) heartbeatStore(c *C, msgID uint64, stats *pdpb.StoreStats) *pdpb.StoreHeartbeatResponse {

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -41,6 +41,7 @@ const (
 	hotRegionScheduleFactor       = 0.9
 	hotRegionMinWriteRate         = 16 * 1024
 	regionHeartBeatReportInterval = 60
+	regionheartbeatSendChanCap    = 1024
 	storeHeartBeatReportInterval  = 10
 	minHotRegionReportInterval    = 3
 	hotRegionAntiCount            = 1
@@ -473,7 +474,7 @@ func newHeartbeatStreams(ctx context.Context, clusterID uint64) *heartbeatStream
 		ctx:       ctx,
 		clusterID: clusterID,
 		streams:   make(map[uint64]pdpb.PD_RegionHeartbeatServer),
-		msgCh:     make(chan *pdpb.RegionHeartbeatResponse, 1),
+		msgCh:     make(chan *pdpb.RegionHeartbeatResponse, regionheartbeatSendChanCap),
 		streamCh:  make(chan updateStream, 1),
 	}
 }

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -497,13 +497,13 @@ func (s *heartbeatStreams) run() {
 				if err := stream.Send(msg); err != nil {
 					log.Errorf("send heartbeat message fail: %v", err)
 					delete(s.streams, storeID)
-					regionHeartbeatCounter.WithLabelValues("down", "err")
+					regionHeartbeatCounter.WithLabelValues("push", "err")
 				} else {
-					regionHeartbeatCounter.WithLabelValues("down", "ok")
+					regionHeartbeatCounter.WithLabelValues("push", "ok")
 				}
 			} else {
 				log.Debugf("heartbeat stream not found for store %v, skip send message", storeID)
-				regionHeartbeatCounter.WithLabelValues("down", "skip")
+				regionHeartbeatCounter.WithLabelValues("push", "skip")
 			}
 		case <-s.ctx.Done():
 			return
@@ -539,7 +539,7 @@ func (s *heartbeatStreams) sendMsg(region *RegionInfo, msg *pdpb.RegionHeartbeat
 }
 
 func (s *heartbeatStreams) sendErr(region *RegionInfo, errType pdpb.ErrorType, errMsg string) {
-	regionHeartbeatCounter.WithLabelValues("up", "err")
+	regionHeartbeatCounter.WithLabelValues("report", "err")
 
 	msg := &pdpb.RegionHeartbeatResponse{
 		Header: &pdpb.ResponseHeader{

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -285,8 +285,9 @@ func (c *coordinator) addOperator(op Operator) bool {
 	c.operators[regionID] = op
 
 	if region := c.cluster.getRegion(op.GetRegionID()); region != nil {
-		msg, _ := op.Do(region)
-		c.hbStreams.sendMsg(region, msg)
+		if msg, _ := op.Do(region); msg != nil {
+			c.hbStreams.sendMsg(region, msg)
+		}
 	}
 
 	collectOperatorCounterMetrics(op)

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -537,3 +537,22 @@ func (s *heartbeatStreams) sendMsg(region *RegionInfo, msg *pdpb.RegionHeartbeat
 	case <-s.ctx.Done():
 	}
 }
+
+func (s *heartbeatStreams) sendErr(region *RegionInfo, errType pdpb.ErrorType, errMsg string) {
+	regionHeartbeatCounter.WithLabelValues("up", "err")
+
+	msg := &pdpb.RegionHeartbeatResponse{
+		Header: &pdpb.ResponseHeader{
+			ClusterId: s.clusterID,
+			Error: &pdpb.Error{
+				Type:    errType,
+				Message: errMsg,
+			},
+		},
+	}
+
+	select {
+	case s.msgCh <- msg:
+	case <-s.ctx.Done():
+	}
+}

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -238,13 +238,7 @@ func (s *Server) RegionHeartbeat(server pdpb.PD_RegionHeartbeatServer) error {
 	cluster := s.GetRaftCluster()
 	if cluster == nil {
 		resp := &pdpb.RegionHeartbeatResponse{
-			Header: &pdpb.ResponseHeader{
-				ClusterId: s.clusterID,
-				Error: &pdpb.Error{
-					Type:    pdpb.ErrorType_NOT_BOOTSTRAPPED,
-					Message: "cluster is not bootstrapped",
-				},
-			},
+			Header: s.notBootstrappedHeader(),
 		}
 		err := server.Send(resp)
 		return errors.Trace(err)
@@ -300,7 +294,7 @@ func (s *Server) RegionHeartbeat(server pdpb.PD_RegionHeartbeatServer) error {
 			hbStreams.sendErr(region, pdpb.ErrorType_UNKNOWN, msg)
 		}
 
-		regionHeartbeatCounter.WithLabelValues("up", "ok")
+		regionHeartbeatCounter.WithLabelValues("report", "ok")
 	}
 }
 

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -65,6 +65,14 @@ var (
 			Help:      "Status of the scheduler.",
 		}, []string{"kind", "type"})
 
+	regionHeartbeatCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "pd",
+			Subsystem: "scheduler",
+			Name:      "region_heartbeat",
+			Help:      "Counter of region hearbeat.",
+		}, []string{"direction", "status"})
+
 	hotSpotStatusGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "pd",
@@ -81,5 +89,6 @@ func init() {
 	prometheus.MustRegister(clusterStatusGauge)
 	prometheus.MustRegister(timeJumpBackCounter)
 	prometheus.MustRegister(schedulerStatusGauge)
+	prometheus.MustRegister(regionHeartbeatCounter)
 	prometheus.MustRegister(hotSpotStatusGauge)
 }

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -71,7 +71,7 @@ var (
 			Subsystem: "scheduler",
 			Name:      "region_heartbeat",
 			Help:      "Counter of region hearbeat.",
-		}, []string{"direction", "status"})
+		}, []string{"type", "status"})
 
 	hotSpotStatusGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/server/operator_test.go
+++ b/server/operator_test.go
@@ -149,10 +149,9 @@ func (o *testOperatorSuite) TestOperatorState(c *C) {
 	tc.addLeaderRegion(1, 4, 2, 3)
 
 	// Get the operator tansfer peer from store 4 to store 1
-	// Now operator are Waiting
 	waitOperator(c, co, 1)
 	op := co.getOperator(1)
-	c.Assert(op.GetState(), Equals, OperatorWaiting)
+	c.Assert(op.GetState(), Equals, OperatorRunning)
 	regionInfo := tc.getRegion(1)
 
 	// Do Operator, Operator start running. doRegionHeartbeatRequest will add one peer in store 1


### PR DESCRIPTION
Another approach of #661.
Now `dispatch()` does not return responses, all responses transfers through `heartbeatStream`.