### PR TITLE
tso: fix for Sub behaviour for go1.9

### DIFF
--- a/server/tso.go
+++ b/server/tso.go
@@ -84,7 +84,7 @@ func (s *Server) syncTimestamp() error {
 
 	for {
 		now = time.Now()
-		if wait := last.Sub(now) + updateTimestampGuard; wait > 0 {
+		if wait := time.Duration(last.UnixNano()-now.UnixNano()) + updateTimestampGuard; wait > 0 {
 			log.Warnf("wait %v to guarantee valid generated timestamp", wait)
 			time.Sleep(wait)
 			continue
@@ -111,7 +111,7 @@ func (s *Server) updateTimestamp() error {
 	prev := s.ts.Load().(*atomicObject).physical
 	now := time.Now()
 
-	since := now.Sub(prev)
+	since := time.Duration(now.UnixNano() - prev.UnixNano())
 	if since > 3*updateTimestampStep {
 		log.Warnf("clock offset: %v, prev: %v, now: %v", since, prev, now)
 	}
@@ -121,7 +121,7 @@ func (s *Server) updateTimestamp() error {
 		return nil
 	}
 
-	if now.Sub(s.lastSavedTime) >= 0 {
+	if now.UnixNano()-s.lastSavedTime.UnixNano() >= 0 {
 		last := s.lastSavedTime
 		save := now.Add(s.cfg.TsoSaveInterval.Duration)
 		if err := s.saveTimestamp(save); err != nil {

--- a/server/util.go
+++ b/server/util.go
@@ -342,3 +342,7 @@ func parseTimestamp(data []byte) (time.Time, error) {
 
 	return time.Unix(0, int64(nano)), nil
 }
+
+func subTimeByWallClock(after time.Time, before time.Time) time.Duration {
+	return time.Duration(after.UnixNano() - before.UnixNano())
+}

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -59,3 +59,13 @@ func (s *testUtilSuite) TestParseTimestap(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(nt.Equal(zeroTime), IsTrue)
 }
+
+func (s *testUtilSuite) TestSubTimeByWallClock(c *C) {
+	for i := 0; i < 3; i++ {
+		r := rand.Int31n(1000)
+		t1 := time.Now()
+		t2 := t1.Add(time.Second * time.Duration(r))
+		duration := subTimeByWallClock(t2, t1)
+		c.Assert(duration, Equals, time.Second*time.Duration(r))
+	}
+}


### PR DESCRIPTION
Other usages of `Sub` seem to be cost measurements, in which case the new behaviour of `Sub` have not affection.

Test passed on both go 1.8.3 and go 1.9 beta 2.
@disksing @siddontang PTAL 

Signed-off-by: Cholerae Hu <huyingqian@pingcap.com>