### PR TITLE
*: fix CI.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PD_PKG := github.com/pingcap/pd
-VENDOR := $(shell rm -f _vendor/src/$(PD_PKG) &&\
+VENDOR := $(shell rm -rf _vendor/src/$(PD_PKG) &&\
                  ln -s `pwd` _vendor/src/$(PD_PKG) &&\
                  pwd)/_vendor
 TEST_PKGS := $(shell find . -iname "*_test.go" -exec dirname {} \; | \


### PR DESCRIPTION
Our internal CI fails with error:
```
+ make test
rm: cannot remove '_vendor/src/github.com/pingcap/pd': Is a directory
```
cc @choleraehyq @nolouch @tiancaiamao 