### PR TITLE
conf: set default value of leader-schedule-limit to 64.

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -47,7 +47,7 @@ address = ""
 [schedule]
 max-snapshot-count = 3
 max-store-down-time = "1h"
-leader-schedule-limit = 1024
+leader-schedule-limit = 64
 region-schedule-limit = 16
 replica-schedule-limit = 24
 

--- a/pkg/etcdutil/etcdutil.go
+++ b/pkg/etcdutil/etcdutil.go
@@ -37,7 +37,7 @@ const (
 	// longer then 1s, they are considered as slow requests.
 	DefaultSlowRequestTime = 1 * time.Second
 
-	maxCheckEtcdRunningCount = 60 * 10
+	maxCheckEtcdRunningCount = 60
 	checkEtcdRunningDelay    = 1 * time.Second
 )
 

--- a/server/config.go
+++ b/server/config.go
@@ -305,7 +305,7 @@ const (
 	defaultMaxReplicas          = 3
 	defaultMaxSnapshotCount     = 3
 	defaultMaxStoreDownTime     = time.Hour
-	defaultLeaderScheduleLimit  = 1024
+	defaultLeaderScheduleLimit  = 64
 	defaultRegionScheduleLimit  = 12
 	defaultReplicaScheduleLimit = 16
 )


### PR DESCRIPTION
Now tikv send a heartbeat after finish transfer leader. So normally the transfer process should be fast, don't need to use the large value, which may cause over balance.