### PR TITLE
replication: update distinct score.

### DIFF
--- a/server/replication.go
+++ b/server/replication.go
@@ -63,29 +63,14 @@ func (r *Replication) GetDistinctScore(stores []*storeInfo, other *storeInfo) fl
 	score := float64(0)
 	locationLabels := r.GetLocationLabels()
 
-	for i := range locationLabels {
-		keys := locationLabels[0 : i+1]
-		level := len(locationLabels) - i - 1
-		levelScore := math.Pow(replicaBaseScore, float64(level))
-
-		for _, s := range stores {
-			if s.GetId() == other.GetId() {
-				continue
-			}
-			id1 := s.getLocationID(keys)
-			if len(id1) == 0 {
-				return 0
-			}
-			id2 := other.getLocationID(keys)
-			if len(id2) == 0 {
-				return 0
-			}
-			if id1 != id2 {
-				score += levelScore
-			}
+	for _, s := range stores {
+		if s.GetId() == other.GetId() {
+			continue
+		}
+		if index := s.compareLocation(other, locationLabels); index != -1 {
+			score += math.Pow(replicaBaseScore, float64(len(locationLabels)-index-1))
 		}
 	}
-
 	return score
 }
 

--- a/server/replication_test.go
+++ b/server/replication_test.go
@@ -50,12 +50,12 @@ func (s *testReplicationSuite) TestDistinctScore(c *C) {
 				store := cluster.getStore(storeID)
 				stores = append(stores, store)
 
-				// Number of stores with different zones.
+				// Number of stores in different zones.
 				nzones := i * len(racks) * len(hosts)
-				// Number of stores with different racks.
-				nracks := nzones + j*len(hosts)
-				// Number of stores with different hosts.
-				nhosts := nracks + k
+				// Number of stores in the same zone but in different racks.
+				nracks := j * len(hosts)
+				// Number of stores in the same rack but in different hosts.
+				nhosts := k
 				score := (nzones*replicaBaseScore+nracks)*replicaBaseScore + nhosts
 				c.Assert(rep.GetDistinctScore(stores, store), Equals, float64(score))
 			}

--- a/server/store.go
+++ b/server/store.go
@@ -131,16 +131,18 @@ func (s *storeInfo) getLabelValue(key string) string {
 	return ""
 }
 
-func (s *storeInfo) getLocationID(keys []string) string {
-	id := ""
-	for _, k := range keys {
-		v := s.getLabelValue(k)
-		if len(v) == 0 {
-			return ""
+// compareLocation compares 2 stores' labels and returns at which level their
+// locations are different. It returns -1 if they are at the same location.
+func (s *storeInfo) compareLocation(other *storeInfo, labels []string) int {
+	for i, key := range labels {
+		v1, v2 := s.getLabelValue(key), other.getLabelValue(key)
+		// If label is not set, the store is considered at the same location
+		// with any other store.
+		if v1 != "" && v2 != "" && v1 != v2 {
+			return i
 		}
-		id += v
 	}
-	return id
+	return -1
 }
 
 // StoreStatus contains information about a store's status.


### PR DESCRIPTION
The main argument is that if 2 stores are located in different zones, whether their host names are the same is meaningless.