### PR TITLE
server: fix heartbeat stream bug.

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -106,7 +106,7 @@ func (c *RaftCluster) start() error {
 		return nil
 	}
 	c.cachedCluster = cluster
-	c.coordinator = newCoordinator(c.cachedCluster, c.s.scheduleOpt)
+	c.coordinator = newCoordinator(c.cachedCluster, c.s.scheduleOpt, c.s.hbStreams)
 	c.quit = make(chan struct{})
 
 	c.wg.Add(2)

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -49,7 +49,9 @@ type testCoordinatorSuite struct{}
 func (s *testCoordinatorSuite) TestBasic(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	_, opt := newTestScheduleConfig()
-	co := newCoordinator(cluster, opt)
+	hbStreams := newHeartbeatStreams(cluster.getClusterID())
+	defer hbStreams.Close()
+	co := newCoordinator(cluster, opt, hbStreams)
 	l := co.limiter
 
 	op1 := newTestOperator(1, LeaderKind)
@@ -96,9 +98,11 @@ func newMockHeartbeatStream() *mockHeartbeatStream {
 func (s *testCoordinatorSuite) TestDispatch(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
+	hbStreams := newHeartbeatStreams(cluster.getClusterID())
+	defer hbStreams.Close()
 
 	_, opt := newTestScheduleConfig()
-	co := newCoordinator(cluster, opt)
+	co := newCoordinator(cluster, opt, hbStreams)
 	co.run()
 	defer co.stop()
 
@@ -158,13 +162,15 @@ func dispatchAndRecvHeartbeat(co *coordinator, region *RegionInfo, stream *mockH
 func (s *testCoordinatorSuite) TestReplica(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
+	hbStreams := newHeartbeatStreams(cluster.getClusterID())
+	defer hbStreams.Close()
 
 	// Turn off balance.
 	cfg, opt := newTestScheduleConfig()
 	cfg.LeaderScheduleLimit = 0
 	cfg.RegionScheduleLimit = 0
 
-	co := newCoordinator(cluster, opt)
+	co := newCoordinator(cluster, opt, hbStreams)
 	co.run()
 	defer co.stop()
 
@@ -214,9 +220,11 @@ func (s *testCoordinatorSuite) TestReplica(c *C) {
 func (s *testCoordinatorSuite) TestPeerState(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
+	hbStreams := newHeartbeatStreams(cluster.getClusterID())
+	defer hbStreams.Close()
 
 	_, opt := newTestScheduleConfig()
-	co := newCoordinator(cluster, opt)
+	co := newCoordinator(cluster, opt, hbStreams)
 	co.run()
 	defer co.stop()
 
@@ -261,9 +269,11 @@ func (s *testCoordinatorSuite) TestPeerState(c *C) {
 func (s *testCoordinatorSuite) TestShouldRun(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
+	hbStreams := newHeartbeatStreams(cluster.getClusterID())
+	defer hbStreams.Close()
 
 	_, opt := newTestScheduleConfig()
-	co := newCoordinator(cluster, opt)
+	co := newCoordinator(cluster, opt, hbStreams)
 
 	tc.LoadRegion(1, 1, 2, 3)
 	tc.LoadRegion(2, 1, 2, 3)
@@ -294,11 +304,13 @@ func (s *testCoordinatorSuite) TestShouldRun(c *C) {
 func (s *testCoordinatorSuite) TestAddScheduler(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
+	hbStreams := newHeartbeatStreams(cluster.getClusterID())
+	defer hbStreams.Close()
 
 	cfg, opt := newTestScheduleConfig()
 	cfg.ReplicaScheduleLimit = 0
 
-	co := newCoordinator(cluster, opt)
+	co := newCoordinator(cluster, opt, hbStreams)
 	co.run()
 	defer co.stop()
 
@@ -391,7 +403,9 @@ type testScheduleControllerSuite struct{}
 func (s *testScheduleControllerSuite) TestController(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	cfg, opt := newTestScheduleConfig()
-	co := newCoordinator(cluster, opt)
+	hbStreams := newHeartbeatStreams(cluster.getClusterID())
+	defer hbStreams.Close()
+	co := newCoordinator(cluster, opt, hbStreams)
 	lb := newBalanceLeaderScheduler(opt)
 	sc := newScheduleController(co, lb, minScheduleInterval)
 
@@ -442,7 +456,9 @@ func (s *testScheduleControllerSuite) TestController(c *C) {
 func (s *testScheduleControllerSuite) TestInterval(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	_, opt := newTestScheduleConfig()
-	co := newCoordinator(cluster, opt)
+	hbStreams := newHeartbeatStreams(cluster.getClusterID())
+	defer hbStreams.Close()
+	co := newCoordinator(cluster, opt, hbStreams)
 	lb := newBalanceLeaderScheduler(opt)
 	sc := newScheduleController(co, lb, minScheduleInterval)
 

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -294,7 +294,7 @@ func (s *Server) RegionHeartbeat(server pdpb.PD_RegionHeartbeatServer) error {
 			hbStreams.sendErr(region, pdpb.ErrorType_UNKNOWN, msg)
 		}
 
-		regionHeartbeatCounter.WithLabelValues("report", "ok")
+		regionHeartbeatCounter.WithLabelValues("report", "ok").Inc()
 	}
 }
 

--- a/server/heartbeat_streams.go
+++ b/server/heartbeat_streams.go
@@ -1,0 +1,133 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"sync"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"golang.org/x/net/context"
+)
+
+type heartbeatStream interface {
+	Send(*pdpb.RegionHeartbeatResponse) error
+}
+
+type streamUpdate struct {
+	storeID uint64
+	stream  heartbeatStream
+}
+
+type heartbeatStreams struct {
+	wg        sync.WaitGroup
+	ctx       context.Context
+	cancel    context.CancelFunc
+	clusterID uint64
+	streams   map[uint64]heartbeatStream
+	msgCh     chan *pdpb.RegionHeartbeatResponse
+	streamCh  chan streamUpdate
+}
+
+func newHeartbeatStreams(clusterID uint64) *heartbeatStreams {
+	ctx, cancel := context.WithCancel(context.Background())
+	hs := &heartbeatStreams{
+		ctx:       ctx,
+		cancel:    cancel,
+		clusterID: clusterID,
+		streams:   make(map[uint64]heartbeatStream),
+		msgCh:     make(chan *pdpb.RegionHeartbeatResponse, regionheartbeatSendChanCap),
+		streamCh:  make(chan streamUpdate, 1),
+	}
+	hs.wg.Add(1)
+	go hs.run()
+	return hs
+}
+
+func (s *heartbeatStreams) run() {
+	defer s.wg.Done()
+	for {
+		select {
+		case update := <-s.streamCh:
+			s.streams[update.storeID] = update.stream
+		case msg := <-s.msgCh:
+			storeID := msg.GetTargetPeer().GetStoreId()
+			if stream, ok := s.streams[storeID]; ok {
+				if err := stream.Send(msg); err != nil {
+					log.Errorf("[region %v] send heartbeat message fail: %v", msg.RegionId, err)
+					delete(s.streams, storeID)
+					regionHeartbeatCounter.WithLabelValues("push", "err").Inc()
+				} else {
+					regionHeartbeatCounter.WithLabelValues("push", "ok").Inc()
+				}
+			} else {
+				log.Debugf("[region %v] heartbeat stream not found for store %v, skip send message", msg.RegionId, storeID)
+				regionHeartbeatCounter.WithLabelValues("push", "skip").Inc()
+			}
+		case <-s.ctx.Done():
+			return
+		}
+	}
+}
+
+func (s *heartbeatStreams) Close() {
+	s.cancel()
+	s.wg.Wait()
+}
+
+func (s *heartbeatStreams) bindStream(storeID uint64, stream heartbeatStream) {
+	update := streamUpdate{
+		storeID: storeID,
+		stream:  stream,
+	}
+	select {
+	case s.streamCh <- update:
+	case <-s.ctx.Done():
+	}
+}
+
+func (s *heartbeatStreams) sendMsg(region *RegionInfo, msg *pdpb.RegionHeartbeatResponse) {
+	if region.Leader == nil {
+		return
+	}
+
+	msg.Header = &pdpb.ResponseHeader{ClusterId: s.clusterID}
+	msg.RegionId = region.GetId()
+	msg.RegionEpoch = region.GetRegionEpoch()
+	msg.TargetPeer = region.Leader
+
+	select {
+	case s.msgCh <- msg:
+	case <-s.ctx.Done():
+	}
+}
+
+func (s *heartbeatStreams) sendErr(region *RegionInfo, errType pdpb.ErrorType, errMsg string) {
+	regionHeartbeatCounter.WithLabelValues("report", "err").Inc()
+
+	msg := &pdpb.RegionHeartbeatResponse{
+		Header: &pdpb.ResponseHeader{
+			ClusterId: s.clusterID,
+			Error: &pdpb.Error{
+				Type:    errType,
+				Message: errMsg,
+			},
+		},
+	}
+
+	select {
+	case s.msgCh <- msg:
+	case <-s.ctx.Done():
+	}
+}

--- a/server/operator_test.go
+++ b/server/operator_test.go
@@ -134,10 +134,11 @@ func doRegionHeartbeatResponse(region *RegionInfo, resp *pdpb.RegionHeartbeatRes
 func (o *testOperatorSuite) TestOperatorState(c *C) {
 	cluster := newClusterInfo(newMockIDAllocator())
 	tc := newTestClusterInfo(cluster)
+	hbStreams := newHeartbeatStreams(cluster.getClusterID())
+	defer hbStreams.Close()
 
 	_, opt := newTestScheduleConfig()
-
-	co := newCoordinator(cluster, opt)
+	co := newCoordinator(cluster, opt, hbStreams)
 	co.run()
 	defer co.stop()
 


### PR DESCRIPTION
The bug:
We create _heartbeatStreams_ in _coordinator_ to manage async region heartbeats. If pd-server loses leadership then quickly becomes leader again, a new _coordinator_ will be created, but grpc steams are still bind to the old one, then scheduler commands will not be able to send to tikv.

The fix:
Create _heartbeatStreams_ along with _Server_, _coordinator_ only keeps a reference.