### PR TITLE
client: add timeout for rpc calls.

### DIFF
--- a/pd-client/client.go
+++ b/pd-client/client.go
@@ -61,6 +61,7 @@ type tsoRequest struct {
 
 const (
 	pdTimeout             = 3 * time.Second
+	updateLeaderTimeout   = time.Second // Use a shorter timeout to recover faster from network isolation.
 	maxMergeTSORequests   = 10000
 	maxInitClusterRetries = 100
 )
@@ -146,10 +147,10 @@ func (c *client) initClusterID() error {
 }
 
 func (c *client) updateLeader() error {
-	ctx, cancel := context.WithCancel(c.ctx)
-	defer cancel()
 	for _, u := range c.urls {
+		ctx, cancel := context.WithTimeout(c.ctx, updateLeaderTimeout)
 		members, err := c.getMembers(ctx, u)
+		cancel()
 		if err != nil || members.GetLeader() == nil || len(members.GetLeader().GetClientUrls()) == 0 {
 			continue
 		}
@@ -284,7 +285,7 @@ func (c *client) tsLoop() {
 
 		if stream == nil {
 			var ctx context.Context
-			ctx, cancel = context.WithCancel(c.ctx)
+			ctx, cancel = context.WithTimeout(c.ctx, pdTimeout)
 			stream, err = c.leaderClient().Tso(ctx)
 			if err != nil {
 				log.Errorf("[pd] create tso stream error: %v", err)

--- a/server/cluster_worker_test.go
+++ b/server/cluster_worker_test.go
@@ -473,8 +473,10 @@ func (s *testClusterWorkerSuite) TestHeartbeatSplit2(c *C) {
 	// Split.
 	r2ID, r2PeerIDs := s.askSplit(c, r1)
 	r2 := splitRegion(c, r1, []byte("m"), r2ID, r2PeerIDs)
+	c.Logf("r1: %v, r2: %v", r1, r2)
 	leaderPeer2 := s.chooseRegionLeader(c, r2)
 	resp := s.heartbeatRegion(c, s.clusterID, r2, leaderPeer2)
+	c.Logf("resp: %+v", resp)
 	c.Assert(resp, IsNil)
 	testutil.WaitUntil(c, s.checkSearchRegions(cluster, "", "m"))
 }


### PR DESCRIPTION
To make pd client recover faster from network isolation.