### PR TITLE
client: remove timeout for streaming call.

### DIFF
--- a/pd-client/client.go
+++ b/pd-client/client.go
@@ -285,8 +285,8 @@ func (c *client) tsLoop() {
 
 		if stream == nil {
 			var ctx context.Context
-			ctx, cancel = context.WithTimeout(c.ctx, pdTimeout)
-			stream, err = c.leaderClient().Tso(ctx)
+			ctx, cancel = context.WithCancel(c.ctx)
+			stream, err = c.leaderClient().Tso(ctx, grpc.FailFast(true))
 			if err != nil {
 				log.Errorf("[pd] create tso stream error: %v", err)
 				c.scheduleCheckLeader()

--- a/pd-client/client.go
+++ b/pd-client/client.go
@@ -286,7 +286,7 @@ func (c *client) tsLoop() {
 		if stream == nil {
 			var ctx context.Context
 			ctx, cancel = context.WithCancel(c.ctx)
-			stream, err = c.leaderClient().Tso(ctx, grpc.FailFast(true))
+			stream, err = c.leaderClient().Tso(ctx)
 			if err != nil {
 				log.Errorf("[pd] create tso stream error: %v", err)
 				c.scheduleCheckLeader()


### PR DESCRIPTION
We should not use `WithTimeout` for streaming calls, which will close the stream after timeout.