### PR TITLE
*: fix active region statistic

### DIFF
--- a/server/cache.go
+++ b/server/cache.go
@@ -708,7 +708,7 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 	var saveKV, saveCache, isNew bool
 	if origin == nil {
 		log.Infof("[region %d] Insert new region {%v}", region.GetId(), region)
-		saveKV, saveCache = true, true
+		saveKV, saveCache, isNew = true, true, true
 	} else {
 		r := region.GetRegionEpoch()
 		o := origin.GetRegionEpoch()

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/pd/pkg/testutil"
 	"github.com/pingcap/pd/server/core"
@@ -289,6 +290,11 @@ func (s *testCoordinatorSuite) TestShouldRun(c *C) {
 		tc.handleRegionHeartbeat(r)
 		c.Assert(co.shouldRun(), Equals, t.shouldRun)
 	}
+	nr := &metapb.Region{Id: 6, Peers: []*metapb.Peer{}}
+	newRegion := core.NewRegionInfo(nr, nil)
+	tc.handleRegionHeartbeat(newRegion)
+	c.Assert(co.cluster.activeRegions, Equals, 6)
+
 }
 
 func (s *testCoordinatorSuite) TestAddScheduler(c *C) {


### PR DESCRIPTION
if we lose some region stored in etcd, and restart PD. we will receive amount heartbeat to insert region, but we don't see it as an active region. then the scheduler will not run.