### PR TITLE
WIP: Add showTableId Command for pd-ctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 PD_PKG := github.com/pingcap/pd
 VENDOR := $(shell rm -rf _vendor/src/$(PD_PKG) &&\
-				 ln -s `pwd` _vendor/src/$(PD_PKG) &&\
-				 pwd)/_vendor
+                 ln -s `pwd` _vendor/src/$(PD_PKG) &&\
+                 pwd)/_vendor
 TEST_PKGS := $(shell find . -iname "*_test.go" -exec dirname {} \; | \
-					 uniq | sed -e "s/^\./github.com\/pingcap\/pd/")
+                     uniq | sed -e "s/^\./github.com\/pingcap\/pd/")
 
 GOFILTER := grep -vE 'vendor|testutil'
 GOCHECKER := $(GOFILTER) | awk '{ print } END { if (NR > 0) { exit 1 } }'

--- a/pdctl/command/table_id_command.go
+++ b/pdctl/command/table_id_command.go
@@ -23,16 +23,21 @@ import (
 	"encoding/json"
 )
 
-var tableIdCmd = NewTableIdCommand()
+var TableIdCmd = NewTableIdCommand()
 
 type tableInfo struct {
 	Name string  `json:"name"`
 	Id int64 `json:"id"`
 }
+
+func (t tableInfo) String() string {
+	return fmt.Sprintf("tableInfo{name: %s, id: %d}", t.Name, t.Id)
+}
+
 // NewPingCommand return a ping subcommand of rootCmd
 func NewTableIdCommand() *cobra.Command {
 	m := &cobra.Command{
-		Use:   "showTableId",
+		Use:   "showTableId <tidb_addr> <db_name> <table_name>",
 		Short: "show the table id given the table name",
 		Run:   showTableIdCommandFunc,
 	}
@@ -40,17 +45,22 @@ func NewTableIdCommand() *cobra.Command {
 }
 
 func showTableIdCommandFunc(cmd *cobra.Command, args []string) {
-	host, err := cmd.Flags().GetString("host")
-	dbName, err := cmd.Flags().GetString("dbName")
-	tableName, err := cmd.Flags().GetString("tableName")
+	if len(args) != 3 {
+		fmt.Println("Usage: showTableId <tidb_addr> <db_name> <table_name>")
+		return
+
+	}
+	host:= args[0]
+	dbName:= args[1]
+	tableName:= args[2]
 
 	if host == "" || dbName == "" || tableName == "" {
 		fmt.Printf("host, dbName and tableName are all required, but now\n " +
 			"host: %s\n dbName: %s\n tableName: %s\n", host, dbName, tableName)
-		os.Exit(1)
+		return
 	}
 
-	urlString := fmt.Sprintf("http://%s/tables/%s/%s/regions", host, dbName, tableName)
+	urlString := fmt.Sprintf("%s/tables/%s/%s/regions", host, dbName, tableName)
 
 	fmt.Println("the url is", urlString)
 
@@ -76,22 +86,5 @@ func showTableIdCommandFunc(cmd *cobra.Command, args []string) {
 		fmt.Println(err)
 		return
 	}
-	fmt.Println("table info:", ti)
-}
-
-func init() {
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// curlCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// curlCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle"
-
-	tableIdCmd.Flags().StringP("tidb", "tidb", "", "The TiDB host")
-	tableIdCmd.Flags().StringP("dbName", "d", "", "The DB name")
-	tableIdCmd.Flags().StringP("tableName", "t", "", "The Table name")
+	fmt.Println(ti)
 }

--- a/pdctl/command/table_id_command.go
+++ b/pdctl/command/table_id_command.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"os"
 	"net/http"
 	"io/ioutil"
 	"encoding/json"
@@ -68,7 +67,7 @@ func showTableIdCommandFunc(cmd *cobra.Command, args []string) {
 
 	if err != nil {
 		fmt.Println(err)
-		os.Exit(1)
+		return
 	}
 
 	// fmt.Println(resp)

--- a/pdctl/command/table_id_command.go
+++ b/pdctl/command/table_id_command.go
@@ -1,0 +1,36 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"fmt"
+	_ "net/http"
+	_ "time"
+
+	"github.com/spf13/cobra"
+)
+
+// NewPingCommand return a ping subcommand of rootCmd
+func NewTableIdCommand() *cobra.Command {
+	m := &cobra.Command{
+		Use:   "show table id by table name",
+		Short: "show the table id given the table name",
+		Run:   showTableIdCommandFunc,
+	}
+	return m
+}
+
+func showTableIdCommandFunc(cmd *cobra.Command, args []string) {
+	fmt.Println("This function is not implemented yet")
+}

--- a/pdctl/ctl.go
+++ b/pdctl/ctl.go
@@ -49,6 +49,7 @@ func init() {
 		command.NewTSOCommand(),
 		command.NewHotSpotCommand(),
 		command.NewClusterCommand(),
+		command.NewTableIdCommand(),
 	)
 	cobra.EnablePrefixMatching = true
 }


### PR DESCRIPTION
Add a command `showTableId` that show the table id from the tidb given the table name.