### PR TITLE
server/schedulers/balance_region.go: fix a error in make dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ default.etcd
 default.pd
 *.swp
 .DS_Store
+tags

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -40,9 +40,9 @@ type balanceRegionScheduler struct {
 // newBalanceRegionScheduler creates a scheduler that tends to keep regions on
 // each store balanced.
 func newBalanceRegionScheduler(opt schedule.Options) schedule.Scheduler {
-	cache := cache.NewIDTTL(storeCacheInterval, 4*storeCacheInterval)
+	ttlCache := cache.NewIDTTL(storeCacheInterval, 4*storeCacheInterval)
 	filters := []schedule.Filter{
-		schedule.NewCacheFilter(cache),
+		schedule.NewCacheFilter(ttlCache),
 		schedule.NewStateFilter(opt),
 		schedule.NewHealthFilter(opt),
 		schedule.NewSnapshotCountFilter(opt),

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -51,7 +51,7 @@ func newBalanceRegionScheduler(opt schedule.Options) schedule.Scheduler {
 
 	return &balanceRegionScheduler{
 		opt:      opt,
-		cache:    cache,
+		cache:    ttlCache,
 		limit:    1,
 		selector: schedule.NewBalanceSelector(core.RegionKind, filters),
 	}


### PR DESCRIPTION
when run make dev, vet will fail:
```
make dev
server/schedulers/balance_region.go:43: declaration of "cache" shadows declaration at server/schedulers/balance_region.go:20
Makefile:41: recipe for target 'check' failed
```
caused by a variable naming problem