### PR TITLE
server: fix a bug that may set not empty store to tombstone state.

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -539,14 +539,7 @@ func (c *RaftCluster) checkStores() {
 		if store.GetState() != metapb.StoreState_Offline {
 			continue
 		}
-		if cluster.getStoreRegionCount(store.GetId()) > 0 {
-			continue
-		}
-		// If pd-server is started recently, or becomes leader recently, the check may
-		// happen before any heartbeat from tikv. So we need to check region metas to
-		// verify no region's peer is on the store.
-		regions := cluster.getMetaRegions()
-		if c.verifyStoreIsEmpty(regions, store.GetId()) {
+		if c.storeIsEmpty(store.GetId()) {
 			err := c.BuryStore(store.GetId(), false)
 			if err != nil {
 				log.Errorf("bury store %v failed: %v", store, err)
@@ -557,7 +550,15 @@ func (c *RaftCluster) checkStores() {
 	}
 }
 
-func (c *RaftCluster) verifyStoreIsEmpty(regions []*metapb.Region, storeID uint64) bool {
+func (c *RaftCluster) storeIsEmpty(storeID uint64) bool {
+	cluster := c.cachedCluster
+	if cluster.getStoreRegionCount(storeID) > 0 {
+		return false
+	}
+	// If pd-server is started recently, or becomes leader recently, the check may
+	// happen before any heartbeat from tikv. So we need to check region metas to
+	// verify no region's peer is on the store.
+	regions := cluster.getMetaRegions()
 	for _, region := range regions {
 		for _, p := range region.GetPeers() {
 			if p.GetStoreId() == storeID {

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -539,7 +539,14 @@ func (c *RaftCluster) checkStores() {
 		if store.GetState() != metapb.StoreState_Offline {
 			continue
 		}
-		if cluster.getStoreRegionCount(store.GetId()) == 0 {
+		if cluster.getStoreRegionCount(store.GetId()) > 0 {
+			continue
+		}
+		// If pd-server is started recently, or becomes leader recently, the check may
+		// happen before any heartbeat from tikv. So we need to check region metas to
+		// verify no region's peer is on the store.
+		regions := cluster.getMetaRegions()
+		if c.verifyStoreIsEmpty(regions, store.GetId()) {
 			err := c.BuryStore(store.GetId(), false)
 			if err != nil {
 				log.Errorf("bury store %v failed: %v", store, err)
@@ -548,6 +555,17 @@ func (c *RaftCluster) checkStores() {
 			}
 		}
 	}
+}
+
+func (c *RaftCluster) verifyStoreIsEmpty(regions []*metapb.Region, storeID uint64) bool {
+	for _, region := range regions {
+		for _, p := range region.GetPeers() {
+			if p.GetStoreId() == storeID {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func (c *RaftCluster) collectMetrics() {


### PR DESCRIPTION
I reproduce the problem in the following steps:
1. start 1pd+1tikv, wait for bootstrap.
2. stop tikv and restart pd.
3. use pd-ctl to remove store1.
4. wait 1 minute, the store is tombstone state.