### PR TITLE
scheduler: clusterInfo refactor

### DIFF
--- a/server/cache.go
+++ b/server/cache.go
@@ -14,7 +14,6 @@
 package server
 
 import (
-	"math/rand"
 	"sync"
 	"time"
 
@@ -28,12 +27,6 @@ import (
 )
 
 var (
-	errStoreNotFound = func(storeID uint64) error {
-		return errors.Errorf("store %v not found", storeID)
-	}
-	errStoreIsBlocked = func(storeID uint64) error {
-		return errors.Errorf("store %v is blocked", storeID)
-	}
 	errRegionNotFound = func(regionID uint64) error {
 		return errors.Errorf("region %v not found", regionID)
 	}
@@ -42,309 +35,6 @@ var (
 	}
 )
 
-type storesInfo struct {
-	stores map[uint64]*core.StoreInfo
-}
-
-func newStoresInfo() *storesInfo {
-	return &storesInfo{
-		stores: make(map[uint64]*core.StoreInfo),
-	}
-}
-
-func (s *storesInfo) getStore(storeID uint64) *core.StoreInfo {
-	store, ok := s.stores[storeID]
-	if !ok {
-		return nil
-	}
-	return store.Clone()
-}
-
-func (s *storesInfo) setStore(store *core.StoreInfo) {
-	s.stores[store.GetId()] = store
-}
-
-func (s *storesInfo) blockStore(storeID uint64) error {
-	store, ok := s.stores[storeID]
-	if !ok {
-		return errStoreNotFound(storeID)
-	}
-	if store.IsBlocked() {
-		return errStoreIsBlocked(storeID)
-	}
-	store.Block()
-	return nil
-}
-
-func (s *storesInfo) unblockStore(storeID uint64) {
-	store, ok := s.stores[storeID]
-	if !ok {
-		log.Fatalf("store %d is unblocked, but it is not found", storeID)
-	}
-	store.Unblock()
-}
-
-func (s *storesInfo) getStores() []*core.StoreInfo {
-	stores := make([]*core.StoreInfo, 0, len(s.stores))
-	for _, store := range s.stores {
-		stores = append(stores, store.Clone())
-	}
-	return stores
-}
-
-func (s *storesInfo) getMetaStores() []*metapb.Store {
-	stores := make([]*metapb.Store, 0, len(s.stores))
-	for _, store := range s.stores {
-		stores = append(stores, proto.Clone(store.Store).(*metapb.Store))
-	}
-	return stores
-}
-
-func (s *storesInfo) getStoreCount() int {
-	return len(s.stores)
-}
-
-func (s *storesInfo) setLeaderCount(storeID uint64, leaderCount int) {
-	if store, ok := s.stores[storeID]; ok {
-		store.LeaderCount = leaderCount
-	}
-}
-
-func (s *storesInfo) setRegionCount(storeID uint64, regionCount int) {
-	if store, ok := s.stores[storeID]; ok {
-		store.RegionCount = regionCount
-	}
-}
-
-func (s *storesInfo) totalWrittenBytes() uint64 {
-	var totalWrittenBytes uint64
-	for _, s := range s.stores {
-		if s.IsUp() {
-			totalWrittenBytes += s.Stats.GetBytesWritten()
-		}
-	}
-	return totalWrittenBytes
-}
-
-func (s *storesInfo) totalReadBytes() uint64 {
-	var totalReadBytes uint64
-	for _, s := range s.stores {
-		if s.IsUp() {
-			totalReadBytes += s.Stats.GetBytesRead()
-		}
-	}
-	return totalReadBytes
-}
-
-// regionMap wraps a map[uint64]*core.RegionInfo and supports randomly pick a region.
-type regionMap struct {
-	m   map[uint64]*regionEntry
-	ids []uint64
-}
-
-type regionEntry struct {
-	*core.RegionInfo
-	pos int
-}
-
-func newRegionMap() *regionMap {
-	return &regionMap{
-		m: make(map[uint64]*regionEntry),
-	}
-}
-
-func (rm *regionMap) Len() int {
-	if rm == nil {
-		return 0
-	}
-	return len(rm.m)
-}
-
-func (rm *regionMap) Get(id uint64) *core.RegionInfo {
-	if rm == nil {
-		return nil
-	}
-	if entry, ok := rm.m[id]; ok {
-		return entry.RegionInfo
-	}
-	return nil
-}
-
-func (rm *regionMap) Put(region *core.RegionInfo) {
-	if old, ok := rm.m[region.GetId()]; ok {
-		old.RegionInfo = region
-		return
-	}
-	rm.m[region.GetId()] = &regionEntry{
-		RegionInfo: region,
-		pos:        len(rm.ids),
-	}
-	rm.ids = append(rm.ids, region.GetId())
-}
-
-func (rm *regionMap) RandomRegion() *core.RegionInfo {
-	if rm.Len() == 0 {
-		return nil
-	}
-	return rm.Get(rm.ids[rand.Intn(rm.Len())])
-}
-
-func (rm *regionMap) Delete(id uint64) {
-	if rm == nil {
-		return
-	}
-	if old, ok := rm.m[id]; ok {
-		len := rm.Len()
-		last := rm.m[rm.ids[len-1]]
-		last.pos = old.pos
-		rm.ids[last.pos] = last.GetId()
-		delete(rm.m, id)
-		rm.ids = rm.ids[:len-1]
-	}
-}
-
-type regionsInfo struct {
-	tree      *regionTree
-	regions   *regionMap            // regionID -> regionInfo
-	leaders   map[uint64]*regionMap // storeID -> regionID -> regionInfo
-	followers map[uint64]*regionMap // storeID -> regionID -> regionInfo
-}
-
-func newRegionsInfo() *regionsInfo {
-	return &regionsInfo{
-		tree:      newRegionTree(),
-		regions:   newRegionMap(),
-		leaders:   make(map[uint64]*regionMap),
-		followers: make(map[uint64]*regionMap),
-	}
-}
-
-func (r *regionsInfo) getRegion(regionID uint64) *core.RegionInfo {
-	region := r.regions.Get(regionID)
-	if region == nil {
-		return nil
-	}
-	return region.Clone()
-}
-
-func (r *regionsInfo) setRegion(region *core.RegionInfo) {
-	if origin := r.regions.Get(region.GetId()); origin != nil {
-		r.removeRegion(origin)
-	}
-	r.addRegion(region)
-}
-
-func (r *regionsInfo) addRegion(region *core.RegionInfo) {
-	// Add to tree and regions.
-	r.tree.update(region.Region)
-	r.regions.Put(region)
-
-	if region.Leader == nil {
-		return
-	}
-
-	// Add to leaders and followers.
-	for _, peer := range region.GetPeers() {
-		storeID := peer.GetStoreId()
-		if peer.GetId() == region.Leader.GetId() {
-			// Add leader peer to leaders.
-			store, ok := r.leaders[storeID]
-			if !ok {
-				store = newRegionMap()
-				r.leaders[storeID] = store
-			}
-			store.Put(region)
-		} else {
-			// Add follower peer to followers.
-			store, ok := r.followers[storeID]
-			if !ok {
-				store = newRegionMap()
-				r.followers[storeID] = store
-			}
-			store.Put(region)
-		}
-	}
-}
-
-func (r *regionsInfo) removeRegion(region *core.RegionInfo) {
-	// Remove from tree and regions.
-	r.tree.remove(region.Region)
-	r.regions.Delete(region.GetId())
-
-	// Remove from leaders and followers.
-	for _, peer := range region.GetPeers() {
-		storeID := peer.GetStoreId()
-		r.leaders[storeID].Delete(region.GetId())
-		r.followers[storeID].Delete(region.GetId())
-	}
-}
-
-func (r *regionsInfo) searchRegion(regionKey []byte) *core.RegionInfo {
-	region := r.tree.search(regionKey)
-	if region == nil {
-		return nil
-	}
-	return r.getRegion(region.GetId())
-}
-
-func (r *regionsInfo) getRegions() []*core.RegionInfo {
-	regions := make([]*core.RegionInfo, 0, r.regions.Len())
-	for _, region := range r.regions.m {
-		regions = append(regions, region.Clone())
-	}
-	return regions
-}
-
-func (r *regionsInfo) getMetaRegions() []*metapb.Region {
-	regions := make([]*metapb.Region, 0, r.regions.Len())
-	for _, region := range r.regions.m {
-		regions = append(regions, proto.Clone(region.Region).(*metapb.Region))
-	}
-	return regions
-}
-
-func (r *regionsInfo) getRegionCount() int {
-	return r.regions.Len()
-}
-
-func (r *regionsInfo) getStoreRegionCount(storeID uint64) int {
-	return r.getStoreLeaderCount(storeID) + r.getStoreFollowerCount(storeID)
-}
-
-func (r *regionsInfo) getStoreLeaderCount(storeID uint64) int {
-	return r.leaders[storeID].Len()
-}
-
-func (r *regionsInfo) getStoreFollowerCount(storeID uint64) int {
-	return r.followers[storeID].Len()
-}
-
-func (r *regionsInfo) randRegion() *core.RegionInfo {
-	return randRegion(r.regions)
-}
-
-func (r *regionsInfo) randLeaderRegion(storeID uint64) *core.RegionInfo {
-	return randRegion(r.leaders[storeID])
-}
-
-func (r *regionsInfo) randFollowerRegion(storeID uint64) *core.RegionInfo {
-	return randRegion(r.followers[storeID])
-}
-
-const randomRegionMaxRetry = 10
-
-func randRegion(regions *regionMap) *core.RegionInfo {
-	for i := 0; i < randomRegionMaxRetry; i++ {
-		region := regions.RandomRegion()
-		if region == nil {
-			return nil
-		}
-		if len(region.DownPeers) == 0 && len(region.PendingPeers) == 0 {
-			return region.Clone()
-		}
-	}
-	return nil
-}
 
 type clusterInfo struct {
 	sync.RWMutex
@@ -352,8 +42,8 @@ type clusterInfo struct {
 	id      IDAllocator
 	kv      *kv
 	meta    *metapb.Cluster
-	stores  *storesInfo
-	regions *regionsInfo
+	stores  *core.StoresInfo
+	regions *core.RegionsInfo
 
 	activeRegions   int
 	writeStatistics cache.Cache
@@ -363,8 +53,8 @@ type clusterInfo struct {
 func newClusterInfo(id IDAllocator) *clusterInfo {
 	return &clusterInfo{
 		id:              id,
-		stores:          newStoresInfo(),
-		regions:         newRegionsInfo(),
+		stores:          core.NewStoresInfo(),
+		regions:         core.NewRegionsInfo(),
 		readStatistics:  cache.NewCache(statCacheMaxLen, cache.TwoQueueCache),
 		writeStatistics: cache.NewCache(statCacheMaxLen, cache.TwoQueueCache),
 	}
@@ -388,13 +78,13 @@ func loadClusterInfo(id IDAllocator, kv *kv) (*clusterInfo, error) {
 	if err := kv.loadStores(c.stores, kvRangeLimit); err != nil {
 		return nil, errors.Trace(err)
 	}
-	log.Infof("load %v stores cost %v", c.stores.getStoreCount(), time.Since(start))
+	log.Infof("load %v stores cost %v", c.stores.GetStoreCount(), time.Since(start))
 
 	start = time.Now()
 	if err := kv.loadRegions(c.regions, kvRangeLimit); err != nil {
 		return nil, errors.Trace(err)
 	}
-	log.Infof("load %v regions cost %v", c.regions.getRegionCount(), time.Since(start))
+	log.Infof("load %v regions cost %v", c.regions.GetRegionCount(), time.Since(start))
 
 	return c, nil
 }
@@ -449,7 +139,7 @@ func (c *clusterInfo) putMetaLocked(meta *metapb.Cluster) error {
 func (c *clusterInfo) GetStore(storeID uint64) *core.StoreInfo {
 	c.RLock()
 	defer c.RUnlock()
-	return c.stores.getStore(storeID)
+	return c.stores.GetStore(storeID)
 }
 
 func (c *clusterInfo) putStore(store *core.StoreInfo) error {
@@ -464,7 +154,7 @@ func (c *clusterInfo) putStoreLocked(store *core.StoreInfo) error {
 			return errors.Trace(err)
 		}
 	}
-	c.stores.setStore(store)
+	c.stores.SetStore(store)
 	return nil
 }
 
@@ -472,60 +162,52 @@ func (c *clusterInfo) putStoreLocked(store *core.StoreInfo) error {
 func (c *clusterInfo) BlockStore(storeID uint64) error {
 	c.Lock()
 	defer c.Unlock()
-	return errors.Trace(c.stores.blockStore(storeID))
+	return errors.Trace(c.stores.BlockStore(storeID))
 }
 
 // UnblockStore allows balancer to select the store.
 func (c *clusterInfo) UnblockStore(storeID uint64) {
 	c.Lock()
 	defer c.Unlock()
-	c.stores.unblockStore(storeID)
+	c.stores.UnblockStore(storeID)
 }
 
 // GetStores returns all stores in the cluster.
 func (c *clusterInfo) GetStores() []*core.StoreInfo {
 	c.RLock()
 	defer c.RUnlock()
-	return c.stores.getStores()
+	return c.stores.GetStores()
 }
 
 func (c *clusterInfo) getMetaStores() []*metapb.Store {
 	c.RLock()
 	defer c.RUnlock()
-	return c.stores.getMetaStores()
+	return c.stores.GetMetaStores()
 }
 
 func (c *clusterInfo) getStoreCount() int {
 	c.RLock()
 	defer c.RUnlock()
-	return c.stores.getStoreCount()
+	return c.stores.GetStoreCount()
 }
 
 func (c *clusterInfo) getStoresWriteStat() map[uint64]uint64 {
 	c.RLock()
 	defer c.RUnlock()
-	res := make(map[uint64]uint64)
-	for _, s := range c.stores.stores {
-		res[s.GetId()] = s.Stats.GetBytesWritten()
-	}
-	return res
+	return c.stores.GetStoresWriteStat()
 }
 
 func (c *clusterInfo) getStoresReadStat() map[uint64]uint64 {
 	c.RLock()
 	defer c.RUnlock()
-	res := make(map[uint64]uint64)
-	for _, s := range c.stores.stores {
-		res[s.GetId()] = s.Stats.GetBytesRead()
-	}
-	return res
+    return c.stores.GetStoresReadStat()
 }
 
 // GetRegions searches for a region by ID.
 func (c *clusterInfo) GetRegion(regionID uint64) *core.RegionInfo {
 	c.RLock()
 	defer c.RUnlock()
-	return c.regions.getRegion(regionID)
+	return c.regions.GetRegion(regionID)
 }
 
 // updateWriteStatCache updates statistic for a region if it's hot, or remove it from statistics if it cools down
@@ -631,7 +313,7 @@ func (c *clusterInfo) IsRegionHot(id uint64) bool {
 func (c *clusterInfo) searchRegion(regionKey []byte) *core.RegionInfo {
 	c.RLock()
 	defer c.RUnlock()
-	return c.regions.searchRegion(regionKey)
+	return c.regions.SearchRegion(regionKey)
 }
 
 func (c *clusterInfo) putRegion(region *core.RegionInfo) error {
@@ -646,58 +328,58 @@ func (c *clusterInfo) putRegionLocked(region *core.RegionInfo) error {
 			return errors.Trace(err)
 		}
 	}
-	c.regions.setRegion(region)
+	c.regions.SetRegion(region)
 	return nil
 }
 
 func (c *clusterInfo) getRegions() []*core.RegionInfo {
 	c.RLock()
 	defer c.RUnlock()
-	return c.regions.getRegions()
+	return c.regions.GetRegions()
 }
 
 func (c *clusterInfo) randomRegion() *core.RegionInfo {
 	c.RLock()
 	defer c.RUnlock()
-	return c.regions.randRegion()
+	return c.regions.RandRegion()
 }
 
 func (c *clusterInfo) getMetaRegions() []*metapb.Region {
 	c.RLock()
 	defer c.RUnlock()
-	return c.regions.getMetaRegions()
+	return c.regions.GetMetaRegions()
 }
 
 func (c *clusterInfo) getRegionCount() int {
 	c.RLock()
 	defer c.RUnlock()
-	return c.regions.getRegionCount()
+	return c.regions.GetRegionCount()
 }
 
 func (c *clusterInfo) getStoreRegionCount(storeID uint64) int {
 	c.RLock()
 	defer c.RUnlock()
-	return c.regions.getStoreRegionCount(storeID)
+	return c.regions.GetStoreRegionCount(storeID)
 }
 
 func (c *clusterInfo) getStoreLeaderCount(storeID uint64) int {
 	c.RLock()
 	defer c.RUnlock()
-	return c.regions.getStoreLeaderCount(storeID)
+	return c.regions.GetStoreLeaderCount(storeID)
 }
 
 // RandLeaderRegion returns a random region that has leader on the store.
 func (c *clusterInfo) RandLeaderRegion(storeID uint64) *core.RegionInfo {
 	c.RLock()
 	defer c.RUnlock()
-	return c.regions.randLeaderRegion(storeID)
+	return c.regions.RandLeaderRegion(storeID)
 }
 
 // RandFolowerRegion returns a random region that has a follower on the store.
 func (c *clusterInfo) RandFollowerRegion(storeID uint64) *core.RegionInfo {
 	c.RLock()
 	defer c.RUnlock()
-	return c.regions.randFollowerRegion(storeID)
+	return c.regions.RandFollowerRegion(storeID)
 }
 
 // GetRegionStores returns all stores that contains the region's peer.
@@ -706,7 +388,7 @@ func (c *clusterInfo) GetRegionStores(region *core.RegionInfo) []*core.StoreInfo
 	defer c.RUnlock()
 	var stores []*core.StoreInfo
 	for id := range region.GetStoreIds() {
-		if store := c.stores.getStore(id); store != nil {
+		if store := c.stores.GetStore(id); store != nil {
 			stores = append(stores, store)
 		}
 	}
@@ -717,7 +399,7 @@ func (c *clusterInfo) GetRegionStores(region *core.RegionInfo) []*core.StoreInfo
 func (c *clusterInfo) GetLeaderStore(region *core.RegionInfo) *core.StoreInfo {
 	c.RLock()
 	defer c.RUnlock()
-	return c.stores.getStore(region.Leader.GetStoreId())
+	return c.stores.GetStore(region.Leader.GetStoreId())
 }
 
 // GetRegionStores returns all stores that contains the region's follower peer.
@@ -726,7 +408,7 @@ func (c *clusterInfo) GetFollowerStores(region *core.RegionInfo) []*core.StoreIn
 	defer c.RUnlock()
 	var stores []*core.StoreInfo
 	for id := range region.GetFollowers() {
-		if store := c.stores.getStore(id); store != nil {
+		if store := c.stores.GetStore(id); store != nil {
 			stores = append(stores, store)
 		}
 	}
@@ -737,7 +419,7 @@ func (c *clusterInfo) GetFollowerStores(region *core.RegionInfo) []*core.StoreIn
 func (c *clusterInfo) isPrepared() bool {
 	c.RLock()
 	defer c.RUnlock()
-	return float64(c.regions.regions.Len())*collectFactor <= float64(c.activeRegions)
+	return float64(c.regions.Length())*collectFactor <= float64(c.activeRegions)
 }
 
 // handleStoreHeartbeat updates the store status.
@@ -746,27 +428,27 @@ func (c *clusterInfo) handleStoreHeartbeat(stats *pdpb.StoreStats) error {
 	defer c.Unlock()
 
 	storeID := stats.GetStoreId()
-	store := c.stores.getStore(storeID)
+	store := c.stores.GetStore(storeID)
 	if store == nil {
-		return errors.Trace(errStoreNotFound(storeID))
+		return errors.Trace(core.ErrStoreNotFound(storeID))
 	}
 	store.Stats = proto.Clone(stats).(*pdpb.StoreStats)
 	store.LastHeartbeatTS = time.Now()
 
-	c.stores.setStore(store)
+	c.stores.SetStore(store)
 	return nil
 }
 
 func (c *clusterInfo) updateStoreStatus(id uint64) {
-	c.stores.setLeaderCount(id, c.regions.getStoreLeaderCount(id))
-	c.stores.setRegionCount(id, c.regions.getStoreRegionCount(id))
+	c.stores.SetLeaderCount(id, c.regions.GetStoreLeaderCount(id))
+	c.stores.SetRegionCount(id, c.regions.GetStoreRegionCount(id))
 }
 
 // handleRegionHeartbeat updates the region information.
 func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 	region = region.Clone()
 	c.RLock()
-	origin := c.regions.getRegion(region.GetId())
+	origin := c.regions.GetRegion(region.GetId())
 	c.RUnlock()
 
 	// Save to KV if meta is updated.
@@ -784,11 +466,11 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 			return errors.Trace(errRegionIsStale(region.Region, origin.Region))
 		}
 		if r.GetVersion() > o.GetVersion() {
-			log.Infof("[region %d] %s, Version changed from {%d} to {%d}", region.GetId(), diffRegionKeyInfo(origin, region), o.GetVersion(), r.GetVersion())
+			log.Infof("[region %d] %s, Version changed from {%d} to {%d}", region.GetId(), core.DiffRegionKeyInfo(origin, region), o.GetVersion(), r.GetVersion())
 			saveKV, saveCache = true, true
 		}
 		if r.GetConfVer() > o.GetConfVer() {
-			log.Infof("[region %d] %s, ConfVer changed from {%d} to {%d}", region.GetId(), diffRegionPeersInfo(origin, region), o.GetConfVer(), r.GetConfVer())
+			log.Infof("[region %d] %s, ConfVer changed from {%d} to {%d}", region.GetId(), core.DiffRegionPeersInfo(origin, region), o.GetConfVer(), r.GetConfVer())
 			saveKV, saveCache = true, true
 		}
 		if region.Leader.GetId() != origin.Leader.GetId() {
@@ -820,7 +502,7 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 	}
 
 	if saveCache {
-		c.regions.setRegion(region)
+		c.regions.SetRegion(region)
 
 		// Update related stores.
 		if origin != nil {
@@ -858,7 +540,7 @@ func (c *clusterInfo) updateWriteStatus(region *core.RegionInfo) {
 	// and we use total written Bytes past storeHeartBeatReportInterval seconds to divide the number of hot regions
 	// divide 2 because the store reports data about two times than the region record write to rocksdb
 	divisor := float64(statCacheMaxLen) * 2 * storeHeartBeatReportInterval
-	hotRegionThreshold := uint64(float64(c.stores.totalWrittenBytes()) / divisor)
+	hotRegionThreshold := uint64(float64(c.stores.TotalWrittenBytes()) / divisor)
 
 	if hotRegionThreshold < hotRegionMinFlowRate {
 		hotRegionThreshold = hotRegionMinFlowRate
@@ -884,7 +566,7 @@ func (c *clusterInfo) updateReadStatus(region *core.RegionInfo) {
 	// suppose the number of the hot regions is statLRUMaxLen
 	// and we use total written Bytes past storeHeartBeatReportInterval seconds to divide the number of hot regions
 	divisor := float64(statCacheMaxLen) * storeHeartBeatReportInterval
-	hotRegionThreshold := uint64(float64(c.stores.totalReadBytes()) / divisor)
+	hotRegionThreshold := uint64(float64(c.stores.TotalReadBytes()) / divisor)
 
 	if hotRegionThreshold < hotRegionMinFlowRate {
 		hotRegionThreshold = hotRegionMinFlowRate

--- a/server/cache.go
+++ b/server/cache.go
@@ -35,7 +35,6 @@ var (
 	}
 )
 
-
 type clusterInfo struct {
 	sync.RWMutex
 
@@ -200,7 +199,7 @@ func (c *clusterInfo) getStoresWriteStat() map[uint64]uint64 {
 func (c *clusterInfo) getStoresReadStat() map[uint64]uint64 {
 	c.RLock()
 	defer c.RUnlock()
-    return c.stores.GetStoresReadStat()
+	return c.stores.GetStoresReadStat()
 }
 
 // GetRegions searches for a region by ID.

--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -53,31 +53,31 @@ func newTestStores(n uint64) []*core.StoreInfo {
 
 func (s *testStoresInfoSuite) TestStores(c *C) {
 	n := uint64(10)
-	cache := newStoresInfo()
+	cache := core.NewStoresInfo()
 	stores := newTestStores(n)
 
 	for i := uint64(0); i < n; i++ {
-		c.Assert(cache.getStore(i), IsNil)
-		c.Assert(cache.blockStore(i), NotNil)
-		cache.setStore(stores[i])
-		c.Assert(cache.getStore(i), DeepEquals, stores[i])
-		c.Assert(cache.getStoreCount(), Equals, int(i+1))
-		c.Assert(cache.blockStore(i), IsNil)
-		c.Assert(cache.getStore(i).IsBlocked(), IsTrue)
-		c.Assert(cache.blockStore(i), NotNil)
-		cache.unblockStore(i)
-		c.Assert(cache.getStore(i).IsBlocked(), IsFalse)
+		c.Assert(cache.GetStore(i), IsNil)
+		c.Assert(cache.BlockStore(i), NotNil)
+		cache.SetStore(stores[i])
+		c.Assert(cache.GetStore(i), DeepEquals, stores[i])
+		c.Assert(cache.GetStoreCount(), Equals, int(i+1))
+		c.Assert(cache.BlockStore(i), IsNil)
+		c.Assert(cache.GetStore(i).IsBlocked(), IsTrue)
+		c.Assert(cache.BlockStore(i), NotNil)
+		cache.UnblockStore(i)
+		c.Assert(cache.GetStore(i).IsBlocked(), IsFalse)
 	}
-	c.Assert(cache.getStoreCount(), Equals, int(n))
+	c.Assert(cache.GetStoreCount(), Equals, int(n))
 
-	for _, store := range cache.getStores() {
+	for _, store := range cache.GetStores() {
 		c.Assert(store, DeepEquals, stores[store.GetId()])
 	}
-	for _, store := range cache.getMetaStores() {
+	for _, store := range cache.GetMetaStores() {
 		c.Assert(store, DeepEquals, stores[store.GetId()].Store)
 	}
 
-	c.Assert(cache.getStoreCount(), Equals, int(n))
+	c.Assert(cache.GetStoreCount(), Equals, int(n))
 }
 
 var _ = Suite(&testRegionsInfoSuite{})
@@ -110,47 +110,47 @@ func newTestRegions(n, np uint64) []*core.RegionInfo {
 
 func (s *testRegionsInfoSuite) Test(c *C) {
 	n, np := uint64(10), uint64(3)
-	cache := newRegionsInfo()
+	cache := core.NewRegionsInfo()
 	regions := newTestRegions(n, np)
 
 	for i := uint64(0); i < n; i++ {
 		region := regions[i]
 		regionKey := []byte{byte(i)}
 
-		c.Assert(cache.getRegion(i), IsNil)
-		c.Assert(cache.searchRegion(regionKey), IsNil)
+		c.Assert(cache.GetRegion(i), IsNil)
+		c.Assert(cache.SearchRegion(regionKey), IsNil)
 		checkRegions(c, cache, regions[0:i])
 
-		cache.addRegion(region)
-		checkRegion(c, cache.getRegion(i), region)
-		checkRegion(c, cache.searchRegion(regionKey), region)
+		cache.AddRegion(region)
+		checkRegion(c, cache.GetRegion(i), region)
+		checkRegion(c, cache.SearchRegion(regionKey), region)
 		checkRegions(c, cache, regions[0:(i+1)])
 
 		// Update leader to peer np-1.
 		region.Leader = region.Peers[np-1]
-		cache.setRegion(region)
-		checkRegion(c, cache.getRegion(i), region)
-		checkRegion(c, cache.searchRegion(regionKey), region)
+		cache.SetRegion(region)
+		checkRegion(c, cache.GetRegion(i), region)
+		checkRegion(c, cache.SearchRegion(regionKey), region)
 		checkRegions(c, cache, regions[0:(i+1)])
 
-		cache.removeRegion(region)
-		c.Assert(cache.getRegion(i), IsNil)
-		c.Assert(cache.searchRegion(regionKey), IsNil)
+		cache.RemoveRegion(region)
+		c.Assert(cache.GetRegion(i), IsNil)
+		c.Assert(cache.SearchRegion(regionKey), IsNil)
 		checkRegions(c, cache, regions[0:i])
 
 		// Reset leader to peer 0.
 		region.Leader = region.Peers[0]
-		cache.addRegion(region)
-		checkRegion(c, cache.getRegion(i), region)
+		cache.AddRegion(region)
+		checkRegion(c, cache.GetRegion(i), region)
 		checkRegions(c, cache, regions[0:(i+1)])
-		checkRegion(c, cache.searchRegion(regionKey), region)
+		checkRegion(c, cache.SearchRegion(regionKey), region)
 	}
 
 	for i := uint64(0); i < n; i++ {
-		region := cache.randLeaderRegion(i)
+		region := cache.RandLeaderRegion(i)
 		c.Assert(region.Leader.GetStoreId(), Equals, i)
 
-		region = cache.randFollowerRegion(i)
+		region = cache.RandFollowerRegion(i)
 		c.Assert(region.Leader.GetStoreId(), Not(Equals), i)
 
 		c.Assert(region.GetStorePeer(i), NotNil)
@@ -158,15 +158,15 @@ func (s *testRegionsInfoSuite) Test(c *C) {
 
 	// All regions will be filtered out if they have pending peers.
 	for i := uint64(0); i < n; i++ {
-		for j := 0; j < cache.getStoreLeaderCount(i); j++ {
-			region := cache.randLeaderRegion(i)
+		for j := 0; j < cache.GetStoreLeaderCount(i); j++ {
+			region := cache.RandLeaderRegion(i)
 			region.PendingPeers = region.Peers
-			cache.setRegion(region)
+			cache.SetRegion(region)
 		}
-		c.Assert(cache.randLeaderRegion(i), IsNil)
+		c.Assert(cache.RandLeaderRegion(i), IsNil)
 	}
 	for i := uint64(0); i < n; i++ {
-		c.Assert(cache.randFollowerRegion(i), IsNil)
+		c.Assert(cache.RandFollowerRegion(i), IsNil)
 	}
 }
 
@@ -194,7 +194,7 @@ func checkRegionsKV(c *C, kv *kv, regions []*core.RegionInfo) {
 	}
 }
 
-func checkRegions(c *C, cache *regionsInfo, regions []*core.RegionInfo) {
+func checkRegions(c *C, cache *core.RegionsInfo, regions []*core.RegionInfo) {
 	regionCount := make(map[uint64]int)
 	leaderCount := make(map[uint64]int)
 	followerCount := make(map[uint64]int)
@@ -203,29 +203,29 @@ func checkRegions(c *C, cache *regionsInfo, regions []*core.RegionInfo) {
 			regionCount[peer.StoreId]++
 			if peer.Id == region.Leader.Id {
 				leaderCount[peer.StoreId]++
-				checkRegion(c, cache.leaders[peer.StoreId].Get(region.Id), region)
+				checkRegion(c, cache.GetLeader(peer.StoreId, region.Id), region)
 			} else {
 				followerCount[peer.StoreId]++
-				checkRegion(c, cache.followers[peer.StoreId].Get(region.Id), region)
+				checkRegion(c, cache.GetFollower(peer.StoreId, region.Id), region)
 			}
 		}
 	}
 
-	c.Assert(cache.getRegionCount(), Equals, len(regions))
+	c.Assert(cache.GetRegionCount(), Equals, len(regions))
 	for id, count := range regionCount {
-		c.Assert(cache.getStoreRegionCount(id), Equals, count)
+		c.Assert(cache.GetStoreRegionCount(id), Equals, count)
 	}
 	for id, count := range leaderCount {
-		c.Assert(cache.getStoreLeaderCount(id), Equals, count)
+		c.Assert(cache.GetStoreLeaderCount(id), Equals, count)
 	}
 	for id, count := range followerCount {
-		c.Assert(cache.getStoreFollowerCount(id), Equals, count)
+		c.Assert(cache.GetStoreFollowerCount(id), Equals, count)
 	}
 
-	for _, region := range cache.getRegions() {
+	for _, region := range cache.GetRegions() {
 		checkRegion(c, region, regions[region.GetId()])
 	}
-	for _, region := range cache.getMetaRegions() {
+	for _, region := range cache.GetMetaRegions() {
 		c.Assert(region, DeepEquals, regions[region.GetId()].Region)
 	}
 }
@@ -444,9 +444,9 @@ func (s *testClusterInfoSuite) testRegionHeartbeat(c *C, cache *clusterInfo) {
 		}
 	}
 
-	for _, store := range cache.stores.getStores() {
-		c.Assert(store.LeaderCount, Equals, cache.regions.getStoreLeaderCount(store.GetId()))
-		c.Assert(store.RegionCount, Equals, cache.regions.getStoreRegionCount(store.GetId()))
+    for _, store := range cache.stores.GetStores() {
+		c.Assert(store.LeaderCount, Equals, cache.regions.GetStoreLeaderCount(store.GetId()))
+		c.Assert(store.RegionCount, Equals, cache.regions.GetStoreRegionCount(store.GetId()))
 	}
 
 	// Test with kv.
@@ -508,22 +508,22 @@ func (s *testClusterInfoSuite) testRegionSplitAndMerge(c *C, cache *clusterInfo)
 
 	// Split.
 	for i := 0; i < n; i++ {
-		regions = splitRegions(regions)
+		regions = core.SplitRegions(regions)
 		heartbeatRegions(c, cache, regions)
 	}
 
 	// Merge.
 	for i := 0; i < n; i++ {
-		regions = mergeRegions(regions)
+		regions = core.MergeRegions(regions)
 		heartbeatRegions(c, cache, regions)
 	}
 
 	// Split twice and merge once.
 	for i := 0; i < n*2; i++ {
 		if (i+1)%3 == 0 {
-			regions = mergeRegions(regions)
+			regions = core.MergeRegions(regions)
 		} else {
-			regions = splitRegions(regions)
+			regions = core.SplitRegions(regions)
 		}
 		heartbeatRegions(c, cache, regions)
 	}
@@ -535,8 +535,8 @@ type testClusterUtilSuite struct{}
 
 func (s *testClusterUtilSuite) TestCheckStaleRegion(c *C) {
 	// (0, 0) v.s. (0, 0)
-	region := newRegion([]byte{}, []byte{})
-	origin := newRegion([]byte{}, []byte{})
+	region := core.NewRegion([]byte{}, []byte{})
+	origin := core.NewRegion([]byte{}, []byte{})
 	c.Assert(checkStaleRegion(region, origin), IsNil)
 	c.Assert(checkStaleRegion(origin, region), IsNil)
 
@@ -569,68 +569,3 @@ func (alloc *mockIDAllocator) Alloc() (uint64, error) {
 	return atomic.AddUint64(&alloc.base, 1), nil
 }
 
-var _ = Suite(&testRegionMapSuite{})
-
-type testRegionMapSuite struct{}
-
-func (s *testRegionMapSuite) TestRegionMap(c *C) {
-	var empty *regionMap
-	c.Assert(empty.Len(), Equals, 0)
-	c.Assert(empty.Get(1), IsNil)
-
-	rm := newRegionMap()
-	s.check(c, rm)
-	rm.Put(s.regionInfo(1))
-	s.check(c, rm, 1)
-
-	rm.Put(s.regionInfo(2))
-	rm.Put(s.regionInfo(3))
-	s.check(c, rm, 1, 2, 3)
-
-	rm.Put(s.regionInfo(3))
-	rm.Delete(4)
-	s.check(c, rm, 1, 2, 3)
-
-	rm.Delete(3)
-	rm.Delete(1)
-	s.check(c, rm, 2)
-
-	rm.Put(s.regionInfo(3))
-	s.check(c, rm, 2, 3)
-}
-
-func (s *testRegionMapSuite) regionInfo(id uint64) *core.RegionInfo {
-	return &core.RegionInfo{
-		Region: &metapb.Region{
-			Id: id,
-		},
-	}
-}
-
-func (s *testRegionMapSuite) check(c *C, rm *regionMap, ids ...uint64) {
-	// Check position.
-	for _, r := range rm.m {
-		c.Assert(rm.ids[r.pos], Equals, r.Id)
-	}
-	// Check Get.
-	for _, id := range ids {
-		c.Assert(rm.Get(id).Id, Equals, id)
-	}
-	// Check Len.
-	c.Assert(rm.Len(), Equals, len(ids))
-	// Check id set.
-	expect := make(map[uint64]struct{})
-	for _, id := range ids {
-		expect[id] = struct{}{}
-	}
-	set1 := make(map[uint64]struct{})
-	for _, r := range rm.m {
-		set1[r.Id] = struct{}{}
-	}
-	set2 := make(map[uint64]struct{})
-	for _, id := range rm.ids {
-		set2[id] = struct{}{}
-	}
-	c.Assert(set1, DeepEquals, expect)
-	c.Assert(set2, DeepEquals, expect)
-}

--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -444,7 +444,7 @@ func (s *testClusterInfoSuite) testRegionHeartbeat(c *C, cache *clusterInfo) {
 		}
 	}
 
-    for _, store := range cache.stores.GetStores() {
+	for _, store := range cache.stores.GetStores() {
 		c.Assert(store.LeaderCount, Equals, cache.regions.GetStoreLeaderCount(store.GetId()))
 		c.Assert(store.RegionCount, Equals, cache.regions.GetStoreRegionCount(store.GetId()))
 	}
@@ -568,4 +568,3 @@ func newMockIDAllocator() *mockIDAllocator {
 func (alloc *mockIDAllocator) Alloc() (uint64, error) {
 	return atomic.AddUint64(&alloc.base, 1), nil
 }
-

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -466,7 +466,7 @@ func (c *RaftCluster) RemoveStore(storeID uint64) error {
 
 	store := cluster.GetStore(storeID)
 	if store == nil {
-		return errors.Trace(errStoreNotFound(storeID))
+		return errors.Trace(core.ErrStoreNotFound(storeID))
 	}
 
 	// Remove an offline store should be OK, nothing to do.
@@ -495,7 +495,7 @@ func (c *RaftCluster) BuryStore(storeID uint64, force bool) error {
 
 	store := cluster.GetStore(storeID)
 	if store == nil {
-		return errors.Trace(errStoreNotFound(storeID))
+		return errors.Trace(core.ErrStoreNotFound(storeID))
 	}
 
 	// Bury a tombstone store should be OK, nothing to do.
@@ -524,7 +524,7 @@ func (c *RaftCluster) SetStoreState(storeID uint64, state metapb.StoreState) err
 
 	store := cluster.GetStore(storeID)
 	if store == nil {
-		return errors.Trace(errStoreNotFound(storeID))
+		return errors.Trace(core.ErrStoreNotFound(storeID))
 	}
 
 	store.State = state
@@ -539,7 +539,7 @@ func (c *RaftCluster) SetStoreWeight(storeID uint64, leader, region float64) err
 
 	store := c.cachedCluster.GetStore(storeID)
 	if store == nil {
-		return errors.Trace(errStoreNotFound(storeID))
+		return errors.Trace(core.ErrStoreNotFound(storeID))
 	}
 
 	if err := c.s.kv.saveStoreWeight(storeID, leader, region); err != nil {

--- a/server/cluster_worker_test.go
+++ b/server/cluster_worker_test.go
@@ -390,14 +390,14 @@ func (s *testClusterWorkerSuite) checkSearchRegions(cluster *RaftCluster, keys .
 		defer cluster.cachedCluster.RUnlock()
 
 		cacheRegions := cluster.cachedCluster.regions
-		if cacheRegions.tree.length() != len(keys)/2 {
-			c.Logf("region length not match, expect %v, got %v", len(keys)/2, cacheRegions.tree.length())
+		if cacheRegions.TreeLength() != len(keys)/2 {
+			c.Logf("region length not match, expect %v, got %v", len(keys)/2, cacheRegions.TreeLength())
 			return false
 		}
 
 		for i := 0; i < len(keys); i += 2 {
 			start, end := []byte(keys[i]), []byte(keys[i+1])
-			region := cacheRegions.tree.search(start)
+			region := cacheRegions.SearchRegion(start)
 			if region == nil {
 				c.Logf("region not found for key: %q", start)
 				return false

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -14,7 +14,13 @@
 package core
 
 import (
+	"math/rand"
 	"time"
+  "fmt"
+  "reflect"
+  "strings"
+  "bytes"
+
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -170,3 +176,282 @@ type HotRegionsStat struct {
 	RegionsCount   int         `json:"regions_count"`
 	RegionsStat    RegionsStat `json:"statistics"`
 }
+
+// regionMap wraps a map[uint64]*core.RegionInfo and supports randomly pick a region.
+type regionMap struct {
+	m   map[uint64]*regionEntry
+	ids []uint64
+}
+
+type regionEntry struct {
+	*RegionInfo
+	pos int
+}
+
+func newRegionMap() *regionMap {
+	return &regionMap{
+		m: make(map[uint64]*regionEntry),
+	}
+}
+
+func (rm *regionMap) Len() int {
+	if rm == nil {
+		return 0
+	}
+	return len(rm.m)
+}
+
+func (rm *regionMap) Get(id uint64) *RegionInfo {
+	if rm == nil {
+		return nil
+	}
+	if entry, ok := rm.m[id]; ok {
+		return entry.RegionInfo
+	}
+	return nil
+}
+
+func (rm *regionMap) Put(region *RegionInfo) {
+	if old, ok := rm.m[region.GetId()]; ok {
+		old.RegionInfo = region
+		return
+	}
+	rm.m[region.GetId()] = &regionEntry{
+		RegionInfo: region,
+		pos:        len(rm.ids),
+	}
+	rm.ids = append(rm.ids, region.GetId())
+}
+
+func (rm *regionMap) RandomRegion() *RegionInfo {
+	if rm.Len() == 0 {
+		return nil
+	}
+	return rm.Get(rm.ids[rand.Intn(rm.Len())])
+}
+
+func (rm *regionMap) Delete(id uint64) {
+	if rm == nil {
+		return
+	}
+	if old, ok := rm.m[id]; ok {
+		len := rm.Len()
+		last := rm.m[rm.ids[len-1]]
+		last.pos = old.pos
+		rm.ids[last.pos] = last.GetId()
+		delete(rm.m, id)
+		rm.ids = rm.ids[:len-1]
+	}
+}
+
+// RegionsInfo for export
+type RegionsInfo struct {
+	tree      *regionTree
+	regions   *regionMap            // regionID -> regionInfo
+	leaders   map[uint64]*regionMap // storeID -> regionID -> regionInfo
+	followers map[uint64]*regionMap // storeID -> regionID -> regionInfo
+}
+
+func NewRegionsInfo() *RegionsInfo {
+	return &RegionsInfo{
+		tree:      newRegionTree(),
+		regions:   newRegionMap(),
+		leaders:   make(map[uint64]*regionMap),
+		followers: make(map[uint64]*regionMap),
+	}
+}
+
+func (r *RegionsInfo) GetRegion(regionID uint64) *RegionInfo {
+	region := r.regions.Get(regionID)
+	if region == nil {
+		return nil
+	}
+	return region.Clone()
+}
+
+func (r *RegionsInfo) SetRegion(region *RegionInfo) {
+	if origin := r.regions.Get(region.GetId()); origin != nil {
+		r.RemoveRegion(origin)
+	}
+	r.AddRegion(region)
+}
+
+func (r *RegionsInfo) Length() int {
+    return r.regions.Len()
+}
+
+func (r *RegionsInfo) TreeLength() int {
+  return r.tree.length()
+}
+func (r *RegionsInfo) AddRegion(region *RegionInfo) {
+	// Add to tree and regions.
+	r.tree.update(region.Region)
+	r.regions.Put(region)
+
+	if region.Leader == nil {
+		return
+	}
+
+	// Add to leaders and followers.
+	for _, peer := range region.GetPeers() {
+		storeID := peer.GetStoreId()
+		if peer.GetId() == region.Leader.GetId() {
+			// Add leader peer to leaders.
+			store, ok := r.leaders[storeID]
+			if !ok {
+				store = newRegionMap()
+				r.leaders[storeID] = store
+			}
+			store.Put(region)
+		} else {
+			// Add follower peer to followers.
+			store, ok := r.followers[storeID]
+			if !ok {
+				store = newRegionMap()
+				r.followers[storeID] = store
+			}
+			store.Put(region)
+		}
+	}
+}
+
+func (r *RegionsInfo) RemoveRegion(region *RegionInfo) {
+	// Remove from tree and regions.
+	r.tree.remove(region.Region)
+	r.regions.Delete(region.GetId())
+
+	// Remove from leaders and followers.
+	for _, peer := range region.GetPeers() {
+		storeID := peer.GetStoreId()
+		r.leaders[storeID].Delete(region.GetId())
+		r.followers[storeID].Delete(region.GetId())
+	}
+}
+
+func (r *RegionsInfo) SearchRegion(regionKey []byte) *RegionInfo {
+	region := r.tree.search(regionKey)
+	if region == nil {
+		return nil
+	}
+	return r.GetRegion(region.GetId())
+}
+
+func (r *RegionsInfo) GetRegions() []*RegionInfo {
+	regions := make([]*RegionInfo, 0, r.regions.Len())
+	for _, region := range r.regions.m {
+		regions = append(regions, region.Clone())
+	}
+	return regions
+}
+
+func (r *RegionsInfo) GetMetaRegions() []*metapb.Region {
+	regions := make([]*metapb.Region, 0, r.regions.Len())
+	for _, region := range r.regions.m {
+		regions = append(regions, proto.Clone(region.Region).(*metapb.Region))
+	}
+	return regions
+}
+
+func (r *RegionsInfo) GetRegionCount() int {
+	return r.regions.Len()
+}
+
+func (r *RegionsInfo) GetStoreRegionCount(storeID uint64) int {
+	return r.GetStoreLeaderCount(storeID) + r.GetStoreFollowerCount(storeID)
+}
+
+func (r *RegionsInfo) GetStoreLeaderCount(storeID uint64) int {
+	return r.leaders[storeID].Len()
+}
+
+func (r *RegionsInfo) GetStoreFollowerCount(storeID uint64) int {
+	return r.followers[storeID].Len()
+}
+
+func (r *RegionsInfo) RandRegion() *RegionInfo {
+	return randRegion(r.regions)
+}
+
+func (r *RegionsInfo) RandLeaderRegion(storeID uint64) *RegionInfo {
+	return randRegion(r.leaders[storeID])
+}
+
+func (r *RegionsInfo) RandFollowerRegion(storeID uint64) *RegionInfo {
+	return randRegion(r.followers[storeID])
+}
+
+// for test
+
+func (r *RegionsInfo) GetLeader(storeID uint64, regionID uint64) *RegionInfo {
+  return r.leaders[storeID].Get(regionID)
+}
+
+func (r *RegionsInfo) GetFollower(storeID uint64, regionID uint64) *RegionInfo {
+  return r.followers[storeID].Get(regionID)
+}
+
+
+const randomRegionMaxRetry = 10
+
+func randRegion(regions *regionMap) *RegionInfo {
+	for i := 0; i < randomRegionMaxRetry; i++ {
+		region := regions.RandomRegion()
+		if region == nil {
+			return nil
+		}
+		if len(region.DownPeers) == 0 && len(region.PendingPeers) == 0 {
+			return region.Clone()
+		}
+	}
+	return nil
+}
+
+func DiffRegionPeersInfo(origin *RegionInfo, other *RegionInfo) string {
+	var ret []string
+	for _, a := range origin.Peers {
+		both := false
+		for _, b := range other.Peers {
+			if reflect.DeepEqual(a, b) {
+				both = true
+				break
+			}
+		}
+		if !both {
+			ret = append(ret, fmt.Sprintf("Remove peer:{%v}", a))
+		}
+	}
+	for _, b := range other.Peers {
+		both := false
+		for _, a := range origin.Peers {
+			if reflect.DeepEqual(a, b) {
+				both = true
+				break
+			}
+		}
+		if !both {
+			ret = append(ret, fmt.Sprintf("Add peer:{%v}", b))
+		}
+	}
+	return strings.Join(ret, ",")
+}
+
+func DiffRegionKeyInfo(origin *RegionInfo, other *RegionInfo) string {
+	var ret []string
+	if !bytes.Equal(origin.Region.StartKey, other.Region.StartKey) {
+		originKey := &metapb.Region{StartKey: origin.Region.StartKey}
+		otherKey := &metapb.Region{StartKey: other.Region.StartKey}
+		ret = append(ret, fmt.Sprintf("StartKey Changed:{%s} -> {%s}", originKey, otherKey))
+	}
+	if !bytes.Equal(origin.Region.EndKey, other.Region.EndKey) {
+		originKey := &metapb.Region{EndKey: origin.Region.EndKey}
+		otherKey := &metapb.Region{EndKey: other.Region.EndKey}
+		ret = append(ret, fmt.Sprintf("EndKey Changed:{%s} -> {%s}", originKey, otherKey))
+	}
+
+	return strings.Join(ret, ",")
+}
+
+
+
+
+

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -252,6 +252,7 @@ type RegionsInfo struct {
 	followers map[uint64]*regionMap // storeID -> regionID -> regionInfo
 }
 
+// NewRegionsInfo creates RegionsInfo with tree, regions, leaders and followers
 func NewRegionsInfo() *RegionsInfo {
 	return &RegionsInfo{
 		tree:      newRegionTree(),
@@ -261,6 +262,7 @@ func NewRegionsInfo() *RegionsInfo {
 	}
 }
 
+// GetRegion return the RegionInfo with regionID 
 func (r *RegionsInfo) GetRegion(regionID uint64) *RegionInfo {
 	region := r.regions.Get(regionID)
 	if region == nil {
@@ -269,6 +271,7 @@ func (r *RegionsInfo) GetRegion(regionID uint64) *RegionInfo {
 	return region.Clone()
 }
 
+// SetRegion set the RegionInfo with regionID
 func (r *RegionsInfo) SetRegion(region *RegionInfo) {
 	if origin := r.regions.Get(region.GetId()); origin != nil {
 		r.RemoveRegion(origin)
@@ -276,13 +279,17 @@ func (r *RegionsInfo) SetRegion(region *RegionInfo) {
 	r.AddRegion(region)
 }
 
+// Length return the RegionsInfo length
 func (r *RegionsInfo) Length() int {
     return r.regions.Len()
 }
 
+// TreeLength return the RegionsInfo tree length(now only used in test) 
 func (r *RegionsInfo) TreeLength() int {
   return r.tree.length()
 }
+
+// AddRegion add RegionInfo to regionTree and regionMap, also update leadres and followers by region peers
 func (r *RegionsInfo) AddRegion(region *RegionInfo) {
 	// Add to tree and regions.
 	r.tree.update(region.Region)
@@ -315,6 +322,7 @@ func (r *RegionsInfo) AddRegion(region *RegionInfo) {
 	}
 }
 
+// RemoveRegion remove RegionInfo from regionTree and regionMap
 func (r *RegionsInfo) RemoveRegion(region *RegionInfo) {
 	// Remove from tree and regions.
 	r.tree.remove(region.Region)
@@ -328,6 +336,7 @@ func (r *RegionsInfo) RemoveRegion(region *RegionInfo) {
 	}
 }
 
+// SearchRegion search RegionInfo from regionTree
 func (r *RegionsInfo) SearchRegion(regionKey []byte) *RegionInfo {
 	region := r.tree.search(regionKey)
 	if region == nil {
@@ -336,6 +345,7 @@ func (r *RegionsInfo) SearchRegion(regionKey []byte) *RegionInfo {
 	return r.GetRegion(region.GetId())
 }
 
+// GetRegions get a set of RegionInfo from regionMap
 func (r *RegionsInfo) GetRegions() []*RegionInfo {
 	regions := make([]*RegionInfo, 0, r.regions.Len())
 	for _, region := range r.regions.m {
@@ -344,6 +354,7 @@ func (r *RegionsInfo) GetRegions() []*RegionInfo {
 	return regions
 }
 
+// GetMetaRegions get a set of metapb.Region from regionMap
 func (r *RegionsInfo) GetMetaRegions() []*metapb.Region {
 	regions := make([]*metapb.Region, 0, r.regions.Len())
 	for _, region := range r.regions.m {
@@ -352,40 +363,47 @@ func (r *RegionsInfo) GetMetaRegions() []*metapb.Region {
 	return regions
 }
 
+// GetRegionCount get the total count of RegionInfo of regionMap
 func (r *RegionsInfo) GetRegionCount() int {
 	return r.regions.Len()
 }
 
+// GetStoreRegionCount get  the total count of  a store's leader and follower RegionInfo by storeID
 func (r *RegionsInfo) GetStoreRegionCount(storeID uint64) int {
 	return r.GetStoreLeaderCount(storeID) + r.GetStoreFollowerCount(storeID)
 }
 
+// GetStoreLeaderCount get the total count of a store's leader RegionInfo
 func (r *RegionsInfo) GetStoreLeaderCount(storeID uint64) int {
 	return r.leaders[storeID].Len()
 }
 
+// GetStoreLeaderCount get the total count of a store's follower RegionInfo
 func (r *RegionsInfo) GetStoreFollowerCount(storeID uint64) int {
 	return r.followers[storeID].Len()
 }
 
+// RandRegion get a region by random
 func (r *RegionsInfo) RandRegion() *RegionInfo {
 	return randRegion(r.regions)
 }
 
+// RandLeaderRegion get a store's leader region by random
 func (r *RegionsInfo) RandLeaderRegion(storeID uint64) *RegionInfo {
 	return randRegion(r.leaders[storeID])
 }
 
+// RandLeaderRegion get a store's follower region by random
 func (r *RegionsInfo) RandFollowerRegion(storeID uint64) *RegionInfo {
 	return randRegion(r.followers[storeID])
 }
 
-// for test
-
+// GetLeader return leader RegionInfo by storeID and regionID(now only used in test)
 func (r *RegionsInfo) GetLeader(storeID uint64, regionID uint64) *RegionInfo {
   return r.leaders[storeID].Get(regionID)
 }
 
+// GetFollower return follower RegionInfo by storeID and regionID(now only used in test)
 func (r *RegionsInfo) GetFollower(storeID uint64, regionID uint64) *RegionInfo {
   return r.followers[storeID].Get(regionID)
 }
@@ -406,6 +424,7 @@ func randRegion(regions *regionMap) *RegionInfo {
 	return nil
 }
 
+// DiffRegionPeersInfo return the difference of peers info  between two RegionInfo
 func DiffRegionPeersInfo(origin *RegionInfo, other *RegionInfo) string {
 	var ret []string
 	for _, a := range origin.Peers {
@@ -435,6 +454,7 @@ func DiffRegionPeersInfo(origin *RegionInfo, other *RegionInfo) string {
 	return strings.Join(ret, ",")
 }
 
+// DiffRegionPeersInfo return the difference of key info between two RegionInfo
 func DiffRegionKeyInfo(origin *RegionInfo, other *RegionInfo) string {
 	var ret []string
 	if !bytes.Equal(origin.Region.StartKey, other.Region.StartKey) {

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -14,13 +14,12 @@
 package core
 
 import (
+	"bytes"
+	"fmt"
 	"math/rand"
+	"reflect"
+	"strings"
 	"time"
-  "fmt"
-  "reflect"
-  "strings"
-  "bytes"
-
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -262,7 +261,7 @@ func NewRegionsInfo() *RegionsInfo {
 	}
 }
 
-// GetRegion return the RegionInfo with regionID 
+// GetRegion return the RegionInfo with regionID
 func (r *RegionsInfo) GetRegion(regionID uint64) *RegionInfo {
 	region := r.regions.Get(regionID)
 	if region == nil {
@@ -281,12 +280,12 @@ func (r *RegionsInfo) SetRegion(region *RegionInfo) {
 
 // Length return the RegionsInfo length
 func (r *RegionsInfo) Length() int {
-    return r.regions.Len()
+	return r.regions.Len()
 }
 
-// TreeLength return the RegionsInfo tree length(now only used in test) 
+// TreeLength return the RegionsInfo tree length(now only used in test)
 func (r *RegionsInfo) TreeLength() int {
-  return r.tree.length()
+	return r.tree.length()
 }
 
 // AddRegion add RegionInfo to regionTree and regionMap, also update leadres and followers by region peers
@@ -400,14 +399,13 @@ func (r *RegionsInfo) RandFollowerRegion(storeID uint64) *RegionInfo {
 
 // GetLeader return leader RegionInfo by storeID and regionID(now only used in test)
 func (r *RegionsInfo) GetLeader(storeID uint64, regionID uint64) *RegionInfo {
-  return r.leaders[storeID].Get(regionID)
+	return r.leaders[storeID].Get(regionID)
 }
 
 // GetFollower return follower RegionInfo by storeID and regionID(now only used in test)
 func (r *RegionsInfo) GetFollower(storeID uint64, regionID uint64) *RegionInfo {
-  return r.followers[storeID].Get(regionID)
+	return r.followers[storeID].Get(regionID)
 }
-
 
 const randomRegionMaxRetry = 10
 
@@ -470,8 +468,3 @@ func DiffRegionKeyInfo(origin *RegionInfo, other *RegionInfo) string {
 
 	return strings.Join(ret, ",")
 }
-
-
-
-
-

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -378,7 +378,7 @@ func (r *RegionsInfo) GetStoreLeaderCount(storeID uint64) int {
 	return r.leaders[storeID].Len()
 }
 
-// GetStoreLeaderCount get the total count of a store's follower RegionInfo
+// GetStoreFollowerCount get the total count of a store's follower RegionInfo
 func (r *RegionsInfo) GetStoreFollowerCount(storeID uint64) int {
 	return r.followers[storeID].Len()
 }
@@ -393,7 +393,7 @@ func (r *RegionsInfo) RandLeaderRegion(storeID uint64) *RegionInfo {
 	return randRegion(r.leaders[storeID])
 }
 
-// RandLeaderRegion get a store's follower region by random
+// RandFollowerRegion get a store's follower region by random
 func (r *RegionsInfo) RandFollowerRegion(storeID uint64) *RegionInfo {
 	return randRegion(r.followers[storeID])
 }
@@ -454,7 +454,7 @@ func DiffRegionPeersInfo(origin *RegionInfo, other *RegionInfo) string {
 	return strings.Join(ret, ",")
 }
 
-// DiffRegionPeersInfo return the difference of key info between two RegionInfo
+// DiffRegionKeyInfo return the difference of key info between two RegionInfo
 func DiffRegionKeyInfo(origin *RegionInfo, other *RegionInfo) string {
 	var ret []string
 	if !bytes.Equal(origin.Region.StartKey, other.Region.StartKey) {

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -15,7 +15,7 @@ package core
 
 import (
 	. "github.com/pingcap/check"
-  "github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/metapb"
 )
 
 var _ = Suite(&testRegionMapSuite{})

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -1,0 +1,85 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	. "github.com/pingcap/check"
+  "github.com/pingcap/kvproto/pkg/metapb"
+)
+
+var _ = Suite(&testRegionMapSuite{})
+
+type testRegionMapSuite struct{}
+
+func (s *testRegionMapSuite) TestRegionMap(c *C) {
+	var empty *regionMap
+	c.Assert(empty.Len(), Equals, 0)
+	c.Assert(empty.Get(1), IsNil)
+
+	rm := newRegionMap()
+	s.check(c, rm)
+	rm.Put(s.regionInfo(1))
+	s.check(c, rm, 1)
+
+	rm.Put(s.regionInfo(2))
+	rm.Put(s.regionInfo(3))
+	s.check(c, rm, 1, 2, 3)
+
+	rm.Put(s.regionInfo(3))
+	rm.Delete(4)
+	s.check(c, rm, 1, 2, 3)
+
+	rm.Delete(3)
+	rm.Delete(1)
+	s.check(c, rm, 2)
+
+	rm.Put(s.regionInfo(3))
+	s.check(c, rm, 2, 3)
+}
+
+func (s *testRegionMapSuite) regionInfo(id uint64) *RegionInfo {
+	return &RegionInfo{
+		Region: &metapb.Region{
+			Id: id,
+		},
+	}
+}
+
+func (s *testRegionMapSuite) check(c *C, rm *regionMap, ids ...uint64) {
+	// Check position.
+	for _, r := range rm.m {
+		c.Assert(rm.ids[r.pos], Equals, r.Id)
+	}
+	// Check Get.
+	for _, id := range ids {
+		c.Assert(rm.Get(id).Id, Equals, id)
+	}
+	// Check Len.
+	c.Assert(rm.Len(), Equals, len(ids))
+	// Check id set.
+	expect := make(map[uint64]struct{})
+	for _, id := range ids {
+		expect[id] = struct{}{}
+	}
+	set1 := make(map[uint64]struct{})
+	for _, r := range rm.m {
+		set1[r.Id] = struct{}{}
+	}
+	set2 := make(map[uint64]struct{})
+	for _, id := range rm.ids {
+		set2[id] = struct{}{}
+	}
+	c.Assert(set1, DeepEquals, expect)
+	c.Assert(set2, DeepEquals, expect)
+}

--- a/server/core/region_tree.go
+++ b/server/core/region_tree.go
@@ -10,7 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package core
 
 import (
 	"bytes"

--- a/server/core/region_tree_test.go
+++ b/server/core/region_tree_test.go
@@ -15,8 +15,8 @@ package core
 
 import (
 	. "github.com/pingcap/check"
-  "github.com/pingcap/kvproto/pkg/metapb"
-  "github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
 )
 
 var _ = Suite(&testRegionSuite{})

--- a/server/core/region_tree_test.go
+++ b/server/core/region_tree_test.go
@@ -11,16 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package core
 
 import (
-	"math"
-
-	"github.com/gogo/protobuf/proto"
 	. "github.com/pingcap/check"
-	"github.com/pingcap/kvproto/pkg/metapb"
-	"github.com/pingcap/kvproto/pkg/pdpb"
-	"github.com/pingcap/pd/server/core"
+  "github.com/pingcap/kvproto/pkg/metapb"
+  "github.com/pingcap/kvproto/pkg/pdpb"
 )
 
 var _ = Suite(&testRegionSuite{})
@@ -43,7 +39,7 @@ func (s *testRegionSuite) TestRegionInfo(c *C) {
 	}
 	downPeer, pendingPeer := peers[0], peers[1]
 
-	info := core.NewRegionInfo(region, peers[0])
+	info := NewRegionInfo(region, peers[0])
 	info.DownPeers = []*pdpb.PeerStats{{Peer: downPeer}}
 	info.PendingPeers = []*metapb.Peer{pendingPeer}
 
@@ -69,16 +65,16 @@ func (s *testRegionSuite) TestRegionInfo(c *C) {
 		StoreId: n,
 	}
 	r.Peers = append(r.Peers, removePeer)
-	c.Assert(diffRegionPeersInfo(info, r), Matches, "Add peer.*")
-	c.Assert(diffRegionPeersInfo(r, info), Matches, "Remove peer.*")
+	c.Assert(DiffRegionPeersInfo(info, r), Matches, "Add peer.*")
+	c.Assert(DiffRegionPeersInfo(r, info), Matches, "Remove peer.*")
 	c.Assert(r.GetStorePeer(n), DeepEquals, removePeer)
 	r.RemoveStorePeer(n)
-	c.Assert(diffRegionPeersInfo(r, info), Equals, "")
+	c.Assert(DiffRegionPeersInfo(r, info), Equals, "")
 	c.Assert(r.GetStorePeer(n), IsNil)
 	r.Region.StartKey = []byte{0}
-	c.Assert(diffRegionKeyInfo(r, info), Matches, "StartKey Changed.*")
+	c.Assert(DiffRegionKeyInfo(r, info), Matches, "StartKey Changed.*")
 	r.Region.EndKey = []byte{1}
-	c.Assert(diffRegionKeyInfo(r, info), Matches, ".*EndKey Changed.*")
+	c.Assert(DiffRegionKeyInfo(r, info), Matches, ".*EndKey Changed.*")
 
 	stores := r.GetStoreIds()
 	c.Assert(stores, HasLen, int(n))
@@ -117,10 +113,10 @@ func (s *testRegionSuite) TestRegionTree(c *C) {
 
 	c.Assert(tree.search([]byte("a")), IsNil)
 
-	regionA := newRegion([]byte("a"), []byte("b"))
-	regionB := newRegion([]byte("b"), []byte("c"))
-	regionC := newRegion([]byte("c"), []byte("d"))
-	regionD := newRegion([]byte("d"), []byte{})
+	regionA := NewRegion([]byte("a"), []byte("b"))
+	regionB := NewRegion([]byte("b"), []byte("c"))
+	regionC := NewRegion([]byte("c"), []byte("d"))
+	regionD := NewRegion([]byte("d"), []byte{})
 
 	tree.update(regionA)
 	tree.update(regionC)
@@ -168,54 +164,6 @@ func (s *testRegionSuite) TestRegionTree(c *C) {
 	c.Assert(tree.search([]byte("e")), Equals, regionE)
 }
 
-func splitRegions(regions []*metapb.Region) []*metapb.Region {
-	results := make([]*metapb.Region, 0, len(regions)*2)
-	for _, region := range regions {
-		start, end := byte(0), byte(math.MaxUint8)
-		if len(region.StartKey) > 0 {
-			start = region.StartKey[0]
-		}
-		if len(region.EndKey) > 0 {
-			end = region.EndKey[0]
-		}
-		middle := []byte{start/2 + end/2}
-		left := proto.Clone(region).(*metapb.Region)
-		left.Id = region.Id + uint64(len(regions))
-		left.EndKey = middle
-		left.RegionEpoch.Version++
-		right := proto.Clone(region).(*metapb.Region)
-		right.Id = region.Id + uint64(len(regions)*2)
-		right.StartKey = middle
-		right.RegionEpoch.Version++
-		results = append(results, left, right)
-	}
-	return results
-}
-
-func mergeRegions(regions []*metapb.Region) []*metapb.Region {
-	results := make([]*metapb.Region, 0, len(regions)/2)
-	for i := 0; i < len(regions); i += 2 {
-		left := regions[i]
-		right := regions[i]
-		if i+1 < len(regions) {
-			right = regions[i+1]
-		}
-		region := &metapb.Region{
-			Id:       left.Id + uint64(len(regions)),
-			StartKey: left.StartKey,
-			EndKey:   right.EndKey,
-		}
-		if left.RegionEpoch.Version > right.RegionEpoch.Version {
-			region.RegionEpoch = left.RegionEpoch
-		} else {
-			region.RegionEpoch = right.RegionEpoch
-		}
-		region.RegionEpoch.Version++
-		results = append(results, region)
-	}
-	return results
-}
-
 func updateRegions(c *C, tree *regionTree, regions []*metapb.Region) {
 	for _, region := range regions {
 		tree.update(region)
@@ -237,35 +185,27 @@ func (s *testRegionSuite) TestRegionTreeSplitAndMerge(c *C) {
 
 	// Split.
 	for i := 0; i < n; i++ {
-		regions = splitRegions(regions)
+		regions = SplitRegions(regions)
 		updateRegions(c, tree, regions)
 	}
 
 	// Merge.
 	for i := 0; i < n; i++ {
-		regions = mergeRegions(regions)
+		regions = MergeRegions(regions)
 		updateRegions(c, tree, regions)
 	}
 
 	// Split twice and merge once.
 	for i := 0; i < n*2; i++ {
 		if (i+1)%3 == 0 {
-			regions = mergeRegions(regions)
+			regions = MergeRegions(regions)
 		} else {
-			regions = splitRegions(regions)
+			regions = SplitRegions(regions)
 		}
 		updateRegions(c, tree, regions)
 	}
 }
 
-func newRegion(start, end []byte) *metapb.Region {
-	return &metapb.Region{
-		StartKey:    start,
-		EndKey:      end,
-		RegionEpoch: &metapb.RegionEpoch{},
-	}
-}
-
 func newRegionItem(start, end []byte) *regionItem {
-	return &regionItem{region: newRegion(start, end)}
+	return &regionItem{region: NewRegion(start, end)}
 }

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -227,25 +227,29 @@ type StoreHotRegionInfos struct {
 type StoreHotRegionsStat map[uint64]*HotRegionsStat
 
 var (
+  // ErrStoreNotFound is for log of store no found
 	ErrStoreNotFound = func(storeID uint64) error {
 		return errors.Errorf("store %v not found", storeID)
 	}
+  // ErrStoreIsBlocked is for log of store is blocked 
 	ErrStoreIsBlocked = func(storeID uint64) error {
 		return errors.Errorf("store %v is blocked", storeID)
 	}
 )
 
-// stores info
+// StoresInfo is a map of storeID to StoreInfo
 type StoresInfo struct {
 	stores map[uint64]*StoreInfo
 }
 
+// NewStoresInfo create a StoresInfo with map of storeID to StoreInfo
 func NewStoresInfo() *StoresInfo {
 	return &StoresInfo{
 		stores: make(map[uint64]*StoreInfo),
 	}
 }
 
+// GetStore return a StoreInfo with storeID 
 func (s *StoresInfo) GetStore(storeID uint64) *StoreInfo {
 	store, ok := s.stores[storeID]
 	if !ok {
@@ -254,10 +258,12 @@ func (s *StoresInfo) GetStore(storeID uint64) *StoreInfo {
 	return store.Clone()
 }
 
+// SetStore set a StoreInfo with storeID 
 func (s *StoresInfo) SetStore(store *StoreInfo) {
 	s.stores[store.GetId()] = store
 }
 
+// BlockStore block a StoreInfo with storeID
 func (s *StoresInfo) BlockStore(storeID uint64) error {
 	store, ok := s.stores[storeID]
 	if !ok {
@@ -270,6 +276,7 @@ func (s *StoresInfo) BlockStore(storeID uint64) error {
 	return nil
 }
 
+// UnblockStore unblock a StoreInfo with storeID
 func (s *StoresInfo) UnblockStore(storeID uint64) {
 	store, ok := s.stores[storeID]
 	if !ok {
@@ -278,6 +285,7 @@ func (s *StoresInfo) UnblockStore(storeID uint64) {
 	store.Unblock()
 }
 
+// GetStores get a complete set of StoreInfo 
 func (s *StoresInfo) GetStores() []*StoreInfo {
 	stores := make([]*StoreInfo, 0, len(s.stores))
 	for _, store := range s.stores {
@@ -286,6 +294,7 @@ func (s *StoresInfo) GetStores() []*StoreInfo {
 	return stores
 }
 
+// GetMetaStores get a complete set of metapb.Store
 func (s *StoresInfo) GetMetaStores() []*metapb.Store {
 	stores := make([]*metapb.Store, 0, len(s.stores))
 	for _, store := range s.stores {
@@ -294,22 +303,26 @@ func (s *StoresInfo) GetMetaStores() []*metapb.Store {
 	return stores
 }
 
+// GetStoreCount return the total count of storeInfo
 func (s *StoresInfo) GetStoreCount() int {
 	return len(s.stores)
 }
 
+// SetLeaderCount set the leader count to a storeInfo
 func (s *StoresInfo) SetLeaderCount(storeID uint64, leaderCount int) {
 	if store, ok := s.stores[storeID]; ok {
 		store.LeaderCount = leaderCount
 	}
 }
 
+// SetRegionCount set the region count to a storeInfo
 func (s *StoresInfo) SetRegionCount(storeID uint64, regionCount int) {
 	if store, ok := s.stores[storeID]; ok {
 		store.RegionCount = regionCount
 	}
 }
 
+// TotalWrittenBytes return the total written bytes of all StoreInfo
 func (s *StoresInfo) TotalWrittenBytes() uint64 {
 	var totalWrittenBytes uint64
 	for _, s := range s.stores {
@@ -320,6 +333,7 @@ func (s *StoresInfo) TotalWrittenBytes() uint64 {
 	return totalWrittenBytes
 }
 
+// TotalReadBytes return the total read bytes of all StoreInfo
 func (s *StoresInfo) TotalReadBytes() uint64 {
 	var totalReadBytes uint64
 	for _, s := range s.stores {
@@ -330,6 +344,7 @@ func (s *StoresInfo) TotalReadBytes() uint64 {
 	return totalReadBytes
 }
 
+// GetStoresWriteStat return the write stat of all StoreInfo
 func (s* StoresInfo) GetStoresWriteStat() map[uint64]uint64 {
 	res := make(map[uint64]uint64)
 	for _, s := range s.stores {
@@ -338,6 +353,7 @@ func (s* StoresInfo) GetStoresWriteStat() map[uint64]uint64 {
     return res
 }
 
+// GetStoresReadStat return the read stat of all StoreInfo
 func (s* StoresInfo) GetStoresReadStat() map[uint64]uint64 {
 	res := make(map[uint64]uint64)
 	for _, s := range s.stores {

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -17,8 +17,8 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/juju/errors"
 	"github.com/gogo/protobuf/proto"
+	"github.com/juju/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 )
@@ -227,11 +227,11 @@ type StoreHotRegionInfos struct {
 type StoreHotRegionsStat map[uint64]*HotRegionsStat
 
 var (
-  // ErrStoreNotFound is for log of store no found
+	// ErrStoreNotFound is for log of store no found
 	ErrStoreNotFound = func(storeID uint64) error {
 		return errors.Errorf("store %v not found", storeID)
 	}
-  // ErrStoreIsBlocked is for log of store is blocked 
+	// ErrStoreIsBlocked is for log of store is blocked
 	ErrStoreIsBlocked = func(storeID uint64) error {
 		return errors.Errorf("store %v is blocked", storeID)
 	}
@@ -249,7 +249,7 @@ func NewStoresInfo() *StoresInfo {
 	}
 }
 
-// GetStore return a StoreInfo with storeID 
+// GetStore return a StoreInfo with storeID
 func (s *StoresInfo) GetStore(storeID uint64) *StoreInfo {
 	store, ok := s.stores[storeID]
 	if !ok {
@@ -258,7 +258,7 @@ func (s *StoresInfo) GetStore(storeID uint64) *StoreInfo {
 	return store.Clone()
 }
 
-// SetStore set a StoreInfo with storeID 
+// SetStore set a StoreInfo with storeID
 func (s *StoresInfo) SetStore(store *StoreInfo) {
 	s.stores[store.GetId()] = store
 }
@@ -285,7 +285,7 @@ func (s *StoresInfo) UnblockStore(storeID uint64) {
 	store.Unblock()
 }
 
-// GetStores get a complete set of StoreInfo 
+// GetStores get a complete set of StoreInfo
 func (s *StoresInfo) GetStores() []*StoreInfo {
 	stores := make([]*StoreInfo, 0, len(s.stores))
 	for _, store := range s.stores {
@@ -345,21 +345,19 @@ func (s *StoresInfo) TotalReadBytes() uint64 {
 }
 
 // GetStoresWriteStat return the write stat of all StoreInfo
-func (s* StoresInfo) GetStoresWriteStat() map[uint64]uint64 {
+func (s *StoresInfo) GetStoresWriteStat() map[uint64]uint64 {
 	res := make(map[uint64]uint64)
 	for _, s := range s.stores {
 		res[s.GetId()] = s.Stats.GetBytesWritten()
 	}
-    return res
+	return res
 }
 
 // GetStoresReadStat return the read stat of all StoreInfo
-func (s* StoresInfo) GetStoresReadStat() map[uint64]uint64 {
+func (s *StoresInfo) GetStoresReadStat() map[uint64]uint64 {
 	res := make(map[uint64]uint64)
 	for _, s := range s.stores {
 		res[s.GetId()] = s.Stats.GetBytesRead()
 	}
-    return res
+	return res
 }
-
-

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -16,6 +16,8 @@ package core
 import (
 	"time"
 
+	log "github.com/Sirupsen/logrus"
+	"github.com/juju/errors"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
@@ -223,3 +225,125 @@ type StoreHotRegionInfos struct {
 
 // StoreHotRegionsStat used to record the hot region statistics group by store
 type StoreHotRegionsStat map[uint64]*HotRegionsStat
+
+var (
+	ErrStoreNotFound = func(storeID uint64) error {
+		return errors.Errorf("store %v not found", storeID)
+	}
+	ErrStoreIsBlocked = func(storeID uint64) error {
+		return errors.Errorf("store %v is blocked", storeID)
+	}
+)
+
+// stores info
+type StoresInfo struct {
+	stores map[uint64]*StoreInfo
+}
+
+func NewStoresInfo() *StoresInfo {
+	return &StoresInfo{
+		stores: make(map[uint64]*StoreInfo),
+	}
+}
+
+func (s *StoresInfo) GetStore(storeID uint64) *StoreInfo {
+	store, ok := s.stores[storeID]
+	if !ok {
+		return nil
+	}
+	return store.Clone()
+}
+
+func (s *StoresInfo) SetStore(store *StoreInfo) {
+	s.stores[store.GetId()] = store
+}
+
+func (s *StoresInfo) BlockStore(storeID uint64) error {
+	store, ok := s.stores[storeID]
+	if !ok {
+		return ErrStoreNotFound(storeID)
+	}
+	if store.IsBlocked() {
+		return ErrStoreIsBlocked(storeID)
+	}
+	store.Block()
+	return nil
+}
+
+func (s *StoresInfo) UnblockStore(storeID uint64) {
+	store, ok := s.stores[storeID]
+	if !ok {
+		log.Fatalf("store %d is unblocked, but it is not found", storeID)
+	}
+	store.Unblock()
+}
+
+func (s *StoresInfo) GetStores() []*StoreInfo {
+	stores := make([]*StoreInfo, 0, len(s.stores))
+	for _, store := range s.stores {
+		stores = append(stores, store.Clone())
+	}
+	return stores
+}
+
+func (s *StoresInfo) GetMetaStores() []*metapb.Store {
+	stores := make([]*metapb.Store, 0, len(s.stores))
+	for _, store := range s.stores {
+		stores = append(stores, proto.Clone(store.Store).(*metapb.Store))
+	}
+	return stores
+}
+
+func (s *StoresInfo) GetStoreCount() int {
+	return len(s.stores)
+}
+
+func (s *StoresInfo) SetLeaderCount(storeID uint64, leaderCount int) {
+	if store, ok := s.stores[storeID]; ok {
+		store.LeaderCount = leaderCount
+	}
+}
+
+func (s *StoresInfo) SetRegionCount(storeID uint64, regionCount int) {
+	if store, ok := s.stores[storeID]; ok {
+		store.RegionCount = regionCount
+	}
+}
+
+func (s *StoresInfo) TotalWrittenBytes() uint64 {
+	var totalWrittenBytes uint64
+	for _, s := range s.stores {
+		if s.IsUp() {
+			totalWrittenBytes += s.Stats.GetBytesWritten()
+		}
+	}
+	return totalWrittenBytes
+}
+
+func (s *StoresInfo) TotalReadBytes() uint64 {
+	var totalReadBytes uint64
+	for _, s := range s.stores {
+		if s.IsUp() {
+			totalReadBytes += s.Stats.GetBytesRead()
+		}
+	}
+	return totalReadBytes
+}
+
+func (s* StoresInfo) GetStoresWriteStat() map[uint64]uint64 {
+	res := make(map[uint64]uint64)
+	for _, s := range s.stores {
+		res[s.GetId()] = s.Stats.GetBytesWritten()
+	}
+    return res
+}
+
+func (s* StoresInfo) GetStoresReadStat() map[uint64]uint64 {
+	res := make(map[uint64]uint64)
+	for _, s := range s.stores {
+		res[s.GetId()] = s.Stats.GetBytesRead()
+	}
+    return res
+}
+
+

--- a/server/core/test_util.go
+++ b/server/core/test_util.go
@@ -20,6 +20,7 @@ import (
   "github.com/pingcap/kvproto/pkg/metapb"
 )
 
+// SplitRegions split a set of metapb.Region by the middle of regionKey
 func SplitRegions(regions []*metapb.Region) []*metapb.Region {
 	results := make([]*metapb.Region, 0, len(regions)*2)
 	for _, region := range regions {
@@ -44,6 +45,7 @@ func SplitRegions(regions []*metapb.Region) []*metapb.Region {
 	return results
 }
 
+// MergeRegions merge a set of metapb.Region by regionKey
 func MergeRegions(regions []*metapb.Region) []*metapb.Region {
 	results := make([]*metapb.Region, 0, len(regions)/2)
 	for i := 0; i < len(regions); i += 2 {
@@ -68,6 +70,7 @@ func MergeRegions(regions []*metapb.Region) []*metapb.Region {
 	return results
 }
 
+// NewRegion create a metapb.Region
 func NewRegion(start, end []byte) *metapb.Region {
 	return &metapb.Region{
 		StartKey:    start,

--- a/server/core/test_util.go
+++ b/server/core/test_util.go
@@ -1,0 +1,77 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"math"
+
+	"github.com/gogo/protobuf/proto"
+  "github.com/pingcap/kvproto/pkg/metapb"
+)
+
+func SplitRegions(regions []*metapb.Region) []*metapb.Region {
+	results := make([]*metapb.Region, 0, len(regions)*2)
+	for _, region := range regions {
+		start, end := byte(0), byte(math.MaxUint8)
+		if len(region.StartKey) > 0 {
+			start = region.StartKey[0]
+		}
+		if len(region.EndKey) > 0 {
+			end = region.EndKey[0]
+		}
+		middle := []byte{start/2 + end/2}
+		left := proto.Clone(region).(*metapb.Region)
+		left.Id = region.Id + uint64(len(regions))
+		left.EndKey = middle
+		left.RegionEpoch.Version++
+		right := proto.Clone(region).(*metapb.Region)
+		right.Id = region.Id + uint64(len(regions)*2)
+		right.StartKey = middle
+		right.RegionEpoch.Version++
+		results = append(results, left, right)
+	}
+	return results
+}
+
+func MergeRegions(regions []*metapb.Region) []*metapb.Region {
+	results := make([]*metapb.Region, 0, len(regions)/2)
+	for i := 0; i < len(regions); i += 2 {
+		left := regions[i]
+		right := regions[i]
+		if i+1 < len(regions) {
+			right = regions[i+1]
+		}
+		region := &metapb.Region{
+			Id:       left.Id + uint64(len(regions)),
+			StartKey: left.StartKey,
+			EndKey:   right.EndKey,
+		}
+		if left.RegionEpoch.Version > right.RegionEpoch.Version {
+			region.RegionEpoch = left.RegionEpoch
+		} else {
+			region.RegionEpoch = right.RegionEpoch
+		}
+		region.RegionEpoch.Version++
+		results = append(results, region)
+	}
+	return results
+}
+
+func NewRegion(start, end []byte) *metapb.Region {
+	return &metapb.Region{
+		StartKey:    start,
+		EndKey:      end,
+		RegionEpoch: &metapb.RegionEpoch{},
+	}
+}

--- a/server/core/test_util.go
+++ b/server/core/test_util.go
@@ -17,7 +17,7 @@ import (
 	"math"
 
 	"github.com/gogo/protobuf/proto"
-  "github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/metapb"
 )
 
 // SplitRegions split a set of metapb.Region by the middle of regionKey

--- a/server/handler.go
+++ b/server/handler.go
@@ -271,7 +271,7 @@ func (h *Handler) AddTransferRegionOperator(regionID uint64, storeIDs map[uint64
 	// Add missing peers.
 	for id := range storeIDs {
 		if c.cluster.GetStore(id) == nil {
-			return errStoreNotFound(id)
+			return core.ErrStoreNotFound(id)
 		}
 		if region.GetStorePeer(id) != nil {
 			continue
@@ -314,7 +314,7 @@ func (h *Handler) AddTransferPeerOperator(regionID uint64, fromStoreID, toStoreI
 	}
 
 	if c.cluster.GetStore(toStoreID) == nil {
-		return errStoreNotFound(toStoreID)
+		return core.ErrStoreNotFound(toStoreID)
 	}
 	newPeer, err := c.cluster.AllocPeer(toStoreID)
 	if err != nil {

--- a/server/kv.go
+++ b/server/kv.go
@@ -162,7 +162,7 @@ func (kv *kv) loadConfig(cfg *Config) (bool, error) {
 	return true, nil
 }
 
-func (kv *kv) loadStores(stores *storesInfo, rangeLimit int64) error {
+func (kv *kv) loadStores(stores *core.StoresInfo, rangeLimit int64) error {
 	nextID := uint64(0)
 	endStore := kv.storePath(math.MaxUint64)
 	withRange := clientv3.WithRange(endStore)
@@ -194,7 +194,7 @@ func (kv *kv) loadStores(stores *storesInfo, rangeLimit int64) error {
 			storeInfo.RegionWeight = regionWeight
 
 			nextID = store.GetId() + 1
-			stores.setStore(storeInfo)
+			stores.SetStore(storeInfo)
 		}
 
 		if len(resp.Kvs) < int(rangeLimit) {
@@ -230,7 +230,7 @@ func (kv *kv) loadFloatWithDefaultValue(path string, def float64) (float64, erro
 	return val, nil
 }
 
-func (kv *kv) loadRegions(regions *regionsInfo, rangeLimit int64) error {
+func (kv *kv) loadRegions(regions *core.RegionsInfo, rangeLimit int64) error {
 	nextID := uint64(0)
 	endRegion := kv.regionPath(math.MaxUint64)
 	withRange := clientv3.WithRange(endRegion)
@@ -250,7 +250,7 @@ func (kv *kv) loadRegions(regions *regionsInfo, rangeLimit int64) error {
 			}
 
 			nextID = region.GetId() + 1
-			regions.setRegion(core.NewRegionInfo(region, nil))
+			regions.SetRegion(core.NewRegionInfo(region, nil))
 		}
 
 		if len(resp.Kvs) < int(rangeLimit) {

--- a/server/kv_test.go
+++ b/server/kv_test.go
@@ -18,6 +18,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/pd/server/core"
 )
 
 var _ = Suite(&testKVSuite{})
@@ -94,21 +95,21 @@ func mustSaveStores(c *C, kv *kv, n int) []*metapb.Store {
 
 func (s *testKVSuite) TestLoadStores(c *C) {
 	kv := newKV(s.server)
-	cache := newStoresInfo()
+	cache := core.NewStoresInfo()
 
 	n := 10
 	stores := mustSaveStores(c, kv, n)
 	c.Assert(kv.loadStores(cache, 3), IsNil)
 
-	c.Assert(cache.getStoreCount(), Equals, n)
-	for _, store := range cache.getMetaStores() {
+	c.Assert(cache.GetStoreCount(), Equals, n)
+	for _, store := range cache.GetMetaStores() {
 		c.Assert(store, DeepEquals, stores[store.GetId()])
 	}
 }
 
 func (s *testKVSuite) TestStoreWeight(c *C) {
 	kv := newKV(s.server)
-	cache := newStoresInfo()
+	cache := core.NewStoresInfo()
 	const n = 3
 
 	mustSaveStores(c, kv, n)
@@ -118,8 +119,8 @@ func (s *testKVSuite) TestStoreWeight(c *C) {
 	leaderWeights := []float64{1.0, 2.0, 0.2}
 	regionWeights := []float64{1.0, 3.0, 0.3}
 	for i := 0; i < n; i++ {
-		c.Assert(cache.getStore(uint64(i)).LeaderWeight, Equals, leaderWeights[i])
-		c.Assert(cache.getStore(uint64(i)).RegionWeight, Equals, regionWeights[i])
+		c.Assert(cache.GetStore(uint64(i)).LeaderWeight, Equals, leaderWeights[i])
+		c.Assert(cache.GetStore(uint64(i)).RegionWeight, Equals, regionWeights[i])
 	}
 }
 
@@ -139,14 +140,14 @@ func mustSaveRegions(c *C, kv *kv, n int) []*metapb.Region {
 
 func (s *testKVSuite) TestLoadRegions(c *C) {
 	kv := newKV(s.server)
-	cache := newRegionsInfo()
+	cache := core.NewRegionsInfo()
 
 	n := 10
 	regions := mustSaveRegions(c, kv, n)
 	c.Assert(kv.loadRegions(cache, 3), IsNil)
 
-	c.Assert(cache.getRegionCount(), Equals, n)
-	for _, region := range cache.getMetaRegions() {
+	c.Assert(cache.GetRegionCount(), Equals, n)
+	for _, region := range cache.GetMetaRegions() {
 		c.Assert(region, DeepEquals, regions[region.GetId()])
 	}
 }

--- a/server/util.go
+++ b/server/util.go
@@ -14,22 +14,17 @@
 package server
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 	"math/rand"
-	"reflect"
-	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/golang/protobuf/proto"
 	"github.com/juju/errors"
-	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/pd/pkg/etcdutil"
-	"github.com/pingcap/pd/server/core"
 	"golang.org/x/net/context"
 )
 
@@ -247,51 +242,6 @@ func minDuration(a, b time.Duration) time.Duration {
 		return a
 	}
 	return b
-}
-
-func diffRegionPeersInfo(origin *core.RegionInfo, other *core.RegionInfo) string {
-	var ret []string
-	for _, a := range origin.Peers {
-		both := false
-		for _, b := range other.Peers {
-			if reflect.DeepEqual(a, b) {
-				both = true
-				break
-			}
-		}
-		if !both {
-			ret = append(ret, fmt.Sprintf("Remove peer:{%v}", a))
-		}
-	}
-	for _, b := range other.Peers {
-		both := false
-		for _, a := range origin.Peers {
-			if reflect.DeepEqual(a, b) {
-				both = true
-				break
-			}
-		}
-		if !both {
-			ret = append(ret, fmt.Sprintf("Add peer:{%v}", b))
-		}
-	}
-	return strings.Join(ret, ",")
-}
-
-func diffRegionKeyInfo(origin *core.RegionInfo, other *core.RegionInfo) string {
-	var ret []string
-	if !bytes.Equal(origin.Region.StartKey, other.Region.StartKey) {
-		originKey := &metapb.Region{StartKey: origin.Region.StartKey}
-		otherKey := &metapb.Region{StartKey: other.Region.StartKey}
-		ret = append(ret, fmt.Sprintf("StartKey Changed:{%s} -> {%s}", originKey, otherKey))
-	}
-	if !bytes.Equal(origin.Region.EndKey, other.Region.EndKey) {
-		originKey := &metapb.Region{EndKey: origin.Region.EndKey}
-		otherKey := &metapb.Region{EndKey: other.Region.EndKey}
-		ret = append(ret, fmt.Sprintf("EndKey Changed:{%s} -> {%s}", originKey, otherKey))
-	}
-
-	return strings.Join(ret, ",")
 }
 
 func parseTimestamp(data []byte) (time.Time, error) {


### PR DESCRIPTION
This pr is a preparation for MockCluster.
1 move storesInfo, regionsInfo and regionTree into core package,  and export their methods as public so that other modules like MockCluster can also use them.
2 move region_tree_test.go into core, and split some util test functions from this file into core/test_util.go, so that test suite like cache_test.go in server can use them.
3 move RegionMapTestSuite from cache_test.go into core/region_test.go for specific test of regionsMap.