### PR TITLE
server: refactor kv.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin
 /vendor
+_vendor/pkg
 _vendor/src/github.com/pingcap/pd
 *.iml
 .idea

--- a/server/core/kv_base.go
+++ b/server/core/kv_base.go
@@ -1,0 +1,75 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"sync"
+
+	"github.com/google/btree"
+)
+
+// KVBase is an abstract interface for load/save pd cluster data.
+type KVBase interface {
+	Load(key string) (string, error)
+	LoadRange(key, endKey string, limit int) ([]string, error)
+	Save(key, value string) error
+}
+
+type memoryKV struct {
+	sync.RWMutex
+	tree *btree.BTree
+}
+
+// NewMemoryKV returns an in-memory kvBase for testing.
+func NewMemoryKV() KVBase {
+	return &memoryKV{
+		tree: btree.New(2),
+	}
+}
+
+type memoryKVItem struct {
+	key, value string
+}
+
+func (s memoryKVItem) Less(than btree.Item) bool {
+	return s.key < than.(memoryKVItem).key
+}
+
+func (kv *memoryKV) Load(key string) (string, error) {
+	kv.RLock()
+	defer kv.RUnlock()
+	item := kv.tree.Get(memoryKVItem{key, ""})
+	if item == nil {
+		return "", nil
+	}
+	return item.(memoryKVItem).value, nil
+}
+
+func (kv *memoryKV) LoadRange(key, endKey string, limit int) ([]string, error) {
+	kv.RLock()
+	defer kv.RUnlock()
+	res := make([]string, 0, limit)
+	kv.tree.AscendRange(memoryKVItem{key, ""}, memoryKVItem{endKey, ""}, func(item btree.Item) bool {
+		res = append(res, item.(memoryKVItem).value)
+		return len(res) < int(limit)
+	})
+	return res, nil
+}
+
+func (kv *memoryKV) Save(key, value string) error {
+	kv.Lock()
+	defer kv.Unlock()
+	kv.tree.ReplaceOrInsert(memoryKVItem{key, value})
+	return nil
+}

--- a/server/kv_test.go
+++ b/server/kv_test.go
@@ -14,8 +14,6 @@
 package server
 
 import (
-	"fmt"
-
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/server/core"
@@ -37,13 +35,10 @@ func (s *testKVSuite) TearDownTest(c *C) {
 }
 
 func (s *testKVSuite) TestBasic(c *C) {
-	kv := newKV(s.server)
+	kv := newKV(newEtcdKVBase(s.server))
 
-	clusterID := s.server.clusterID
-	storePath := fmt.Sprintf("/pd/%v/raft/s/00000000000000000123", clusterID)
-	regionPath := fmt.Sprintf("/pd/%v/raft/r/00000000000000000123", clusterID)
-	c.Assert(kv.storePath(123), Equals, storePath)
-	c.Assert(kv.regionPath(123), Equals, regionPath)
+	c.Assert(kv.storePath(123), Equals, "raft/s/00000000000000000123")
+	c.Assert(kv.regionPath(123), Equals, "raft/r/00000000000000000123")
 
 	meta := &metapb.Cluster{Id: 123}
 	ok, err := kv.loadMeta(meta)
@@ -94,7 +89,7 @@ func mustSaveStores(c *C, kv *kv, n int) []*metapb.Store {
 }
 
 func (s *testKVSuite) TestLoadStores(c *C) {
-	kv := newKV(s.server)
+	kv := newKV(newEtcdKVBase(s.server))
 	cache := core.NewStoresInfo()
 
 	n := 10
@@ -108,7 +103,7 @@ func (s *testKVSuite) TestLoadStores(c *C) {
 }
 
 func (s *testKVSuite) TestStoreWeight(c *C) {
-	kv := newKV(s.server)
+	kv := newKV(newEtcdKVBase(s.server))
 	cache := core.NewStoresInfo()
 	const n = 3
 
@@ -139,7 +134,7 @@ func mustSaveRegions(c *C, kv *kv, n int) []*metapb.Region {
 }
 
 func (s *testKVSuite) TestLoadRegions(c *C) {
-	kv := newKV(s.server)
+	kv := newKV(newEtcdKVBase(s.server))
 	cache := core.NewRegionsInfo()
 
 	n := 10

--- a/server/server.go
+++ b/server/server.go
@@ -177,7 +177,8 @@ func (s *Server) startServer() error {
 	s.leaderValue = s.marshalLeader()
 
 	s.idAlloc = &idAllocator{s: s}
-	s.kv = newKV(s)
+	kvBase := newEtcdKVBase(s)
+	s.kv = newKV(kvBase)
 	s.cluster = newRaftCluster(s, s.clusterID)
 	s.hbStreams = newHeartbeatStreams(s.clusterID)
 


### PR DESCRIPTION
Extract kv to an interface. The benefits include a) plugin schedulers or namespace classifiers can save data without depend on server package, b) some tests can use in-memory storage without starting etcd server. 