### PR TITLE
*: add some store states.

### DIFF
--- a/server/api/label.go
+++ b/server/api/label.go
@@ -71,6 +71,8 @@ func (h *labelsHandler) GetStores(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	maxDownTime := h.svr.GetScheduleConfig().MaxStoreDownTime.Duration
+
 	stores := cluster.GetStores()
 	storesInfo := &storesInfo{
 		Stores: make([]*storeInfo, 0, len(stores)),
@@ -84,7 +86,7 @@ func (h *labelsHandler) GetStores(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		storeInfo := newStoreInfo(store)
+		storeInfo := newStoreInfo(store, maxDownTime)
 		storesInfo.Stores = append(storesInfo.Stores, storeInfo)
 	}
 	storesInfo.Count = len(storesInfo.Stores)

--- a/server/api/store_test.go
+++ b/server/api/store_test.go
@@ -266,10 +266,14 @@ func (s *testStoreSuite) TestDownState(c *C) {
 		Stats:           &pdpb.StoreStats{},
 		LastHeartbeatTS: time.Now(),
 	}
-	storeInfo := newStoreInfo(store)
+	storeInfo := newStoreInfo(store, time.Hour)
 	c.Assert(storeInfo.Store.StateName, Equals, metapb.StoreState_Up.String())
 
 	store.LastHeartbeatTS = time.Now().Add(-time.Minute * 2)
-	storeInfo = newStoreInfo(store)
+	storeInfo = newStoreInfo(store, time.Hour)
+	c.Assert(storeInfo.Store.StateName, Equals, disconnectedName)
+
+	store.LastHeartbeatTS = time.Now().Add(-time.Hour * 2)
+	storeInfo = newStoreInfo(store, time.Hour)
 	c.Assert(storeInfo.Store.StateName, Equals, downStateName)
 }

--- a/server/schedule/filters.go
+++ b/server/schedule/filters.go
@@ -172,8 +172,6 @@ func (f *cacheFilter) FilterTarget(store *core.StoreInfo) bool {
 
 type storageThresholdFilter struct{}
 
-const storageAvailableRatioThreshold = 0.2
-
 // NewStorageThresholdFilter creates a Filter that filters all stores that are
 // almost full.
 func NewStorageThresholdFilter(opt Options) Filter {
@@ -185,7 +183,7 @@ func (f *storageThresholdFilter) FilterSource(store *core.StoreInfo) bool {
 }
 
 func (f *storageThresholdFilter) FilterTarget(store *core.StoreInfo) bool {
-	return store.AvailableRatio() < storageAvailableRatioThreshold
+	return store.LowSpace()
 }
 
 // distinctScoreFilter ensures that distinct score will not decrease.


### PR DESCRIPTION
Introduce the `Disconnected` state to identify stores that lost heartbeats for a short period of time, the `LowSpace` state to be shown in metrics as warning for potential disk space shortage risk. 