### PR TITLE
fix isPureTableID bug

### DIFF
--- a/table/codec.go
+++ b/table/codec.go
@@ -84,7 +84,12 @@ func decodeCmpUintToInt(u uint64) int64 {
 
 // IsPureTableID return true iff b is consist of tablePrefix and 8-byte tableID
 func IsPureTableID(b []byte) bool {
-	return len(b) == len(tablePrefix)+8
+	_, key, err := decodeBytes(b)
+	if err != nil {
+		// should never happen
+		return false
+	}
+	return len(key) == len(tablePrefix)+8
 }
 
 func decodeBytes(b []byte) ([]byte, []byte, error) {


### PR DESCRIPTION
in `isPureTableID` function, decode the key first and then compare the length.