### PR TITLE
coordinator: remove verbose kv

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -114,7 +114,7 @@ func (c *RaftCluster) start() error {
 		return nil
 	}
 	c.cachedCluster = cluster
-	c.coordinator = newCoordinator(c.cachedCluster, c.s.scheduleOpt, c.s.hbStreams, c.s.kv, c.s.classifier)
+	c.coordinator = newCoordinator(c.cachedCluster, c.s.scheduleOpt, c.s.hbStreams, c.s.classifier)
 	c.quit = make(chan struct{})
 
 	c.wg.Add(2)

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -63,10 +63,9 @@ type coordinator struct {
 	classifier       namespace.Classifier
 	histories        cache.Cache
 	hbStreams        *heartbeatStreams
-	kv               *core.KV
 }
 
-func newCoordinator(cluster *clusterInfo, opt *scheduleOption, hbStreams *heartbeatStreams, kv *core.KV, classifier namespace.Classifier) *coordinator {
+func newCoordinator(cluster *clusterInfo, opt *scheduleOption, hbStreams *heartbeatStreams, classifier namespace.Classifier) *coordinator {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &coordinator{
 		ctx:              ctx,
@@ -81,7 +80,6 @@ func newCoordinator(cluster *clusterInfo, opt *scheduleOption, hbStreams *heartb
 		classifier:       classifier,
 		histories:        cache.NewDefaultCache(historiesCacheSize),
 		hbStreams:        hbStreams,
-		kv:               kv,
 	}
 }
 
@@ -158,7 +156,7 @@ func (c *coordinator) run() {
 
 	// remove invalid scheduler config and persist
 	scheduleCfg.Schedulers = scheduleCfg.Schedulers[:k]
-	if err := c.opt.persist(c.kv); err != nil {
+	if err := c.opt.persist(c.cluster.kv); err != nil {
 		log.Errorf("can't persist schedule config: %v", err)
 	}
 

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -104,12 +104,12 @@ type testCoordinatorSuite struct{}
 
 func (s *testCoordinatorSuite) TestBasic(c *C) {
 	cluster := newClusterInfo(core.NewMockIDAllocator())
+	cluster.kv = core.NewKV(core.NewMemoryKV())
 	_, opt := newTestScheduleConfig()
 	hbStreams := newHeartbeatStreams(cluster.getClusterID())
-	kv := core.NewKV(core.NewMemoryKV())
-
 	defer hbStreams.Close()
-	co := newCoordinator(cluster, opt, hbStreams, kv, namespace.DefaultClassifier)
+
+	co := newCoordinator(cluster, opt, hbStreams, namespace.DefaultClassifier)
 	l := co.limiter
 
 	op1 := newTestOperator(1, core.LeaderKind)
@@ -155,13 +155,13 @@ func newMockHeartbeatStream() *mockHeartbeatStream {
 
 func (s *testCoordinatorSuite) TestDispatch(c *C) {
 	cluster := newClusterInfo(core.NewMockIDAllocator())
+	cluster.kv = core.NewKV(core.NewMemoryKV())
 	tc := newTestClusterInfo(cluster)
+	_, opt := newTestScheduleConfig()
 	hbStreams := newHeartbeatStreams(cluster.getClusterID())
-	kv := core.NewKV(core.NewMemoryKV())
 	defer hbStreams.Close()
 
-	_, opt := newTestScheduleConfig()
-	co := newCoordinator(cluster, opt, hbStreams, kv, namespace.DefaultClassifier)
+	co := newCoordinator(cluster, opt, hbStreams, namespace.DefaultClassifier)
 	co.run()
 	defer co.stop()
 
@@ -230,9 +230,10 @@ func dispatchAndRecvHeartbeat(c *C, co *coordinator, region *core.RegionInfo, st
 
 func (s *testCoordinatorSuite) TestReplica(c *C) {
 	cluster := newClusterInfo(core.NewMockIDAllocator())
+	cluster.kv = core.NewKV(core.NewMemoryKV())
 	tc := newTestClusterInfo(cluster)
+	_, opt := newTestScheduleConfig()
 	hbStreams := newHeartbeatStreams(cluster.getClusterID())
-	kv := core.NewKV(core.NewMemoryKV())
 	defer hbStreams.Close()
 
 	// Turn off balance.
@@ -240,7 +241,7 @@ func (s *testCoordinatorSuite) TestReplica(c *C) {
 	cfg.LeaderScheduleLimit = 0
 	cfg.RegionScheduleLimit = 0
 
-	co := newCoordinator(cluster, opt, hbStreams, kv, namespace.DefaultClassifier)
+	co := newCoordinator(cluster, opt, hbStreams, namespace.DefaultClassifier)
 	co.run()
 	defer co.stop()
 
@@ -286,13 +287,13 @@ func (s *testCoordinatorSuite) TestReplica(c *C) {
 
 func (s *testCoordinatorSuite) TestPeerState(c *C) {
 	cluster := newClusterInfo(core.NewMockIDAllocator())
+	cluster.kv = core.NewKV(core.NewMemoryKV())
 	tc := newTestClusterInfo(cluster)
+	_, opt := newTestScheduleConfig()
 	hbStreams := newHeartbeatStreams(cluster.getClusterID())
-	kv := core.NewKV(core.NewMemoryKV())
 	defer hbStreams.Close()
 
-	_, opt := newTestScheduleConfig()
-	co := newCoordinator(cluster, opt, hbStreams, kv, namespace.DefaultClassifier)
+	co := newCoordinator(cluster, opt, hbStreams, namespace.DefaultClassifier)
 	co.run()
 	defer co.stop()
 
@@ -334,13 +335,13 @@ func (s *testCoordinatorSuite) TestPeerState(c *C) {
 
 func (s *testCoordinatorSuite) TestShouldRun(c *C) {
 	cluster := newClusterInfo(core.NewMockIDAllocator())
+	cluster.kv = core.NewKV(core.NewMemoryKV())
 	tc := newTestClusterInfo(cluster)
+	_, opt := newTestScheduleConfig()
 	hbStreams := newHeartbeatStreams(cluster.getClusterID())
-	kv := core.NewKV(core.NewMemoryKV())
 	defer hbStreams.Close()
 
-	_, opt := newTestScheduleConfig()
-	co := newCoordinator(cluster, opt, hbStreams, kv, namespace.DefaultClassifier)
+	co := newCoordinator(cluster, opt, hbStreams, namespace.DefaultClassifier)
 
 	tc.LoadRegion(1, 1, 2, 3)
 	tc.LoadRegion(2, 1, 2, 3)
@@ -375,14 +376,15 @@ func (s *testCoordinatorSuite) TestShouldRun(c *C) {
 
 func (s *testCoordinatorSuite) TestAddScheduler(c *C) {
 	cluster := newClusterInfo(core.NewMockIDAllocator())
+	cluster.kv = core.NewKV(core.NewMemoryKV())
 	tc := newTestClusterInfo(cluster)
+	_, opt := newTestScheduleConfig()
 	hbStreams := newHeartbeatStreams(cluster.getClusterID())
-	kv := core.NewKV(core.NewMemoryKV())
 	defer hbStreams.Close()
 
 	cfg, opt := newTestScheduleConfig()
 	cfg.ReplicaScheduleLimit = 0
-	co := newCoordinator(cluster, opt, hbStreams, kv, namespace.DefaultClassifier)
+	co := newCoordinator(cluster, opt, hbStreams, namespace.DefaultClassifier)
 	co.run()
 	defer co.stop()
 
@@ -434,14 +436,15 @@ func (s *testCoordinatorSuite) TestAddScheduler(c *C) {
 
 func (s *testCoordinatorSuite) TestPersistScheduler(c *C) {
 	cluster := newClusterInfo(core.NewMockIDAllocator())
+	cluster.kv = core.NewKV(core.NewMemoryKV())
 	tc := newTestClusterInfo(cluster)
+	_, opt := newTestScheduleConfig()
 	hbStreams := newHeartbeatStreams(cluster.getClusterID())
-	kv := core.NewKV(core.NewMemoryKV())
 	defer hbStreams.Close()
 
 	cfg, opt := newTestScheduleConfig()
 	cfg.ReplicaScheduleLimit = 0
-	co := newCoordinator(cluster, opt, hbStreams, kv, namespace.DefaultClassifier)
+	co := newCoordinator(cluster, opt, hbStreams, namespace.DefaultClassifier)
 	co.run()
 
 	// Add stores 1,2
@@ -461,14 +464,14 @@ func (s *testCoordinatorSuite) TestPersistScheduler(c *C) {
 	c.Assert(co.removeScheduler("balance-region-scheduler"), IsNil)
 	c.Assert(co.removeScheduler("balance-hot-region-scheduler"), IsNil)
 	c.Assert(co.schedulers, HasLen, 2)
-	c.Assert(co.opt.persist(co.kv), IsNil)
+	c.Assert(co.opt.persist(co.cluster.kv), IsNil)
 	co.stop()
 
 	// make a new coordinator for testing
 	// whether the schedulers added or removed in dynamic way are recorded in opt
-	opt.reload(kv)
+	opt.reload(co.cluster.kv)
 
-	co = newCoordinator(cluster, opt, hbStreams, kv, namespace.DefaultClassifier)
+	co = newCoordinator(cluster, opt, hbStreams, namespace.DefaultClassifier)
 	co.run()
 	c.Assert(co.schedulers, HasLen, 2)
 	bls, err := schedule.CreateScheduler("balance-leader", opt, co.limiter)
@@ -480,11 +483,11 @@ func (s *testCoordinatorSuite) TestPersistScheduler(c *C) {
 	c.Assert(co.schedulers, HasLen, 4)
 	c.Assert(co.removeScheduler("grant-leader-scheduler-1"), IsNil)
 	c.Assert(co.schedulers, HasLen, 3)
-	c.Assert(co.opt.persist(co.kv), IsNil)
+	c.Assert(co.opt.persist(co.cluster.kv), IsNil)
 	co.stop()
 
-	opt.reload(kv)
-	co = newCoordinator(cluster, opt, hbStreams, kv, namespace.DefaultClassifier)
+	opt.reload(co.cluster.kv)
+	co = newCoordinator(cluster, opt, hbStreams, namespace.DefaultClassifier)
 
 	co.run()
 	defer co.stop()
@@ -495,9 +498,10 @@ func (s *testCoordinatorSuite) TestPersistScheduler(c *C) {
 
 func (s *testCoordinatorSuite) TestRestart(c *C) {
 	cluster := newClusterInfo(core.NewMockIDAllocator())
+	cluster.kv = core.NewKV(core.NewMemoryKV())
 	tc := newTestClusterInfo(cluster)
+	_, opt := newTestScheduleConfig()
 	hbStreams := newHeartbeatStreams(cluster.getClusterID())
-	kv := core.NewKV(core.NewMemoryKV())
 	defer hbStreams.Close()
 
 	// Turn off balance, we test add replica only.
@@ -514,7 +518,7 @@ func (s *testCoordinatorSuite) TestRestart(c *C) {
 	region := cluster.GetRegion(1)
 
 	// Add 1 replica on store 2.
-	co := newCoordinator(cluster, opt, hbStreams, kv, namespace.DefaultClassifier)
+	co := newCoordinator(cluster, opt, hbStreams, namespace.DefaultClassifier)
 	co.run()
 	stream := newMockHeartbeatStream()
 	resp := dispatchAndRecvHeartbeat(c, co, region, stream)
@@ -523,7 +527,7 @@ func (s *testCoordinatorSuite) TestRestart(c *C) {
 	co.stop()
 
 	// Recreate coodinator then add another replica on store 3.
-	co = newCoordinator(cluster, opt, hbStreams, kv, namespace.DefaultClassifier)
+	co = newCoordinator(cluster, opt, hbStreams, namespace.DefaultClassifier)
 	co.run()
 	resp = dispatchAndRecvHeartbeat(c, co, region, stream)
 	checkAddPeerResp(c, resp, 3)
@@ -580,12 +584,12 @@ func (s *mockLimitScheduler) IsScheduleAllowed() bool {
 
 func (s *testScheduleControllerSuite) TestController(c *C) {
 	cluster := newClusterInfo(core.NewMockIDAllocator())
+	cluster.kv = core.NewKV(core.NewMemoryKV())
 	_, opt := newTestScheduleConfig()
 	hbStreams := newHeartbeatStreams(cluster.getClusterID())
-	kv := core.NewKV(core.NewMemoryKV())
 	defer hbStreams.Close()
 
-	co := newCoordinator(cluster, opt, hbStreams, kv, namespace.DefaultClassifier)
+	co := newCoordinator(cluster, opt, hbStreams, namespace.DefaultClassifier)
 	scheduler, err := schedule.CreateScheduler("balance-leader", opt, co.limiter)
 	c.Assert(err, IsNil)
 	lb := &mockLimitScheduler{
@@ -636,12 +640,12 @@ func (s *testScheduleControllerSuite) TestController(c *C) {
 
 func (s *testScheduleControllerSuite) TestInterval(c *C) {
 	cluster := newClusterInfo(core.NewMockIDAllocator())
+	cluster.kv = core.NewKV(core.NewMemoryKV())
 	_, opt := newTestScheduleConfig()
 	hbStreams := newHeartbeatStreams(cluster.getClusterID())
-	kv := core.NewKV(core.NewMemoryKV())
 	defer hbStreams.Close()
 
-	co := newCoordinator(cluster, opt, hbStreams, kv, namespace.DefaultClassifier)
+	co := newCoordinator(cluster, opt, hbStreams, namespace.DefaultClassifier)
 	lb, err := schedule.CreateScheduler("balance-leader", opt, co.limiter)
 	c.Assert(err, IsNil)
 	sc := newScheduleController(co, lb)

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -232,7 +232,6 @@ func (s *testCoordinatorSuite) TestReplica(c *C) {
 	cluster := newClusterInfo(core.NewMockIDAllocator())
 	cluster.kv = core.NewKV(core.NewMemoryKV())
 	tc := newTestClusterInfo(cluster)
-	_, opt := newTestScheduleConfig()
 	hbStreams := newHeartbeatStreams(cluster.getClusterID())
 	defer hbStreams.Close()
 
@@ -378,7 +377,6 @@ func (s *testCoordinatorSuite) TestAddScheduler(c *C) {
 	cluster := newClusterInfo(core.NewMockIDAllocator())
 	cluster.kv = core.NewKV(core.NewMemoryKV())
 	tc := newTestClusterInfo(cluster)
-	_, opt := newTestScheduleConfig()
 	hbStreams := newHeartbeatStreams(cluster.getClusterID())
 	defer hbStreams.Close()
 
@@ -438,7 +436,6 @@ func (s *testCoordinatorSuite) TestPersistScheduler(c *C) {
 	cluster := newClusterInfo(core.NewMockIDAllocator())
 	cluster.kv = core.NewKV(core.NewMemoryKV())
 	tc := newTestClusterInfo(cluster)
-	_, opt := newTestScheduleConfig()
 	hbStreams := newHeartbeatStreams(cluster.getClusterID())
 	defer hbStreams.Close()
 
@@ -500,7 +497,6 @@ func (s *testCoordinatorSuite) TestRestart(c *C) {
 	cluster := newClusterInfo(core.NewMockIDAllocator())
 	cluster.kv = core.NewKV(core.NewMemoryKV())
 	tc := newTestClusterInfo(cluster)
-	_, opt := newTestScheduleConfig()
 	hbStreams := newHeartbeatStreams(cluster.getClusterID())
 	defer hbStreams.Close()
 

--- a/server/handler.go
+++ b/server/handler.go
@@ -95,7 +95,7 @@ func (h *Handler) AddScheduler(name string, args ...string) error {
 	log.Infof("create scheduler %s", s.GetName())
 	if err = c.addScheduler(s, args...); err != nil {
 		log.Errorf("can not add scheduler %v: %v", s.GetName(), err)
-	} else if err = c.opt.persist(c.kv); err != nil {
+	} else if err = c.opt.persist(c.cluster.kv); err != nil {
 		log.Errorf("can not persist scheduler config: %v", err)
 	}
 	return errors.Trace(err)
@@ -109,7 +109,7 @@ func (h *Handler) RemoveScheduler(name string) error {
 	}
 	if err = c.removeScheduler(name); err != nil {
 		log.Errorf("can not remove scheduler %v: %v", name, err)
-	} else if err = c.opt.persist(c.kv); err != nil {
+	} else if err = c.opt.persist(c.cluster.kv); err != nil {
 		log.Errorf("can not persist scheduler config: %v", err)
 	}
 	return errors.Trace(err)


### PR DESCRIPTION
we can get kv from clusterInfo in coordinator, so coordinator doesn't need kv field.