### PR TITLE
table: adjust table id calculation.

### DIFF
--- a/table/namespace_classifier_test.go
+++ b/table/namespace_classifier_test.go
@@ -196,7 +196,7 @@ func (s *testTableNamespaceSuite) TestClassifierWithInfiniteEdge(c *C) {
 		StartKey: []byte("startKey"),
 	}, &metapb.Peer{})
 	ns := classifier.GetRegionNamespace(regionInfo)
-	c.Assert(ns, Equals, "test1")
+	c.Assert(ns, Equals, "global")
 
 	// mock the end edge
 	classifier = s.newClassifier(c, mockTableIDDecoderForEdge{})
@@ -224,7 +224,7 @@ func (s *testTableNamespaceSuite) TestClassifierWithCrossTable(c *C) {
 		EndKey:   []byte("endKey"),
 	}, &metapb.Peer{})
 	ns := classifier.GetRegionNamespace(regionInfo)
-	c.Assert(ns, Equals, "global")
+	c.Assert(ns, Equals, "test1")
 }
 
 func (s *testTableNamespaceSuite) TestClassifierWithTableSplit(c *C) {


### PR DESCRIPTION
In order to allow tikv to support region merge easily, now only split at the begining of a region. 

ref https://github.com/pingcap/tidb/pull/4926