### PR TITLE
schedule: remove pending peer before add new peer.

### DIFF
--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -90,6 +90,13 @@ func (c *testClusterInfo) setStoreDown(storeID uint64) {
 	store.LastHeartbeatTS = time.Time{}
 	c.putStore(store)
 }
+
+func (c *testClusterInfo) setStoreOffline(storeID uint64) {
+	store := c.GetStore(storeID)
+	store.State = metapb.StoreState_Offline
+	c.putStore(store)
+}
+
 func (c *testClusterInfo) LoadRegion(regionID uint64, followerIds ...uint64) {
 	//  regions load from etcd will have no leader
 	region := &metapb.Region{Id: regionID}
@@ -285,6 +292,14 @@ func (s *testCoordinatorSuite) TestReplica(c *C) {
 	checkRemovePeerResp(c, resp, 4)
 	region.RemoveStorePeer(4)
 	dispatchHeartbeatNoResp(c, co, region, stream)
+
+	// Remove offline peer directly when it's pending.
+	tc.addLeaderRegion(3, 1, 2, 3)
+	tc.setStoreOffline(3)
+	region = tc.GetRegion(3)
+	region.PendingPeers = []*metapb.Peer{region.GetStorePeer(3)}
+	resp = dispatchAndRecvHeartbeat(c, co, region, stream)
+	checkRemovePeerResp(c, resp, 3)
 }
 
 func (s *testCoordinatorSuite) TestPeerState(c *C) {


### PR DESCRIPTION
Consider we have 3 peers (A, B, C), we set the store that contains C to offline while C is pending. If we generate an operator that adds a replica D then removes C, D will not be successfully added util C is normal again.

So it's better to remove C directly.