### PR TITLE
core, schedule: use size as a factor of score

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -51,7 +51,7 @@ max-store-down-time = "1h"
 leader-schedule-limit = 64
 region-schedule-limit = 16
 replica-schedule-limit = 24
-tolerate-size-ratio = 2.5
+tolerant-size-ratio = 2.5
 
 # customized schedulers, the format is as below
 # if empty, it will use balance-leader, balance-region, hot-region as default

--- a/conf/config.toml
+++ b/conf/config.toml
@@ -51,6 +51,7 @@ max-store-down-time = "1h"
 leader-schedule-limit = 64
 region-schedule-limit = 16
 replica-schedule-limit = 24
+balance-tolerant-ratio = 2.5
 
 # customized schedulers, the format is as below
 # if empty, it will use balance-leader, balance-region, hot-region as default

--- a/conf/config.toml
+++ b/conf/config.toml
@@ -51,7 +51,7 @@ max-store-down-time = "1h"
 leader-schedule-limit = 64
 region-schedule-limit = 16
 replica-schedule-limit = 24
-balance-tolerant-ratio = 2.5
+tolerate-size-ratio = 2.5
 
 # customized schedulers, the format is as below
 # if empty, it will use balance-leader, balance-region, hot-region as default

--- a/server/cache.go
+++ b/server/cache.go
@@ -170,6 +170,13 @@ func (c *clusterInfo) GetStores() []*core.StoreInfo {
 	return c.BasicCluster.GetStores()
 }
 
+// GetStoresAverageScore returns the total resource score of all StoreInfo
+func (c *clusterInfo) GetStoresAverageScore(kind core.ResourceKind) float64 {
+	c.RLock()
+	defer c.RUnlock()
+	return c.BasicCluster.GetStoresAverageScore(kind)
+}
+
 func (c *clusterInfo) getMetaStores() []*metapb.Store {
 	c.RLock()
 	defer c.RUnlock()

--- a/server/config.go
+++ b/server/config.go
@@ -316,6 +316,8 @@ type ScheduleConfig struct {
 	RegionScheduleLimit uint64 `toml:"region-schedule-limit,omitempty" json:"region-schedule-limit"`
 	// ReplicaScheduleLimit is the max coexist replica schedules.
 	ReplicaScheduleLimit uint64 `toml:"replica-schedule-limit,omitempty" json:"replica-schedule-limit"`
+	// BalanceTolerantRatio is the ratio of buffer size for balance scheduler.
+	BalanceTolerantRatio float64 `toml:"balance-tolerant-ratio,omitempty" json:"balance-tolerant-ratio"`
 	// Schedulers support for loding customized schedulers
 	Schedulers SchedulerConfigs `toml:"schedulers,omitempty" json:"schedulers-v2"` // json v2 is for the sake of compatible upgrade
 }
@@ -329,6 +331,7 @@ func (c *ScheduleConfig) clone() *ScheduleConfig {
 		LeaderScheduleLimit:  c.LeaderScheduleLimit,
 		RegionScheduleLimit:  c.RegionScheduleLimit,
 		ReplicaScheduleLimit: c.ReplicaScheduleLimit,
+		BalanceTolerantRatio: c.BalanceTolerantRatio,
 		Schedulers:           schedulers,
 	}
 }
@@ -350,6 +353,7 @@ const (
 	defaultLeaderScheduleLimit  = 64
 	defaultRegionScheduleLimit  = 12
 	defaultReplicaScheduleLimit = 16
+	defaultBalanceTolerantRatio = 2.5
 )
 
 var defaultSchedulers = SchedulerConfigs{
@@ -365,6 +369,7 @@ func (c *ScheduleConfig) adjust() {
 	adjustUint64(&c.LeaderScheduleLimit, defaultLeaderScheduleLimit)
 	adjustUint64(&c.RegionScheduleLimit, defaultRegionScheduleLimit)
 	adjustUint64(&c.ReplicaScheduleLimit, defaultReplicaScheduleLimit)
+	adjustFloat64(&c.BalanceTolerantRatio, defaultBalanceTolerantRatio)
 	adjustSchedulers(&c.Schedulers, defaultSchedulers)
 }
 
@@ -452,6 +457,10 @@ func (o *scheduleOption) GetRegionScheduleLimit() uint64 {
 
 func (o *scheduleOption) GetReplicaScheduleLimit() uint64 {
 	return o.load().ReplicaScheduleLimit
+}
+
+func (o *scheduleOption) GetBalanceTolerantRatio() float64 {
+	return o.load().BalanceTolerantRatio
 }
 
 func (o *scheduleOption) GetSchedulers() SchedulerConfigs {

--- a/server/config.go
+++ b/server/config.go
@@ -316,8 +316,8 @@ type ScheduleConfig struct {
 	RegionScheduleLimit uint64 `toml:"region-schedule-limit,omitempty" json:"region-schedule-limit"`
 	// ReplicaScheduleLimit is the max coexist replica schedules.
 	ReplicaScheduleLimit uint64 `toml:"replica-schedule-limit,omitempty" json:"replica-schedule-limit"`
-	// BalanceTolerantRatio is the ratio of buffer size for balance scheduler.
-	BalanceTolerantRatio float64 `toml:"balance-tolerant-ratio,omitempty" json:"balance-tolerant-ratio"`
+	// TolerantSizeRatio is the ratio of buffer size for balance scheduler.
+	TolerantSizeRatio float64 `toml:"tolerant-size-ratio,omitempty" json:"tolerant-size-ratio"`
 	// Schedulers support for loding customized schedulers
 	Schedulers SchedulerConfigs `toml:"schedulers,omitempty" json:"schedulers-v2"` // json v2 is for the sake of compatible upgrade
 }
@@ -331,7 +331,7 @@ func (c *ScheduleConfig) clone() *ScheduleConfig {
 		LeaderScheduleLimit:  c.LeaderScheduleLimit,
 		RegionScheduleLimit:  c.RegionScheduleLimit,
 		ReplicaScheduleLimit: c.ReplicaScheduleLimit,
-		BalanceTolerantRatio: c.BalanceTolerantRatio,
+		TolerantSizeRatio:    c.TolerantSizeRatio,
 		Schedulers:           schedulers,
 	}
 }
@@ -353,7 +353,7 @@ const (
 	defaultLeaderScheduleLimit  = 64
 	defaultRegionScheduleLimit  = 12
 	defaultReplicaScheduleLimit = 16
-	defaultBalanceTolerantRatio = 2.5
+	defaultTolerantSizeRatio    = 2.5
 )
 
 var defaultSchedulers = SchedulerConfigs{
@@ -369,7 +369,7 @@ func (c *ScheduleConfig) adjust() {
 	adjustUint64(&c.LeaderScheduleLimit, defaultLeaderScheduleLimit)
 	adjustUint64(&c.RegionScheduleLimit, defaultRegionScheduleLimit)
 	adjustUint64(&c.ReplicaScheduleLimit, defaultReplicaScheduleLimit)
-	adjustFloat64(&c.BalanceTolerantRatio, defaultBalanceTolerantRatio)
+	adjustFloat64(&c.TolerantSizeRatio, defaultTolerantSizeRatio)
 	adjustSchedulers(&c.Schedulers, defaultSchedulers)
 }
 
@@ -459,8 +459,8 @@ func (o *scheduleOption) GetReplicaScheduleLimit() uint64 {
 	return o.load().ReplicaScheduleLimit
 }
 
-func (o *scheduleOption) GetBalanceTolerantRatio() float64 {
-	return o.load().BalanceTolerantRatio
+func (o *scheduleOption) GetTolerantSizeRatio() float64 {
+	return o.load().TolerantSizeRatio
 }
 
 func (o *scheduleOption) GetSchedulers() SchedulerConfigs {

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -106,17 +106,17 @@ const minWeight = 1e-6
 // LeaderScore returns the store's leader score: leaderCount / leaderWeight.
 func (s *StoreInfo) LeaderScore() float64 {
 	if s.LeaderWeight <= 0 {
-		return float64(s.LeaderCount) / minWeight
+		return float64(s.LeaderSize) / minWeight
 	}
-	return float64(s.LeaderCount) / s.LeaderWeight
+	return float64(s.LeaderSize) / s.LeaderWeight
 }
 
 // RegionScore returns the store's region score: regionSize / regionWeight.
 func (s *StoreInfo) RegionScore() float64 {
 	if s.RegionWeight <= 0 {
-		return float64(s.RegionCount) / minWeight
+		return float64(s.RegionSize) / minWeight
 	}
-	return float64(s.RegionCount) / s.RegionWeight
+	return float64(s.RegionSize) / s.RegionWeight
 }
 
 // StorageSize returns store's used storage size reported from tikv.
@@ -170,6 +170,24 @@ func (s *StoreInfo) ResourceScore(kind ResourceKind) float64 {
 		return s.LeaderScore()
 	case RegionKind:
 		return s.RegionScore()
+	default:
+		return 0
+	}
+}
+
+// ResourceWeight returns weight of leader/region in the score
+func (s *StoreInfo) ResourceWeight(kind ResourceKind) float64 {
+	switch kind {
+	case LeaderKind:
+		if s.LeaderWeight <= 0 {
+			return minWeight
+		}
+		return s.LeaderWeight
+	case RegionKind:
+		if s.RegionWeight <= 0 {
+			return minWeight
+		}
+		return s.RegionWeight
 	default:
 		return 0
 	}
@@ -364,6 +382,19 @@ func (s *StoresInfo) SetRegionSize(storeID uint64, regionSize int64) {
 	if store, ok := s.stores[storeID]; ok {
 		store.RegionSize = regionSize
 	}
+}
+
+// AverageResourceScore return the total resource score of all StoreInfo
+func (s *StoresInfo) AverageResourceScore(kind ResourceKind) float64 {
+	var totalResourceScore float64
+	var count int
+	for _, s := range s.stores {
+		if s.IsUp() {
+			count++
+			totalResourceScore += s.ResourceScore(kind)
+		}
+	}
+	return totalResourceScore / float64(count)
 }
 
 // TotalWrittenBytes return the total written bytes of all StoreInfo

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -386,15 +386,15 @@ func (s *StoresInfo) SetRegionSize(storeID uint64, regionSize int64) {
 
 // AverageResourceScore return the total resource score of all StoreInfo
 func (s *StoresInfo) AverageResourceScore(kind ResourceKind) float64 {
-	var totalResourceScore float64
-	var count int
+	var totalResourceSize int64
+	var totalResourceWeight float64
 	for _, s := range s.stores {
 		if s.IsUp() {
-			count++
-			totalResourceScore += s.ResourceScore(kind)
+			totalResourceWeight += s.ResourceWeight(kind)
+			totalResourceSize += s.ResourceSize(kind)
 		}
 	}
-	return totalResourceScore / float64(count)
+	return float64(totalResourceSize) / totalResourceWeight
 }
 
 // TotalWrittenBytes return the total written bytes of all StoreInfo

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -394,6 +394,10 @@ func (s *StoresInfo) AverageResourceScore(kind ResourceKind) float64 {
 			totalResourceSize += s.ResourceSize(kind)
 		}
 	}
+
+	if totalResourceWeight == 0 {
+		return 0
+	}
 	return float64(totalResourceSize) / totalResourceWeight
 }
 

--- a/server/schedule/basic_cluster.go
+++ b/server/schedule/basic_cluster.go
@@ -135,6 +135,11 @@ func (bc *BasicCluster) GetLeaderStore(region *core.RegionInfo) *core.StoreInfo 
 	return bc.Stores.GetStore(region.Leader.GetStoreId())
 }
 
+// GetStoresAverageScore returns the total resource score of all StoreInfo
+func (bc *BasicCluster) GetStoresAverageScore(kind core.ResourceKind) float64 {
+	return bc.Stores.AverageResourceScore(kind)
+}
+
 // BlockStore stops balancer from selecting the store.
 func (bc *BasicCluster) BlockStore(storeID uint64) error {
 	return errors.Trace(bc.Stores.BlockStore(storeID))

--- a/server/schedule/opts.go
+++ b/server/schedule/opts.go
@@ -21,6 +21,7 @@ import (
 type Options interface {
 	GetLeaderScheduleLimit() uint64
 	GetRegionScheduleLimit() uint64
+	GetBalanceTolerantRatio() float64
 
 	GetMaxSnapshotCount() uint64
 	GetMaxPendingPeerCount() uint64

--- a/server/schedule/opts.go
+++ b/server/schedule/opts.go
@@ -21,7 +21,7 @@ import (
 type Options interface {
 	GetLeaderScheduleLimit() uint64
 	GetRegionScheduleLimit() uint64
-	GetBalanceTolerantRatio() float64
+	GetTolerantSizeRatio() float64
 
 	GetMaxSnapshotCount() uint64
 	GetMaxPendingPeerCount() uint64

--- a/server/schedule/scheduler.go
+++ b/server/schedule/scheduler.go
@@ -34,6 +34,7 @@ type Cluster interface {
 	GetRegionStores(region *core.RegionInfo) []*core.StoreInfo
 	GetFollowerStores(region *core.RegionInfo) []*core.StoreInfo
 	GetLeaderStore(region *core.RegionInfo) *core.StoreInfo
+	GetStoresAverageScore(kind core.ResourceKind) float64
 	ScanRegions(startKey []byte, limit int) []*core.RegionInfo
 
 	BlockStore(id uint64) error

--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -76,7 +76,8 @@ func (l *balanceLeaderScheduler) Schedule(cluster schedule.Cluster, opInfluence 
 
 	source := cluster.GetStore(region.Leader.GetStoreId())
 	target := cluster.GetStore(newLeader.GetStoreId())
-	if !shouldBalance(source, target, core.LeaderKind, opInfluence) {
+	avgScore := cluster.GetStoresAverageScore(core.LeaderKind)
+	if !shouldBalance(source, target, avgScore, core.LeaderKind, region, opInfluence) {
 		schedulerCounter.WithLabelValues(l.GetName(), "skip").Inc()
 		return nil
 	}

--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -77,7 +77,7 @@ func (l *balanceLeaderScheduler) Schedule(cluster schedule.Cluster, opInfluence 
 	source := cluster.GetStore(region.Leader.GetStoreId())
 	target := cluster.GetStore(newLeader.GetStoreId())
 	avgScore := cluster.GetStoresAverageScore(core.LeaderKind)
-	if !shouldBalance(source, target, avgScore, core.LeaderKind, region, opInfluence) {
+	if !shouldBalance(source, target, avgScore, core.LeaderKind, region, opInfluence, l.opt.GetBalanceTolerantRatio()) {
 		schedulerCounter.WithLabelValues(l.GetName(), "skip").Inc()
 		return nil
 	}

--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -77,7 +77,7 @@ func (l *balanceLeaderScheduler) Schedule(cluster schedule.Cluster, opInfluence 
 	source := cluster.GetStore(region.Leader.GetStoreId())
 	target := cluster.GetStore(newLeader.GetStoreId())
 	avgScore := cluster.GetStoresAverageScore(core.LeaderKind)
-	if !shouldBalance(source, target, avgScore, core.LeaderKind, region, opInfluence, l.opt.GetBalanceTolerantRatio()) {
+	if !shouldBalance(source, target, avgScore, core.LeaderKind, region, opInfluence, l.opt.GetTolerantSizeRatio()) {
 		schedulerCounter.WithLabelValues(l.GetName(), "skip").Inc()
 		return nil
 	}

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -118,7 +118,8 @@ func (s *balanceRegionScheduler) transferPeer(cluster schedule.Cluster, region *
 	}
 
 	target := cluster.GetStore(newPeer.GetStoreId())
-	if !shouldBalance(source, target, core.RegionKind, opInfluence) {
+	avgScore := cluster.GetStoresAverageScore(core.RegionKind)
+	if !shouldBalance(source, target, avgScore, core.RegionKind, region, opInfluence) {
 		schedulerCounter.WithLabelValues(s.GetName(), "skip").Inc()
 		return nil
 	}

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -119,7 +119,7 @@ func (s *balanceRegionScheduler) transferPeer(cluster schedule.Cluster, region *
 
 	target := cluster.GetStore(newPeer.GetStoreId())
 	avgScore := cluster.GetStoresAverageScore(core.RegionKind)
-	if !shouldBalance(source, target, avgScore, core.RegionKind, region, opInfluence, s.opt.GetBalanceTolerantRatio()) {
+	if !shouldBalance(source, target, avgScore, core.RegionKind, region, opInfluence, s.opt.GetTolerantSizeRatio()) {
 		schedulerCounter.WithLabelValues(s.GetName(), "skip").Inc()
 		return nil
 	}

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -119,7 +119,7 @@ func (s *balanceRegionScheduler) transferPeer(cluster schedule.Cluster, region *
 
 	target := cluster.GetStore(newPeer.GetStoreId())
 	avgScore := cluster.GetStoresAverageScore(core.RegionKind)
-	if !shouldBalance(source, target, avgScore, core.RegionKind, region, opInfluence) {
+	if !shouldBalance(source, target, avgScore, core.RegionKind, region, opInfluence, s.opt.GetBalanceTolerantRatio()) {
 		schedulerCounter.WithLabelValues(s.GetName(), "skip").Inc()
 		return nil
 	}

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -109,7 +109,7 @@ func (s *testBalanceSpeedSuite) testBalanceSpeed(c *C, tests []testBalanceSpeedC
 		source := tc.GetStore(1)
 		target := tc.GetStore(2)
 		region := &core.RegionInfo{ApproximateSize: t.regionSize}
-		c.Assert(shouldBalance(source, target, t.avgScore, core.LeaderKind, region, newTestOpInfluence(1, 2, core.LeaderKind, t.diff), defaultBalanceTolerantRatio), Equals, t.expectedResult)
+		c.Assert(shouldBalance(source, target, t.avgScore, core.LeaderKind, region, newTestOpInfluence(1, 2, core.LeaderKind, t.diff), defaultTolerantSizeRatio), Equals, t.expectedResult)
 	}
 
 	for _, t := range tests {
@@ -118,7 +118,7 @@ func (s *testBalanceSpeedSuite) testBalanceSpeed(c *C, tests []testBalanceSpeedC
 		source := tc.GetStore(1)
 		target := tc.GetStore(2)
 		region := &core.RegionInfo{ApproximateSize: t.regionSize}
-		c.Assert(shouldBalance(source, target, t.avgScore, core.RegionKind, region, newTestOpInfluence(1, 2, core.RegionKind, t.diff), defaultBalanceTolerantRatio), Equals, t.expectedResult)
+		c.Assert(shouldBalance(source, target, t.avgScore, core.RegionKind, region, newTestOpInfluence(1, 2, core.RegionKind, t.diff), defaultTolerantSizeRatio), Equals, t.expectedResult)
 	}
 }
 

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -109,7 +109,7 @@ func (s *testBalanceSpeedSuite) testBalanceSpeed(c *C, tests []testBalanceSpeedC
 		source := tc.GetStore(1)
 		target := tc.GetStore(2)
 		region := &core.RegionInfo{ApproximateSize: t.regionSize}
-		c.Assert(shouldBalance(source, target, t.avgScore, core.LeaderKind, region, newTestOpInfluence(1, 2, core.LeaderKind, t.diff)), Equals, t.expectedResult)
+		c.Assert(shouldBalance(source, target, t.avgScore, core.LeaderKind, region, newTestOpInfluence(1, 2, core.LeaderKind, t.diff), defaultBalanceTolerantRatio), Equals, t.expectedResult)
 	}
 
 	for _, t := range tests {
@@ -118,7 +118,7 @@ func (s *testBalanceSpeedSuite) testBalanceSpeed(c *C, tests []testBalanceSpeedC
 		source := tc.GetStore(1)
 		target := tc.GetStore(2)
 		region := &core.RegionInfo{ApproximateSize: t.regionSize}
-		c.Assert(shouldBalance(source, target, t.avgScore, core.RegionKind, region, newTestOpInfluence(1, 2, core.RegionKind, t.diff)), Equals, t.expectedResult)
+		c.Assert(shouldBalance(source, target, t.avgScore, core.RegionKind, region, newTestOpInfluence(1, 2, core.RegionKind, t.diff), defaultBalanceTolerantRatio), Equals, t.expectedResult)
 	}
 }
 

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -39,40 +39,34 @@ type testBalanceSpeedSuite struct{}
 type testBalanceSpeedCase struct {
 	sourceCount    uint64
 	targetCount    uint64
+	avgScore       float64
+	regionSize     int64
 	diff           int
 	expectedResult bool
 }
 
 func (s *testBalanceSpeedSuite) TestBalanceSpeed(c *C) {
 	testCases := []testBalanceSpeedCase{
-		// diff >= 2
-		{1, 0, 0, false},
-		{2, 0, 0, true},
-		{2, 0, 1, false},
-		{2, 1, 0, false},
-		{9, 0, 0, true},
-		{9, 0, 8, false},
-		{9, 6, 0, true},
-		{9, 6, 2, false},
-		{9, 8, 0, false},
-		// diff >= sqrt(10) = 3.16
-		{10, 0, 0, true},
-		{10, 0, 5, false},
-		{10, 6, 0, true},
-		{10, 6, 4, false},
-		{10, 7, 0, false},
-		// diff >= sqrt(100) = 10
-		{100, 89, 0, true},
-		{100, 89, 2, false},
-		{100, 91, 0, false},
-		// diff >= sqrt(1000) = 31.6
-		{1000, 968, 0, true},
-		{1000, 968, 20, false},
-		{1000, 969, 0, false},
-		// diff >= sqrt(10000) = 100
-		{10000, 9899, 0, true},
-		{10000, 9899, 100, false},
-		{10000, 9901, 0, false},
+		// source > avg > target
+		{2, 0, 10, 1, 0, true},
+		{2, 0, 10, 1, 10, false},
+		{2, 0, 10, 10, 0, false},
+		{10, 10, 100, 1, 0, false},
+		{20, 10, 150, 20, 0, true},
+		{20, 10, 150, 20, 50, false},
+		{20, 10, 150, 30, 0, false},
+		{1000, 2, 7500, 1, 0, true},
+		{1000, 2, 7500, 20, 0, true},
+		{1000, 2, 7500, 300, 0, true},
+		{1000, 2, 7500, 300, 2000, false},
+		{1000, 2, 7500, 1000, 0, true},
+		{1000, 2, 7500, 1001, 0, false},
+		// source > target > avg
+		{5, 2, 10, 1, 0, false},
+		{5, 2, 10, 10, 0, false},
+		// avg > source > target
+		{4, 0, 50, 1, 0, false},
+		{4, 0, 50, 10, 0, false},
 	}
 
 	s.testBalanceSpeed(c, testCases, 1)
@@ -114,7 +108,8 @@ func (s *testBalanceSpeedSuite) testBalanceSpeed(c *C, tests []testBalanceSpeedC
 		tc.addLeaderStore(2, int(t.targetCount))
 		source := tc.GetStore(1)
 		target := tc.GetStore(2)
-		c.Assert(shouldBalance(source, target, core.LeaderKind, newTestOpInfluence(1, 2, core.LeaderKind, t.diff)), Equals, t.expectedResult)
+		region := &core.RegionInfo{ApproximateSize: t.regionSize}
+		c.Assert(shouldBalance(source, target, t.avgScore, core.LeaderKind, region, newTestOpInfluence(1, 2, core.LeaderKind, t.diff)), Equals, t.expectedResult)
 	}
 
 	for _, t := range tests {
@@ -122,7 +117,8 @@ func (s *testBalanceSpeedSuite) testBalanceSpeed(c *C, tests []testBalanceSpeedC
 		tc.addRegionStore(2, int(t.targetCount))
 		source := tc.GetStore(1)
 		target := tc.GetStore(2)
-		c.Assert(shouldBalance(source, target, core.RegionKind, newTestOpInfluence(1, 2, core.RegionKind, t.diff)), Equals, t.expectedResult)
+		region := &core.RegionInfo{ApproximateSize: t.regionSize}
+		c.Assert(shouldBalance(source, target, t.avgScore, core.RegionKind, region, newTestOpInfluence(1, 2, core.RegionKind, t.diff)), Equals, t.expectedResult)
 	}
 }
 
@@ -170,13 +166,12 @@ func (s *testBalanceLeaderSchedulerSuite) TestBalanceLimit(c *C) {
 	s.tc.addLeaderStore(3, 0)
 	s.tc.addLeaderStore(4, 0)
 	s.tc.addLeaderRegion(1, 1, 2, 3, 4)
-	// Test min balance diff (>=2).
 	c.Check(s.schedule(nil), IsNil)
 
 	// Stores:     1    2    3    4
-	// Leaders:    2    0    0    0
+	// Leaders:    10   0    0    0
 	// Region1:    L    F    F    F
-	s.tc.updateLeaderCount(1, 2)
+	s.tc.updateLeaderCount(1, 10)
 	c.Check(s.schedule(nil), NotNil)
 
 	// Stores:     1    2    3    4
@@ -187,49 +182,47 @@ func (s *testBalanceLeaderSchedulerSuite) TestBalanceLimit(c *C) {
 	s.tc.updateLeaderCount(3, 9)
 	s.tc.updateLeaderCount(4, 10)
 	s.tc.addLeaderRegion(1, 4, 1, 2, 3)
-	// Min balance diff is 4. Now is 10-7=3.
 	c.Check(s.schedule(nil), IsNil)
 
 	// Stores:     1    2    3    4
 	// Leaders:    7    8    9   16
 	// Region1:    F    F    F    L
 	s.tc.updateLeaderCount(4, 16)
-	// Min balance diff is 4. Now is 16-7=9.
 	c.Check(s.schedule(nil), NotNil)
 }
 
 func (s *testBalanceLeaderSchedulerSuite) TestScheduleWithOpInfluence(c *C) {
 	// Stores:     1    2    3    4
-	// Leaders:    7    8    9   11
+	// Leaders:    7    8    9   16
 	// Region1:    F    F    F    L
 	s.tc.addLeaderStore(1, 7)
 	s.tc.addLeaderStore(2, 8)
 	s.tc.addLeaderStore(3, 9)
-	s.tc.addLeaderStore(4, 11)
+	s.tc.addLeaderStore(4, 16)
 	s.tc.addLeaderRegion(1, 4, 1, 2, 3)
 	op := s.schedule(nil)
 	c.Check(op, NotNil)
 	c.Check(s.schedule([]*schedule.Operator{op}), IsNil)
 
 	// Stores:     1    2    3    4
-	// Leaders:    8    8    9   10
+	// Leaders:    8    8    9   15
 	// Region1:    F    F    F    L
 	s.tc.updateLeaderCount(1, 8)
 	s.tc.updateLeaderCount(2, 8)
 	s.tc.updateLeaderCount(3, 9)
-	s.tc.updateLeaderCount(4, 10)
+	s.tc.updateLeaderCount(4, 15)
 	s.tc.addLeaderRegion(1, 4, 1, 2, 3)
 	c.Check(s.schedule(nil), IsNil)
 }
 
 func (s *testBalanceLeaderSchedulerSuite) TestBalanceFilter(c *C) {
 	// Stores:     1    2    3    4
-	// Leaders:    1    2    3   10
+	// Leaders:    1    2    3   16
 	// Region1:    F    F    F    L
 	s.tc.addLeaderStore(1, 1)
 	s.tc.addLeaderStore(2, 2)
 	s.tc.addLeaderStore(3, 3)
-	s.tc.addLeaderStore(4, 10)
+	s.tc.addLeaderStore(4, 16)
 	s.tc.addLeaderRegion(1, 4, 1, 2, 3)
 
 	CheckTransferLeader(c, s.schedule(nil), 4, 1)
@@ -268,25 +261,25 @@ func (s *testBalanceLeaderSchedulerSuite) TestLeaderWeight(c *C) {
 
 func (s *testBalanceLeaderSchedulerSuite) TestBalanceSelector(c *C) {
 	// Stores:     1    2    3    4
-	// Leaders:    1    2    3   10
+	// Leaders:    1    2    3   16
 	// Region1:    -    F    F    L
 	// Region2:    F    F    L    -
 	s.tc.addLeaderStore(1, 1)
 	s.tc.addLeaderStore(2, 2)
 	s.tc.addLeaderStore(3, 3)
-	s.tc.addLeaderStore(4, 10)
+	s.tc.addLeaderStore(4, 16)
 	s.tc.addLeaderRegion(1, 4, 2, 3)
 	s.tc.addLeaderRegion(2, 3, 1, 2)
-	// Average leader is 4. Select store 4 as source.
+	// Average leader is 5.5. Select store 4 as source.
 	CheckTransferLeader(c, s.schedule(nil), 4, 2)
 
 	// Stores:     1    2    3    4
-	// Leaders:    1    8    9   10
+	// Leaders:    1    14   15   16
 	// Region1:    -    F    F    L
 	// Region2:    F    F    L    -
-	s.tc.updateLeaderCount(2, 8)
-	s.tc.updateLeaderCount(3, 9)
-	// Average leader is 7. Select store 1 as target.
+	s.tc.updateLeaderCount(2, 14)
+	s.tc.updateLeaderCount(3, 15)
+	// Average leader is 11.5. Select store 1 as target.
 	CheckTransferLeader(c, s.schedule(nil), 3, 1)
 }
 
@@ -309,16 +302,13 @@ func (s *testBalanceRegionSchedulerSuite) TestBalance(c *C) {
 	tc.addRegionStore(1, 6)
 	tc.addRegionStore(2, 8)
 	tc.addRegionStore(3, 8)
-	tc.addRegionStore(4, 9)
+	tc.addRegionStore(4, 16)
 	// Add region 1 with leader in store 4.
 	tc.addLeaderRegion(1, 4)
 	CheckTransferPeer(c, sb.Schedule(cluster, schedule.NewOpInfluence(nil, cluster)), 4, 1)
 
 	// Test stateFilter.
 	tc.setStoreOffline(1)
-	// Test min balance diff (>=2).
-	c.Assert(sb.Schedule(cluster, schedule.NewOpInfluence(nil, cluster)), IsNil)
-	// 9 - 6 >= 2
 	tc.updateRegionCount(2, 6)
 	cache.Remove(4)
 	// When store 1 is offline, it will be filtered,
@@ -344,9 +334,9 @@ func (s *testBalanceRegionSchedulerSuite) TestReplicas3(c *C) {
 	cache := sb.(*balanceRegionScheduler).cache
 
 	// Store 1 has the largest region score, so the balancer try to replace peer in store 1.
-	tc.addLabelsStore(1, 6, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
-	tc.addLabelsStore(2, 5, map[string]string{"zone": "z1", "rack": "r2", "host": "h1"})
-	tc.addLabelsStore(3, 4, map[string]string{"zone": "z1", "rack": "r2", "host": "h2"})
+	tc.addLabelsStore(1, 16, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(2, 15, map[string]string{"zone": "z1", "rack": "r2", "host": "h1"})
+	tc.addLabelsStore(3, 14, map[string]string{"zone": "z1", "rack": "r2", "host": "h2"})
 
 	tc.addLeaderRegion(1, 1, 2, 3)
 	// This schedule try to replace peer in store 1, but we have no other stores,
@@ -412,7 +402,7 @@ func (s *testBalanceRegionSchedulerSuite) TestReplicas5(c *C) {
 	tc.addLabelsStore(2, 5, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"})
 	tc.addLabelsStore(3, 6, map[string]string{"zone": "z3", "rack": "r1", "host": "h1"})
 	tc.addLabelsStore(4, 7, map[string]string{"zone": "z4", "rack": "r1", "host": "h1"})
-	tc.addLabelsStore(5, 8, map[string]string{"zone": "z5", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(5, 28, map[string]string{"zone": "z5", "rack": "r1", "host": "h1"})
 
 	tc.addLeaderRegion(1, 1, 2, 3, 4, 5)
 
@@ -429,7 +419,7 @@ func (s *testBalanceRegionSchedulerSuite) TestReplicas5(c *C) {
 	CheckTransferPeer(c, sb.Schedule(cluster, schedule.NewOpInfluence(nil, cluster)), 5, 1)
 
 	// Store 6 has smaller region score and higher distinct score.
-	tc.addLabelsStore(11, 9, map[string]string{"zone": "z1", "rack": "r2", "host": "h1"})
+	tc.addLabelsStore(11, 29, map[string]string{"zone": "z1", "rack": "r2", "host": "h1"})
 	tc.addLabelsStore(12, 8, map[string]string{"zone": "z2", "rack": "r2", "host": "h1"})
 	tc.addLabelsStore(13, 7, map[string]string{"zone": "z3", "rack": "r2", "host": "h1"})
 	tc.addLeaderRegion(1, 2, 3, 11, 12, 13)

--- a/server/schedulers/mockcluster.go
+++ b/server/schedulers/mockcluster.go
@@ -121,6 +121,18 @@ func (mc *mockCluster) updateStoreRegionWeight(storeID uint64, weight float64) {
 	mc.PutStore(store)
 }
 
+func (mc *mockCluster) updateStoreLeaderSize(storeID uint64, size int64) {
+	store := mc.GetStore(storeID)
+	store.LeaderSize = size
+	mc.PutStore(store)
+}
+
+func (mc *mockCluster) updateStoreRegionSize(storeID uint64, size int64) {
+	store := mc.GetStore(storeID)
+	store.RegionSize = size
+	mc.PutStore(store)
+}
+
 func (mc *mockCluster) addLabelsStore(storeID uint64, regionCount int, labels map[string]string) {
 	mc.addRegionStore(storeID, regionCount)
 	store := mc.GetStore(storeID)

--- a/server/schedulers/mockcluster.go
+++ b/server/schedulers/mockcluster.go
@@ -255,6 +255,7 @@ const (
 	defaultLeaderScheduleLimit  = 64
 	defaultRegionScheduleLimit  = 12
 	defaultReplicaScheduleLimit = 16
+	defaultBalanceTolerantRatio = 2.5
 )
 
 // MockSchedulerOptions is a mock of SchedulerOptions
@@ -268,6 +269,7 @@ type MockSchedulerOptions struct {
 	MaxReplicas           int
 	LocationLabels        []string
 	HotRegionLowThreshold int
+	BalanceTolerantRatio  float64
 }
 
 func newMockSchedulerOptions() *MockSchedulerOptions {
@@ -279,6 +281,7 @@ func newMockSchedulerOptions() *MockSchedulerOptions {
 	mso.MaxReplicas = defaultMaxReplicas
 	mso.HotRegionLowThreshold = schedule.HotRegionLowThreshold
 	mso.MaxPendingPeerCount = defaultMaxPendingPeerCount
+	mso.BalanceTolerantRatio = defaultBalanceTolerantRatio
 	return mso
 }
 
@@ -320,6 +323,11 @@ func (mso *MockSchedulerOptions) GetLocationLabels() []string {
 // GetHotRegionLowThreshold mock method
 func (mso *MockSchedulerOptions) GetHotRegionLowThreshold() int {
 	return mso.HotRegionLowThreshold
+}
+
+// GetBalanceTolerantRatio mock method
+func (mso *MockSchedulerOptions) GetBalanceTolerantRatio() float64 {
+	return mso.BalanceTolerantRatio
 }
 
 // SetMaxReplicas mock method

--- a/server/schedulers/mockcluster.go
+++ b/server/schedulers/mockcluster.go
@@ -255,7 +255,7 @@ const (
 	defaultLeaderScheduleLimit  = 64
 	defaultRegionScheduleLimit  = 12
 	defaultReplicaScheduleLimit = 16
-	defaultBalanceTolerantRatio = 2.5
+	defaultTolerantSizeRatio    = 2.5
 )
 
 // MockSchedulerOptions is a mock of SchedulerOptions
@@ -269,7 +269,7 @@ type MockSchedulerOptions struct {
 	MaxReplicas           int
 	LocationLabels        []string
 	HotRegionLowThreshold int
-	BalanceTolerantRatio  float64
+	TolerantSizeRatio     float64
 }
 
 func newMockSchedulerOptions() *MockSchedulerOptions {
@@ -281,7 +281,7 @@ func newMockSchedulerOptions() *MockSchedulerOptions {
 	mso.MaxReplicas = defaultMaxReplicas
 	mso.HotRegionLowThreshold = schedule.HotRegionLowThreshold
 	mso.MaxPendingPeerCount = defaultMaxPendingPeerCount
-	mso.BalanceTolerantRatio = defaultBalanceTolerantRatio
+	mso.TolerantSizeRatio = defaultTolerantSizeRatio
 	return mso
 }
 
@@ -325,9 +325,9 @@ func (mso *MockSchedulerOptions) GetHotRegionLowThreshold() int {
 	return mso.HotRegionLowThreshold
 }
 
-// GetBalanceTolerantRatio mock method
-func (mso *MockSchedulerOptions) GetBalanceTolerantRatio() float64 {
-	return mso.BalanceTolerantRatio
+// GetTolerantSizeRatio mock method
+func (mso *MockSchedulerOptions) GetTolerantSizeRatio() float64 {
+	return mso.TolerantSizeRatio
 }
 
 // SetMaxReplicas mock method

--- a/server/schedulers/test_util.go
+++ b/server/schedulers/test_util.go
@@ -20,6 +20,7 @@ import (
 
 // CheckAddPeer check add peer
 func CheckAddPeer(c *check.C, op *schedule.Operator, storeID uint64) {
+	c.Assert(op, check.NotNil)
 	c.Assert(op.Len(), check.Equals, 1)
 	c.Assert(op.Step(0).(schedule.AddPeer).ToStore, check.Equals, storeID)
 }
@@ -33,6 +34,7 @@ func CheckTransferLeader(c *check.C, op *schedule.Operator, sourceID, targetID u
 
 // CheckTransferPeer checks peer transfer
 func CheckTransferPeer(c *check.C, op *schedule.Operator, sourceID, targetID uint64) {
+	c.Assert(op, check.NotNil)
 	if op.Len() == 2 {
 		c.Assert(op.Step(0).(schedule.AddPeer).ToStore, check.Equals, targetID)
 		c.Assert(op.Step(1).(schedule.RemovePeer).FromStore, check.Equals, sourceID)

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -139,10 +139,6 @@ func minDuration(a, b time.Duration) time.Duration {
 	return b
 }
 
-const (
-	tolerantRatio = 2.5
-)
-
 func takeInfluence(store *core.StoreInfo, storeInfluence *schedule.StoreInfluence) {
 	store.LeaderCount += storeInfluence.LeaderCount
 	store.RegionCount += storeInfluence.RegionCount
@@ -153,7 +149,7 @@ func takeInfluence(store *core.StoreInfo, storeInfluence *schedule.StoreInfluenc
 // shouldBalance returns true if we should balance the source and target store.
 // The tolerantRatio provides a buffer to make the cluster stable, so that we
 // don't need to schedule very frequently.
-func shouldBalance(source, target *core.StoreInfo, avgScore float64, kind core.ResourceKind, region *core.RegionInfo, opInfluence schedule.OpInfluence) bool {
+func shouldBalance(source, target *core.StoreInfo, avgScore float64, kind core.ResourceKind, region *core.RegionInfo, opInfluence schedule.OpInfluence, tolerantRatio float64) bool {
 	takeInfluence(source, opInfluence.GetStoreInfluence(source.GetId()))
 	takeInfluence(target, opInfluence.GetStoreInfluence(target.GetId()))
 

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -149,6 +149,7 @@ func takeInfluence(store *core.StoreInfo, storeInfluence *schedule.StoreInfluenc
 // shouldBalance returns true if we should balance the source and target store.
 // The tolerantRatio provides a buffer to make the cluster stable, so that we
 // don't need to schedule very frequently.
+// TODO: simplify the arguments
 func shouldBalance(source, target *core.StoreInfo, avgScore float64, kind core.ResourceKind, region *core.RegionInfo, opInfluence schedule.OpInfluence, tolerantRatio float64) bool {
 	takeInfluence(source, opInfluence.GetStoreInfluence(source.GetId()))
 	takeInfluence(target, opInfluence.GetStoreInfluence(target.GetId()))

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -170,7 +170,7 @@ func shouldBalance(source, target *core.StoreInfo, avgScore float64, kind core.R
 	sourceSizeDiff := (sourceScore - avgScore) * source.ResourceWeight(kind)
 	targetSizeDiff := (avgScore - targetScore) * target.ResourceWeight(kind)
 
-	return math.Min(sourceSizeDiff, targetSizeDiff) > float64(region.ApproximateSize)*tolerantRatio
+	return math.Min(sourceSizeDiff, targetSizeDiff) >= float64(region.ApproximateSize)*tolerantRatio
 }
 
 func adjustBalanceLimit(cluster schedule.Cluster, kind core.ResourceKind) uint64 {


### PR DESCRIPTION
When calculate region/leader score, use size instead of count, in order to balance store size in final.

new shouldBalance logic:

1. introduce avgScore to make sure moving is not unnecessary. Cause in some case:
   note that: avgScore is not equal to totalScore / count, since weight is not same for every store, move will cause the change of score for two involved store is not equal. So it should be totalSize / totalWeight.
   - sourceScore > targetScore > avgScore, if move, targetScore is still higher than avgScore, and then target store will be scheduled to move some region or leader to other stores with smaller score. But is is better to move some region or leader from source store to store with score lower than avgScore, so it is unnecessary
   - avgScore > sourceScore > targetScore, if move, sourceScore is still lower than avgScore, source store still need other stores to move region or leader to it for closing avgScore, so it is unnecessary.
2. avgScore is the score when stores in perfect balance state. Based on the weight, we can know the difference of size for current state to be in perfect balance state, and the minimum of them is the largest size of region to be moved. And the tolerantRatio provides a buffer to make the cluster stable, so that we don't need to schedule very frequently.
