### PR TITLE
api: better region key output.

### DIFF
--- a/server/api/region.go
+++ b/server/api/region.go
@@ -14,23 +14,57 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/pd/server"
+	"github.com/pingcap/pd/server/core"
 	"github.com/unrolled/render"
 )
 
 type regionInfo struct {
-	Region *metapb.Region `json:"region"`
-	Leader *metapb.Peer   `json:"leader"`
+	ID          uint64              `json:"id"`
+	StartKey    string              `json:"start_key"`
+	EndKey      string              `json:"end_key"`
+	RegionEpoch *metapb.RegionEpoch `json:"epoch,omitempty"`
+	Peers       []*metapb.Peer      `json:"peers,omitempty"`
+
+	Leader          *metapb.Peer      `json:"leader,omitempty"`
+	DownPeers       []*pdpb.PeerStats `json:"down_peers,omitempty"`
+	PendingPeers    []*metapb.Peer    `json:"pending_peers,omitempty"`
+	WrittenBytes    uint64            `json:"written_bytes,omitempty"`
+	ReadBytes       uint64            `json:"read_bytes,omitempty"`
+	ApproximateSize int64             `json:"approximate_size,omitempty"`
+}
+
+func newRegionInfo(r *core.RegionInfo) *regionInfo {
+	if r == nil {
+		return nil
+	}
+	return &regionInfo{
+		ID:          r.Id,
+		StartKey:    strings.Trim(fmt.Sprintf("%q", r.StartKey), "\""),
+		EndKey:      strings.Trim(fmt.Sprintf("%q", r.EndKey), "\""),
+		RegionEpoch: r.RegionEpoch,
+		Peers:       r.Peers,
+
+		Leader:          r.Leader,
+		DownPeers:       r.DownPeers,
+		PendingPeers:    r.PendingPeers,
+		WrittenBytes:    r.WrittenBytes,
+		ReadBytes:       r.ReadBytes,
+		ApproximateSize: r.ApproximateSize,
+	}
 }
 
 type regionsInfo struct {
-	Count   int              `json:"count"`
-	Regions []*metapb.Region `json:"regions"`
+	Count   int           `json:"count"`
+	Regions []*regionInfo `json:"regions"`
 }
 
 type regionHandler struct {
@@ -61,7 +95,7 @@ func (h *regionHandler) GetRegionByID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	regionInfo := cluster.GetRegionInfoByID(regionID)
-	h.rd.JSON(w, http.StatusOK, regionInfo)
+	h.rd.JSON(w, http.StatusOK, newRegionInfo(regionInfo))
 }
 
 func (h *regionHandler) GetRegionByKey(w http.ResponseWriter, r *http.Request) {
@@ -73,7 +107,7 @@ func (h *regionHandler) GetRegionByKey(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	key := vars["key"]
 	regionInfo := cluster.GetRegionInfoByKey([]byte(key))
-	h.rd.JSON(w, http.StatusOK, regionInfo)
+	h.rd.JSON(w, http.StatusOK, newRegionInfo(regionInfo))
 }
 
 type regionsHandler struct {
@@ -96,9 +130,13 @@ func (h *regionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	regions := cluster.GetRegions()
+	regionInfos := make([]*regionInfo, len(regions))
+	for i, r := range regions {
+		regionInfos[i] = newRegionInfo(&core.RegionInfo{Region: r})
+	}
 	regionsInfo := &regionsInfo{
 		Count:   len(regions),
-		Regions: regions,
+		Regions: regionInfos,
 	}
 	h.rd.JSON(w, http.StatusOK, regionsInfo)
 }

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -18,7 +18,6 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
-	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/pd/server"
 	"github.com/pingcap/pd/server/core"
 )
@@ -58,9 +57,7 @@ func newTestRegionInfo(regionID, storeID uint64, start, end []byte) *core.Region
 			EndKey:   end,
 			Peers:    []*metapb.Peer{leader},
 		},
-		Leader:       leader,
-		DownPeers:    make([]*pdpb.PeerStats, 0),
-		PendingPeers: make([]*metapb.Peer, 0),
+		Leader: leader,
 	}
 }
 
@@ -68,14 +65,14 @@ func (s *testRegionSuite) TestRegion(c *C) {
 	r := newTestRegionInfo(2, 1, []byte("a"), []byte("b"))
 	mustRegionHeartbeat(c, s.svr, r)
 	url := fmt.Sprintf("%s/region/id/%d", s.urlPrefix, r.GetId())
-	r1 := &core.RegionInfo{}
+	r1 := &regionInfo{}
 	err := readJSONWithURL(url, r1)
 	c.Assert(err, IsNil)
-	c.Assert(r1, DeepEquals, r)
+	c.Assert(r1, DeepEquals, newRegionInfo(r))
 
 	url = fmt.Sprintf("%s/region/key/%s", s.urlPrefix, "a")
-	r2 := &core.RegionInfo{}
+	r2 := &regionInfo{}
 	err = readJSONWithURL(url, r2)
 	c.Assert(err, IsNil)
-	c.Assert(r2, DeepEquals, r)
+	c.Assert(r2, DeepEquals, newRegionInfo(r))
 }


### PR DESCRIPTION
Fix #816 
Fix #498 

before:
```
» region 6
{
  "id": 6,
  "start_key": "dIAAAAAAAAD/BQAAAAAAAAD4",
  "end_key": "dIAAAAAAAAD/BwAAAAAAAAD4",
  "region_epoch": {
    "conf_ver": 1,
    "version": 3
  },
  "peers": [
    {
      "id": 7,
      "store_id": 1
    }
  ],
  "Leader": {
    "id": 7,
    "store_id": 1
  },
  "DownPeers": [],
  "PendingPeers": [],
  "WrittenBytes": 0,
  "ReadBytes": 0
}
```
after:
```
» region 6
{
  "id": 6,
  "start_key": "t\\x80\\x00\\x00\\x00\\x00\\x00\\x00\\xff\\x05\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xf8",
  "end_key": "t\\x80\\x00\\x00\\x00\\x00\\x00\\x00\\xff\\a\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xf8",
  "epoch": {
    "conf_ver": 1,
    "version": 3
  },
  "peers": [
    {
      "id": 7,
      "store_id": 1
    }
  ],
  "leader": {
    "id": 7,
    "store_id": 1
  }
}
```