### PR TITLE
pd-client: fix tso duration metrics

### DIFF
--- a/pd-client/client.go
+++ b/pd-client/client.go
@@ -399,8 +399,8 @@ func (c *client) finishTSORequest(requests []*tsoRequest, physical, firstLogical
 		}
 		req := requests[i]
 		req.physical, req.logical = physical, firstLogical+int64(i)
-		req.done <- err
 		cmdDuration.WithLabelValues("tso").Observe(time.Since(req.start).Seconds())
+		req.done <- err
 	}
 }
 


### PR DESCRIPTION
Finish tso metrics should be done in `finishTSORequest()`, rather than `Wait()`

@siddontang @disksing 