### PR TITLE
alter_Makefile_go_env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ endif
 
 test:
 	# testing..
-	@GOPATH=$(VENDOR) ENABLE_CGO=1 go test -race -cover $(TEST_PKGS)
+	@GOPATH=$(VENDOR) CGO_ENABLED=1 go test -race -cover $(TEST_PKGS)
 
 check:
 	go get github.com/golang/lint/golint

--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,13 @@ dev: build check test
 
 build:
 ifeq ("$(WITH_RACE)", "1")
-	GOPATH=$(VENDOR) ENABLE_CGO=1 go build -race -ldflags '$(LDFLAGS)' -o bin/pd-server cmd/pd-server/main.go
+	GOPATH=$(VENDOR) CGO_ENABLED=1 go build -race -ldflags '$(LDFLAGS)' -o bin/pd-server cmd/pd-server/main.go
 else
-	GOPATH=$(VENDOR) go build -ldflags '$(LDFLAGS)' -o bin/pd-server cmd/pd-server/main.go
+	GOPATH=$(VENDOR) CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o bin/pd-server cmd/pd-server/main.go
 endif
-	GOPATH=$(VENDOR) go build -ldflags '$(LDFLAGS)' -o bin/pd-ctl cmd/pd-ctl/main.go
-	GOPATH=$(VENDOR) go build -o bin/pd-tso-bench cmd/pd-tso-bench/main.go
-	GOPATH=$(VENDOR) go build -o bin/pd-recover cmd/pd-recover/main.go
+	GOPATH=$(VENDOR) CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o bin/pd-ctl cmd/pd-ctl/main.go
+	GOPATH=$(VENDOR) CGO_ENABLED=0 go build -o bin/pd-tso-bench cmd/pd-tso-bench/main.go
+	GOPATH=$(VENDOR) CGO_ENABLED=0 go build -o bin/pd-recover cmd/pd-recover/main.go
 
 test:
 	# testing..


### PR DESCRIPTION
alter makefile go env 

Change ENABLE_CGO=1  to CGO_ENABLED=1 ，add CGO_ENABLED=0

use CGO_ENABLED=1 ：
```
 ldd pd-server 
	linux-vdso.so.1 =>  (0x00007ffd1e8e9000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f7d41369000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f7d40fa6000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f7d41591000)
```
use CGO_ENABLED=0

```
ldd pd-server 
	not a dynamic executable
```


