### PR TITLE
config: fix join without scheme.

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -268,6 +268,12 @@ func (c *Config) adjust() error {
 
 	adjustString(&c.InitialClusterState, defualtInitialClusterState)
 
+	if len(c.Join) > 0 {
+		if _, err := url.Parse(c.Join); err != nil {
+			return errors.Errorf("failed to parse join addr:%s, err:%v", c.Join, err)
+		}
+	}
+
 	adjustInt64(&c.LeaderLease, defaultLeaderLease)
 
 	adjustDuration(&c.TsoSaveInterval, time.Duration(defaultLeaderLease)*time.Second)
@@ -447,6 +453,9 @@ type SecurityConfig struct {
 
 // ToTLSConfig generatres tls config.
 func (s SecurityConfig) ToTLSConfig() (*tls.Config, error) {
+	if len(s.CertPath) == 0 && len(s.KeyPath) == 0 {
+		return nil, nil
+	}
 	tlsInfo := transport.TLSInfo{
 		CertFile:      s.CertPath,
 		KeyFile:       s.KeyPath,

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -1,0 +1,35 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testConfigSuite{})
+
+type testConfigSuite struct{}
+
+func (s *testConfigSuite) TestTLS(c *C) {
+	cfg := NewConfig()
+	tls, err := cfg.Security.ToTLSConfig()
+	c.Assert(err, IsNil)
+	c.Assert(tls, IsNil)
+}
+
+func (s *testConfigSuite) TestBadFormatJoinAddr(c *C) {
+	cfg := NewTestSingleConfig()
+	cfg.Join = "127.0.0.1:2379" // Wrong join addr without scheme.
+	c.Assert(cfg.adjust(), NotNil)
+}


### PR DESCRIPTION
pd-server fails with throwing error log 'authentication handshake failed' when the `Join` is set to a 'host:port' style address instead of URL, such as "127.0.0.1:2379". The problem actually contains 2 bugs:
1. For integrity, we should only allow join a URL format as "http(s)://host:port".
2. If TLS is not configured, we should not pass a `tls.Config` to etcd.

The second issue was not revealed before because `tls.Config` did not take effect when scheme is explicitly specified as http.