### PR TITLE
fix score when region size is zero

### DIFF
--- a/server/core/store.go
+++ b/server/core/store.go
@@ -14,6 +14,7 @@
 package core
 
 import (
+	"math"
 	"strings"
 	"time"
 
@@ -105,18 +106,20 @@ const minWeight = 1e-6
 
 // LeaderScore returns the store's leader score: leaderCount / leaderWeight.
 func (s *StoreInfo) LeaderScore() float64 {
+	size := math.Min(1, float64(s.LeaderSize))
 	if s.LeaderWeight <= 0 {
-		return float64(s.LeaderSize) / minWeight
+		return size / minWeight
 	}
-	return float64(s.LeaderSize) / s.LeaderWeight
+	return size / s.LeaderWeight
 }
 
 // RegionScore returns the store's region score: regionSize / regionWeight.
 func (s *StoreInfo) RegionScore() float64 {
+	size := math.Min(1, float64(s.RegionSize))
 	if s.RegionWeight <= 0 {
-		return float64(s.RegionSize) / minWeight
+		return size / minWeight
 	}
-	return float64(s.RegionSize) / s.RegionWeight
+	return size / s.RegionWeight
 }
 
 // StorageSize returns store's used storage size reported from tikv.

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -106,7 +106,7 @@ const minWeight = 1e-6
 
 // LeaderScore returns the store's leader score: leaderCount / leaderWeight.
 func (s *StoreInfo) LeaderScore() float64 {
-	size := math.Min(1, float64(s.LeaderSize))
+	size := math.Max(1, float64(s.LeaderSize))
 	if s.LeaderWeight <= 0 {
 		return size / minWeight
 	}
@@ -115,7 +115,7 @@ func (s *StoreInfo) LeaderScore() float64 {
 
 // RegionScore returns the store's region score: regionSize / regionWeight.
 func (s *StoreInfo) RegionScore() float64 {
-	size := math.Min(1, float64(s.RegionSize))
+	size := math.Max(1, float64(s.RegionSize))
 	if s.RegionWeight <= 0 {
 		return size / minWeight
 	}

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -170,9 +170,9 @@ func (s *testBalanceLeaderSchedulerSuite) TestBalanceLimit(c *C) {
 	c.Check(s.schedule(nil), IsNil)
 
 	// Stores:     1    2    3    4
-	// Leaders:    10   0    0    0
+	// Leaders:    16   0    0    0
 	// Region1:    L    F    F    F
-	s.tc.updateLeaderCount(1, 10)
+	s.tc.updateLeaderCount(1, 16)
 	c.Check(s.schedule(nil), NotNil)
 
 	// Stores:     1    2    3    4


### PR DESCRIPTION
when region size is zero, the score will be zero accordingly. When scheduler move this kind of regions, the score of store isn't affected, leading to maldistribution of region count for stores.