### PR TITLE
proto: compatible with proto3.

### DIFF
--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -389,8 +389,8 @@ func (s *Server) AskSplit(ctx context.Context, request *pdpb.AskSplitRequest) (*
 	if cluster == nil {
 		return &pdpb.AskSplitResponse{Header: s.notBootstrappedHeader()}, nil
 	}
-	if request.GetRegion().GetStartKey() == nil {
-		return nil, errors.New("missing region start key for split")
+	if request.GetRegion() == nil {
+		return nil, errors.New("missing region key for split")
 	}
 	req := &pdpb.AskSplitRequest{
 		Region: request.Region,

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -390,7 +390,7 @@ func (s *Server) AskSplit(ctx context.Context, request *pdpb.AskSplitRequest) (*
 		return &pdpb.AskSplitResponse{Header: s.notBootstrappedHeader()}, nil
 	}
 	if request.GetRegion() == nil {
-		return nil, errors.New("missing region key for split")
+		return nil, errors.New("missing region for split")
 	}
 	req := &pdpb.AskSplitRequest{
 		Region: request.Region,


### PR DESCRIPTION
Suppress errors when a newer version of tikv (probably v1.1) connects to pd v1.0.x.
Related issue: https://github.com/pingcap/tikv/issues/2681