### PR TITLE
main: fix join failed when log dir is same as data dir

### DIFF
--- a/pkg/logutil/log.go
+++ b/pkg/logutil/log.go
@@ -221,6 +221,7 @@ var once sync.Once
 // InitLogger initializes PD's logger.
 func InitLogger(cfg *LogConfig) error {
 	var err error
+
 	once.Do(func() {
 		log.SetLevel(StringToLogLevel(cfg.Level))
 		log.AddHook(&contextHook{})

--- a/server/join.go
+++ b/server/join.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/coreos/etcd/clientv3"
@@ -72,9 +73,8 @@ func PrepareJoinCluster(cfg *Config) error {
 	}
 
 	// Cases with data directory.
-
 	initialCluster := ""
-	if wal.Exist(cfg.DataDir) {
+	if wal.Exist(path.Join(cfg.DataDir, "member")) {
 		cfg.InitialCluster = initialCluster
 		cfg.InitialClusterState = embed.ClusterStateFlagExisting
 		return nil


### PR DESCRIPTION
if log directory is subdirectory of data directory, a new pd to join cluster will fail cause log directory will create before checking data directory whether exists and pd will regard the new join pd as a already existing pd.

this pr does: 
don't allow log directory to be the subdirectory of data directory