### PR TITLE
 server: reduce the lock overhead

### DIFF
--- a/server/cache.go
+++ b/server/cache.go
@@ -372,8 +372,8 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 	region = region.Clone()
 	c.RLock()
 	origin := c.Regions.GetRegion(region.GetId())
-	isWriteUpdate, writeItem := c.IsUpdateWriteStatus(region)
-	isReadUpdate, readItem := c.IsUpdateReadStatus(region)
+	isWriteUpdate, writeItem := c.CheckWriteStatus(region)
+	isReadUpdate, readItem := c.CheckReadStatus(region)
 	c.RUnlock()
 
 	// Save to KV if meta is updated.

--- a/server/cache.go
+++ b/server/cache.go
@@ -473,7 +473,7 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 		if readItem == nil {
 			c.ReadStatistics.Remove(key)
 		} else {
-			c.ReadStatistics.Put(key, writeItem)
+			c.ReadStatistics.Put(key, readItem)
 		}
 	}
 	return nil

--- a/server/cache.go
+++ b/server/cache.go
@@ -428,6 +428,7 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 	}
 
 	c.Lock()
+	defer c.Unlock()
 	if isNew {
 		c.activeRegions++
 	}
@@ -467,7 +468,6 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 			c.ReadStatistics.Put(key, writeItem)
 		}
 	}
-	c.Unlock()
 	return nil
 }
 

--- a/server/cache.go
+++ b/server/cache.go
@@ -372,8 +372,8 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 	region = region.Clone()
 	c.RLock()
 	origin := c.Regions.GetRegion(region.GetId())
-	isWriteUpdate, key, writeItem := c.IsUpdateWriteStatus(region.Clone())
-	isReadUpdate, key, readItem := c.IsUpdateReadStatus(region.Clone())
+	isWriteUpdate, key, writeItem := c.IsUpdateWriteStatus(region)
+	isReadUpdate, key, readItem := c.IsUpdateReadStatus(region)
 	c.RUnlock()
 
 	// Save to KV if meta is updated.

--- a/server/cache.go
+++ b/server/cache.go
@@ -372,8 +372,8 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 	region = region.Clone()
 	c.RLock()
 	origin := c.Regions.GetRegion(region.GetId())
-	isWriteUpdate, key, writeItem := c.IsUpdateWriteStatus(region)
-	isReadUpdate, key, readItem := c.IsUpdateReadStatus(region)
+	isWriteUpdate, writeItem := c.IsUpdateWriteStatus(region)
+	isReadUpdate, readItem := c.IsUpdateReadStatus(region)
 	c.RUnlock()
 
 	// Save to KV if meta is updated.
@@ -452,6 +452,7 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 			c.updateStoreStatus(p.GetStoreId())
 		}
 	}
+	key := region.GetId()
 	if isWriteUpdate {
 		if writeItem == nil {
 			c.WriteStatistics.Remove(key)

--- a/server/schedule/basic_cluster.go
+++ b/server/schedule/basic_cluster.go
@@ -263,7 +263,7 @@ func (bc *BasicCluster) isNeedUpdateWriteStatCache(region *core.RegionInfo, hotR
 }
 
 // IsUpdateReadStatus update the read status
-func (bc *BasicCluster) IsUpdateReadStatus(region *core.RegionInfo) (isUpdate bool, key uint64, item *core.RegionStat) {
+func (bc *BasicCluster) IsUpdateReadStatus(region *core.RegionInfo) (bool, uint64, *core.RegionStat) {
 	var ReadBytesPerSec uint64
 	v, isExist := bc.ReadStatistics.Peek(region.GetId())
 	if isExist && !Simulating { // When simulating, we can't calculate it using physical time.

--- a/server/schedule/basic_cluster.go
+++ b/server/schedule/basic_cluster.go
@@ -205,7 +205,11 @@ func (bc *BasicCluster) CheckWriteStatus(region *core.RegionInfo) (bool, *core.R
 	var WrittenBytesPerSec uint64
 	v, isExist := bc.WriteStatistics.Peek(region.GetId())
 	if isExist && !Simulating {
-		interval := time.Since(v.(*core.RegionStat).LastUpdateTime).Seconds()
+		value, ok := v.(*core.RegionStat)
+		if !ok {
+			return false, nil
+		}
+		interval := time.Since(value.LastUpdateTime).Seconds()
 		if interval < minHotRegionReportInterval {
 			return false, nil
 		}
@@ -267,7 +271,11 @@ func (bc *BasicCluster) CheckReadStatus(region *core.RegionInfo) (bool, *core.Re
 	var ReadBytesPerSec uint64
 	v, isExist := bc.ReadStatistics.Peek(region.GetId())
 	if isExist && !Simulating { // When simulating, we can't calculate it using physical time.
-		interval := time.Now().Sub(v.(*core.RegionStat).LastUpdateTime).Seconds()
+		value, ok := v.(*core.RegionStat)
+		if !ok {
+			return false, nil
+		}
+		interval := time.Since(value.LastUpdateTime).Seconds()
 		if interval < minHotRegionReportInterval {
 			return false, nil
 		}

--- a/server/schedule/basic_cluster.go
+++ b/server/schedule/basic_cluster.go
@@ -205,11 +205,7 @@ func (bc *BasicCluster) CheckWriteStatus(region *core.RegionInfo) (bool, *core.R
 	var WrittenBytesPerSec uint64
 	v, isExist := bc.WriteStatistics.Peek(region.GetId())
 	if isExist && !Simulating {
-		value, ok := v.(*core.RegionStat)
-		if !ok {
-			return false, nil
-		}
-		interval := time.Since(value.LastUpdateTime).Seconds()
+		interval := time.Since(v.(*core.RegionStat).LastUpdateTime).Seconds()
 		if interval < minHotRegionReportInterval {
 			return false, nil
 		}
@@ -271,11 +267,7 @@ func (bc *BasicCluster) CheckReadStatus(region *core.RegionInfo) (bool, *core.Re
 	var ReadBytesPerSec uint64
 	v, isExist := bc.ReadStatistics.Peek(region.GetId())
 	if isExist && !Simulating { // When simulating, we can't calculate it using physical time.
-		value, ok := v.(*core.RegionStat)
-		if !ok {
-			return false, nil
-		}
-		interval := time.Since(value.LastUpdateTime).Seconds()
+		interval := time.Since(v.(*core.RegionStat).LastUpdateTime).Seconds()
 		if interval < minHotRegionReportInterval {
 			return false, nil
 		}

--- a/server/schedule/basic_cluster.go
+++ b/server/schedule/basic_cluster.go
@@ -200,8 +200,8 @@ func (bc *BasicCluster) PutRegion(region *core.RegionInfo) error {
 	return nil
 }
 
-// IsUpdateWriteStatus update the write status
-func (bc *BasicCluster) IsUpdateWriteStatus(region *core.RegionInfo) (bool, *core.RegionStat) {
+// CheckWriteStatus checks the write status, return whether need update statistics and item
+func (bc *BasicCluster) CheckWriteStatus(region *core.RegionInfo) (bool, *core.RegionStat) {
 	var WrittenBytesPerSec uint64
 	v, isExist := bc.WriteStatistics.Peek(region.GetId())
 	if isExist && !Simulating {
@@ -262,8 +262,8 @@ func (bc *BasicCluster) isNeedUpdateWriteStatCache(region *core.RegionInfo, hotR
 	return true, newItem
 }
 
-// IsUpdateReadStatus update the read status
-func (bc *BasicCluster) IsUpdateReadStatus(region *core.RegionInfo) (bool, *core.RegionStat) {
+// CheckReadStatus checks the read status, return whether need update statistics and item
+func (bc *BasicCluster) CheckReadStatus(region *core.RegionInfo) (bool, *core.RegionStat) {
 	var ReadBytesPerSec uint64
 	v, isExist := bc.ReadStatistics.Peek(region.GetId())
 	if isExist && !Simulating { // When simulating, we can't calculate it using physical time.

--- a/server/schedule/basic_cluster.go
+++ b/server/schedule/basic_cluster.go
@@ -200,7 +200,7 @@ func (bc *BasicCluster) PutRegion(region *core.RegionInfo) error {
 	return nil
 }
 
-// CheckWriteStatus checks the write status, return whether need update statistics and item
+// CheckWriteStatus checks the write status, returns whether need update statistics and item
 func (bc *BasicCluster) CheckWriteStatus(region *core.RegionInfo) (bool, *core.RegionStat) {
 	var WrittenBytesPerSec uint64
 	v, isExist := bc.WriteStatistics.Peek(region.GetId())
@@ -262,7 +262,7 @@ func (bc *BasicCluster) isNeedUpdateWriteStatCache(region *core.RegionInfo, hotR
 	return true, newItem
 }
 
-// CheckReadStatus checks the read status, return whether need update statistics and item
+// CheckReadStatus checks the read status, returns whether need update statistics and item
 func (bc *BasicCluster) CheckReadStatus(region *core.RegionInfo) (bool, *core.RegionStat) {
 	var ReadBytesPerSec uint64
 	v, isExist := bc.ReadStatistics.Peek(region.GetId())

--- a/server/schedulers/mockcluster.go
+++ b/server/schedulers/mockcluster.go
@@ -169,7 +169,14 @@ func (mc *mockCluster) LoadRegion(regionID uint64, followerIds ...uint64) {
 func (mc *mockCluster) addLeaderRegionWithWriteInfo(regionID uint64, leaderID uint64, writtenBytes uint64, followerIds ...uint64) {
 	r := mc.newMockRegionInfo(regionID, leaderID, followerIds...)
 	r.WrittenBytes = writtenBytes
-	mc.BasicCluster.UpdateWriteStatus(r)
+	isUpdate, key, item := mc.BasicCluster.IsUpdateWriteStatus(r)
+	if isUpdate {
+		if item == nil {
+			mc.BasicCluster.WriteStatistics.Remove(key)
+		} else {
+			mc.BasicCluster.WriteStatistics.Put(key, item)
+		}
+	}
 	mc.PutRegion(r)
 }
 
@@ -215,7 +222,14 @@ func (mc *mockCluster) updateStorageReadBytes(storeID uint64, BytesRead uint64) 
 func (mc *mockCluster) addLeaderRegionWithReadInfo(regionID uint64, leaderID uint64, readBytes uint64, followerIds ...uint64) {
 	r := mc.newMockRegionInfo(regionID, leaderID, followerIds...)
 	r.ReadBytes = readBytes
-	mc.BasicCluster.UpdateReadStatus(r)
+	isUpdate, key, item := mc.BasicCluster.IsUpdateReadStatus(r)
+	if isUpdate {
+		if item == nil {
+			mc.BasicCluster.ReadStatistics.Remove(key)
+		} else {
+			mc.BasicCluster.ReadStatistics.Put(key, item)
+		}
+	}
 	mc.PutRegion(r)
 }
 

--- a/server/schedulers/mockcluster.go
+++ b/server/schedulers/mockcluster.go
@@ -169,12 +169,12 @@ func (mc *mockCluster) LoadRegion(regionID uint64, followerIds ...uint64) {
 func (mc *mockCluster) addLeaderRegionWithWriteInfo(regionID uint64, leaderID uint64, writtenBytes uint64, followerIds ...uint64) {
 	r := mc.newMockRegionInfo(regionID, leaderID, followerIds...)
 	r.WrittenBytes = writtenBytes
-	isUpdate, key, item := mc.BasicCluster.IsUpdateWriteStatus(r)
+	isUpdate, item := mc.BasicCluster.IsUpdateWriteStatus(r)
 	if isUpdate {
 		if item == nil {
-			mc.BasicCluster.WriteStatistics.Remove(key)
+			mc.BasicCluster.WriteStatistics.Remove(regionID)
 		} else {
-			mc.BasicCluster.WriteStatistics.Put(key, item)
+			mc.BasicCluster.WriteStatistics.Put(regionID, item)
 		}
 	}
 	mc.PutRegion(r)
@@ -222,12 +222,12 @@ func (mc *mockCluster) updateStorageReadBytes(storeID uint64, BytesRead uint64) 
 func (mc *mockCluster) addLeaderRegionWithReadInfo(regionID uint64, leaderID uint64, readBytes uint64, followerIds ...uint64) {
 	r := mc.newMockRegionInfo(regionID, leaderID, followerIds...)
 	r.ReadBytes = readBytes
-	isUpdate, key, item := mc.BasicCluster.IsUpdateReadStatus(r)
+	isUpdate, item := mc.BasicCluster.IsUpdateReadStatus(r)
 	if isUpdate {
 		if item == nil {
-			mc.BasicCluster.ReadStatistics.Remove(key)
+			mc.BasicCluster.ReadStatistics.Remove(regionID)
 		} else {
-			mc.BasicCluster.ReadStatistics.Put(key, item)
+			mc.BasicCluster.ReadStatistics.Put(regionID, item)
 		}
 	}
 	mc.PutRegion(r)

--- a/server/schedulers/mockcluster.go
+++ b/server/schedulers/mockcluster.go
@@ -169,7 +169,7 @@ func (mc *mockCluster) LoadRegion(regionID uint64, followerIds ...uint64) {
 func (mc *mockCluster) addLeaderRegionWithWriteInfo(regionID uint64, leaderID uint64, writtenBytes uint64, followerIds ...uint64) {
 	r := mc.newMockRegionInfo(regionID, leaderID, followerIds...)
 	r.WrittenBytes = writtenBytes
-	isUpdate, item := mc.BasicCluster.IsUpdateWriteStatus(r)
+	isUpdate, item := mc.BasicCluster.CheckWriteStatus(r)
 	if isUpdate {
 		if item == nil {
 			mc.BasicCluster.WriteStatistics.Remove(regionID)
@@ -222,7 +222,7 @@ func (mc *mockCluster) updateStorageReadBytes(storeID uint64, BytesRead uint64) 
 func (mc *mockCluster) addLeaderRegionWithReadInfo(regionID uint64, leaderID uint64, readBytes uint64, followerIds ...uint64) {
 	r := mc.newMockRegionInfo(regionID, leaderID, followerIds...)
 	r.ReadBytes = readBytes
-	isUpdate, item := mc.BasicCluster.IsUpdateReadStatus(r)
+	isUpdate, item := mc.BasicCluster.CheckReadStatus(r)
 	if isUpdate {
 		if item == nil {
 			mc.BasicCluster.ReadStatistics.Remove(regionID)


### PR DESCRIPTION
When the number of regions is large, the lock is  expensive when processing the heartbeat.now does not need to get the lock if cache not needs to update.