### PR TITLE
api, pdctl, server: support config label scheduler and label property.

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -78,7 +78,6 @@ location-labels = []
 
 [label-property]
 # Do not assign region leaders to stores that have these tags.
-reject-leader = [
-# { key = "zone", value = "cn1"},
-# { key = "disk", value = "hdd"}
-]
+#  [[label-property.reject-leader]]
+#  key = "zone"
+#  value = "cn1

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -56,6 +56,8 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	router.HandleFunc("/api/v1/config/namespace/{name}", confHandler.GetNamespace).Methods("GET")
 	router.HandleFunc("/api/v1/config/namespace/{name}", confHandler.SetNamespace).Methods("POST")
 	router.HandleFunc("/api/v1/config/namespace/{name}", confHandler.DeleteNamespace).Methods("DELETE")
+	router.HandleFunc("/api/v1/config/label-property", confHandler.GetLabelProperty).Methods("GET")
+	router.HandleFunc("/api/v1/config/label-property", confHandler.SetLabelProperty).Methods("POST")
 
 	storeHandler := newStoreHandler(svr, rd)
 	router.HandleFunc("/api/v1/store/{id}", storeHandler.Get).Methods("GET")

--- a/server/api/scheduler.go
+++ b/server/api/scheduler.go
@@ -66,9 +66,13 @@ func (h *schedulerHandler) Post(w http.ResponseWriter, r *http.Request) {
 			h.r.JSON(w, http.StatusInternalServerError, err.Error())
 			return
 		}
-
 	case "balance-region-scheduler":
 		if err := h.AddBalanceRegionScheduler(); err != nil {
+			h.r.JSON(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	case "label-scheduler":
+		if err := h.AddLabelScheduler(); err != nil {
 			h.r.JSON(w, http.StatusInternalServerError, err.Error())
 			return
 		}

--- a/server/cache.go
+++ b/server/cache.go
@@ -551,6 +551,6 @@ func (c *clusterInfo) GetHotRegionLowThreshold() int {
 	return c.opt.GetHotRegionLowThreshold()
 }
 
-func (c *clusterInfo) IsRejectLeader(labels []*metapb.StoreLabel) bool {
-	return c.opt.IsRejectLeader(labels)
+func (c *clusterInfo) CheckLabelProperty(typ string, labels []*metapb.StoreLabel) bool {
+	return c.opt.CheckLabelProperty(typ, labels)
 }

--- a/server/config.go
+++ b/server/config.go
@@ -490,8 +490,16 @@ type StoreLabel struct {
 }
 
 // LabelPropertyConfig is the config section to set properties to store labels.
-type LabelPropertyConfig struct {
-	RejectLeader []StoreLabel `toml:"reject-leader" json:"reject-leader"`
+type LabelPropertyConfig map[string][]StoreLabel
+
+func (c LabelPropertyConfig) clone() LabelPropertyConfig {
+	m := make(map[string][]StoreLabel, len(c))
+	for k, sl := range c {
+		sl2 := make([]StoreLabel, 0, len(sl))
+		sl2 = append(sl2, sl...)
+		m[k] = sl2
+	}
+	return m
 }
 
 // ParseUrls parse a string into multiple urls.

--- a/server/handler.go
+++ b/server/handler.go
@@ -149,6 +149,11 @@ func (h *Handler) AddBalanceHotRegionScheduler() error {
 	return h.AddScheduler("hot-region")
 }
 
+// AddLabelScheduler adds a label-scheduler.
+func (h *Handler) AddLabelScheduler() error {
+	return h.AddScheduler("label")
+}
+
 // AddAdjacentRegionScheduler adds a balance-adjacent-region-scheduler.
 func (h *Handler) AddAdjacentRegionScheduler(args ...string) error {
 	return h.AddScheduler("adjacent-region", args...)

--- a/server/schedule/filters.go
+++ b/server/schedule/filters.go
@@ -276,5 +276,5 @@ func (f rejectLeaderFilter) FilterSource(opt Options, store *core.StoreInfo) boo
 }
 
 func (f rejectLeaderFilter) FilterTarget(opt Options, store *core.StoreInfo) bool {
-	return opt.IsRejectLeader(store.Labels)
+	return opt.CheckLabelProperty(RejectLeader, store.Labels)
 }

--- a/server/schedule/operator.go
+++ b/server/schedule/operator.go
@@ -280,7 +280,7 @@ func removePeerSteps(cluster Cluster, region *core.RegionInfo, storeID uint64) (
 	if region.Leader != nil && region.Leader.GetStoreId() == storeID {
 		for id := range region.GetFollowers() {
 			follower := cluster.GetStore(id)
-			if follower != nil && !cluster.IsRejectLeader(follower.Labels) {
+			if follower != nil && !cluster.CheckLabelProperty(RejectLeader, follower.Labels) {
 				steps = append(steps, TransferLeader{FromStore: storeID, ToStore: id})
 				kind = OpLeader
 				break

--- a/server/schedule/opts.go
+++ b/server/schedule/opts.go
@@ -39,8 +39,7 @@ type Options interface {
 	GetHotRegionLowThreshold() int
 	GetTolerantSizeRatio() float64
 
-	// IsRejectLeader checks if a store is not allow to have region leaders.
-	IsRejectLeader(labels []*metapb.StoreLabel) bool
+	CheckLabelProperty(typ string, labels []*metapb.StoreLabel) bool
 }
 
 // NamespaceOptions for namespace cluster.
@@ -50,3 +49,9 @@ type NamespaceOptions interface {
 	GetReplicaScheduleLimit(name string) uint64
 	GetMaxReplicas(name string) int
 }
+
+const (
+	// RejectLeader is the label property type that sugguests a store should not
+	// have any region leaders.
+	RejectLeader = "reject-leader"
+)

--- a/server/schedulers/label.go
+++ b/server/schedulers/label.go
@@ -60,7 +60,7 @@ func (s *labelScheduler) Schedule(cluster schedule.Cluster, opInfluence schedule
 	stores := cluster.GetStores()
 	rejectLeaderStores := make(map[uint64]struct{})
 	for _, s := range stores {
-		if cluster.IsRejectLeader(s.Labels) {
+		if cluster.CheckLabelProperty(schedule.RejectLeader, s.Labels) {
 			rejectLeaderStores[s.GetId()] = struct{}{}
 		}
 	}

--- a/server/schedulers/mockcluster.go
+++ b/server/schedulers/mockcluster.go
@@ -298,10 +298,10 @@ func (mc *mockCluster) GetMaxReplicas() int {
 	return mc.MockSchedulerOptions.GetMaxReplicas(namespace.DefaultNamespace)
 }
 
-func (mc *mockCluster) IsRejectLeader(labels []*metapb.StoreLabel) bool {
-	for _, c := range mc.MockSchedulerOptions.RejectLeaderLabels {
+func (mc *mockCluster) CheckLabelProperty(typ string, labels []*metapb.StoreLabel) bool {
+	for _, cfg := range mc.LabelProperties[typ] {
 		for _, l := range labels {
-			if c.Key == l.Key && c.Value == l.Value {
+			if l.Key == cfg.Key && l.Value == cfg.Value {
 				return true
 			}
 		}
@@ -333,7 +333,7 @@ type MockSchedulerOptions struct {
 	LocationLabels        []string
 	HotRegionLowThreshold int
 	TolerantSizeRatio     float64
-	RejectLeaderLabels    []*metapb.StoreLabel
+	LabelProperties       map[string][]*metapb.StoreLabel
 }
 
 func newMockSchedulerOptions() *MockSchedulerOptions {

--- a/server/schedulers/scheduler_test.go
+++ b/server/schedulers/scheduler_test.go
@@ -191,7 +191,9 @@ type testRejectLeaderSuite struct{}
 
 func (s *testRejectLeaderSuite) TestRejectLeader(c *C) {
 	opt := newTestScheduleConfig()
-	opt.RejectLeaderLabels = []*metapb.StoreLabel{{Key: "noleader", Value: "true"}}
+	opt.LabelProperties = map[string][]*metapb.StoreLabel{
+		schedule.RejectLeader: {{Key: "noleader", Value: "true"}},
+	}
 	tc := newMockCluster(opt)
 
 	// Add 2 stores 1,2.

--- a/server/server.go
+++ b/server/server.go
@@ -519,6 +519,33 @@ func (s *Server) DeleteNamespaceConfig(name string) {
 	}
 }
 
+// SetLabelProperty inserts a label property config.
+func (s *Server) SetLabelProperty(typ, labelKey, labelValue string) error {
+	s.scheduleOpt.SetLabelProperty(typ, labelKey, labelValue)
+	err := s.scheduleOpt.persist(s.kv)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	log.Infof("label property config is updated: %+v", s.scheduleOpt.loadLabelPropertyConfig())
+	return nil
+}
+
+// DeleteLabelProperty deletes a label property config.
+func (s *Server) DeleteLabelProperty(typ, labelKey, labelValue string) error {
+	s.scheduleOpt.DeleteLabelProperty(typ, labelKey, labelValue)
+	err := s.scheduleOpt.persist(s.kv)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	log.Infof("label property config is updated: %+v", s.scheduleOpt.loadLabelPropertyConfig())
+	return nil
+}
+
+// GetLabelProperty returns the whole label property config.
+func (s *Server) GetLabelProperty() LabelPropertyConfig {
+	return s.scheduleOpt.loadLabelPropertyConfig().clone()
+}
+
 // GetSecurityConfig get the security config.
 func (s *Server) GetSecurityConfig() *SecurityConfig {
 	return &s.cfg.Security


### PR DESCRIPTION
Usage: 
```
> config show label-property
{
  "reject-leader": [
    {
      "key": "zone",
      "value": "cn1"
    },
    {
      "key": "disk",
      "value": "hdd"
    }
  ]
}

> config delete label-property reject-leader zone cn1

> config set label-property reject-leader zone cn2 

```