### PR TITLE
*: fix panic caused by region not found.

### DIFF
--- a/cmd/pd-server/main.go
+++ b/cmd/pd-server/main.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"syscall"
 
@@ -43,6 +44,12 @@ func main() {
 		server.PrintPDInfo()
 		os.Exit(0)
 	}
+
+	defer func() {
+		if e := recover(); e != nil {
+			log.Fatalf("panic: %s", string(debug.Stack()))
+		}
+	}()
 
 	switch errors.Cause(err) {
 	case nil:

--- a/cmd/pd-server/main.go
+++ b/cmd/pd-server/main.go
@@ -47,7 +47,7 @@ func main() {
 
 	defer func() {
 		if e := recover(); e != nil {
-			log.Fatalf("panic: %s", string(debug.Stack()))
+			log.Fatalf("server panic, err: %v, stack: %s", e, string(debug.Stack()))
 		}
 	}()
 

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -784,6 +784,12 @@ func (s *testBalanceHotWriteRegionSchedulerSuite) TestBalance(c *C) {
 	// We can find that the leader of all hot regions are on store 1,
 	// so one of the leader will transfer to another store.
 	checkTransferLeaderFrom(c, hb.Schedule(tc, schedule.NewOpInfluence(nil, tc)), 1)
+
+	// Should not panic if region not found.
+	for i := uint64(1); i <= 3; i++ {
+		tc.Regions.RemoveRegion(tc.GetRegion(i))
+	}
+	hb.Schedule(tc, schedule.NewOpInfluence(nil, tc))
 }
 
 var _ = Suite(&testBalanceHotReadRegionSchedulerSuite{})
@@ -840,6 +846,12 @@ func (s *testBalanceHotReadRegionSchedulerSuite) TestBalance(c *C) {
 	// Now appear two read hot region in store 1 and 4
 	// We will Transfer peer from 1 to 5
 	checkTransferPeerWithLeaderTransfer(c, hb.Schedule(tc, schedule.NewOpInfluence(nil, tc)), 1, 5)
+
+	// Should not panic if region not found.
+	for i := uint64(1); i <= 3; i++ {
+		tc.Regions.RemoveRegion(tc.GetRegion(i))
+	}
+	hb.Schedule(tc, schedule.NewOpInfluence(nil, tc))
 }
 
 func checkRemovePeer(c *C, op *schedule.Operator, storeID uint64) {

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -189,6 +189,9 @@ func (h *balanceHotRegionsScheduler) calcScore(items []*core.RegionStat, cluster
 		}
 
 		regionInfo := cluster.GetRegion(r.RegionID)
+		if regionInfo == nil {
+			continue
+		}
 
 		var storeIDs []uint64
 		if isCountReplica {
@@ -239,7 +242,7 @@ func (h *balanceHotRegionsScheduler) balanceByPeer(cluster schedule.Cluster, sto
 	for _, i := range h.r.Perm(storesStat[srcStoreID].RegionsStat.Len()) {
 		rs := storesStat[srcStoreID].RegionsStat[i]
 		srcRegion := cluster.GetRegion(rs.RegionID)
-		if len(srcRegion.DownPeers) != 0 || len(srcRegion.PendingPeers) != 0 {
+		if srcRegion == nil || len(srcRegion.DownPeers) != 0 || len(srcRegion.PendingPeers) != 0 {
 			continue
 		}
 
@@ -299,7 +302,7 @@ func (h *balanceHotRegionsScheduler) balanceByLeader(cluster schedule.Cluster, s
 	for _, i := range h.r.Perm(storesStat[srcStoreID].RegionsStat.Len()) {
 		rs := storesStat[srcStoreID].RegionsStat[i]
 		srcRegion := cluster.GetRegion(rs.RegionID)
-		if len(srcRegion.DownPeers) != 0 || len(srcRegion.PendingPeers) != 0 {
+		if srcRegion == nil || len(srcRegion.DownPeers) != 0 || len(srcRegion.PendingPeers) != 0 {
 			continue
 		}
 


### PR DESCRIPTION
When region merge is enabled, `GetRegion()` may return nil, so we need to check it.