### PR TITLE
server: increase replica scheduler limit default value

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -381,7 +381,7 @@ const (
 	defaultMaxStoreDownTime     = 30 * time.Minute
 	defaultLeaderScheduleLimit  = 64
 	defaultRegionScheduleLimit  = 12
-	defaultReplicaScheduleLimit = 16
+	defaultReplicaScheduleLimit = 32
 	defaultTolerantSizeRatio    = 2.5
 )
 

--- a/server/schedulers/mockcluster.go
+++ b/server/schedulers/mockcluster.go
@@ -335,7 +335,7 @@ const (
 	defaultMaxStoreDownTime     = 30 * time.Minute
 	defaultLeaderScheduleLimit  = 64
 	defaultRegionScheduleLimit  = 12
-	defaultReplicaScheduleLimit = 16
+	defaultReplicaScheduleLimit = 32
 	defaultTolerantSizeRatio    = 2.5
 )
 


### PR DESCRIPTION
Increase replica scheduler limiter to speed up failover.