### PR TITLE
disable http keep alives

### DIFF
--- a/server/api/redirector.go
+++ b/server/api/redirector.go
@@ -85,7 +85,7 @@ func newCustomReverseProxies(urls []url.URL, tlsConfig *tls.Config) *customRever
 	p := &customReverseProxies{
 		client: &http.Client{
 			Transport: &http.Transport{
-				TLSClientConfig: tlsConfig,
+				TLSClientConfig:   tlsConfig,
 				DisableKeepAlives: true,
 			},
 		},

--- a/server/api/redirector.go
+++ b/server/api/redirector.go
@@ -86,6 +86,7 @@ func newCustomReverseProxies(urls []url.URL, tlsConfig *tls.Config) *customRever
 		client: &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: tlsConfig,
+				DisableKeepAlives: true,
 			},
 		},
 	}


### PR DESCRIPTION
disable http keep alives for port reuse
```
[pingcap@x-1 ~]$ sudo netstat -antlp |grep "bin/pd-server" |grep 2379 |wc -l && date
10975
Fri Mar  2 15:22:35 CST 2018
[pingcap@xi-1 ~]$ sudo netstat -antlp |grep "bin/pd-server" |grep 2379 |wc -l && date
11760
Fri Mar  2 15:22:40 CST 2018
[pingcap@x-1 ~]$ sudo netstat -antlp |grep "bin/pd-server" |grep 2379 |wc -l && date
13318
Fri Mar  2 15:22:50 CST 2018
[pingcap@x-1 ~]$ sudo netstat -antlp |grep "bin/pd-server" |grep 2379 |tail
tcp        0      0 10.1.0.4:2379           10.1.0.5:42738          ESTABLISHED 12643/bin/pd-server
tcp        0      0 10.1.0.4:2379           10.1.0.5:41476          ESTABLISHED 12643/bin/pd-server
tcp        0      0 10.1.0.4:2379           10.1.0.6:57098          ESTABLISHED 12643/bin/pd-server
tcp        0      0 10.1.0.4:2379           10.1.0.6:57648          ESTABLISHED 12643/bin/pd-server
tcp        0      0 10.1.0.4:2379           10.1.0.6:60650          ESTABLISHED 12643/bin/pd-server
tcp        0      0 10.1.0.4:2379           10.1.0.6:56802          ESTABLISHED 12643/bin/pd-server
tcp        0      0 10.1.0.4:2379           10.1.0.5:45748          ESTABLISHED 12643/bin/pd-server
tcp        0      0 10.1.0.4:2379           10.1.0.6:57454          ESTABLISHED 12643/bin/pd-server
tcp        0      0 10.1.0.4:2379           10.1.0.6:59680          ESTABLISHED 12643/bin/pd-server
tcp        0      0 10.1.0.4:2379           10.1.0.6:35206          ESTABLISHED 12643/bin/pd-server
```

pd.log 
```
2018/03/01 19:09:26.558 redirector.go:106: [error] Get http://10.1.0.5:2379/pd/api/v1/stores: dial tcp 10.1.0.5:2379: connect: cannot assign requested address
2018/03/01 19:09:26.583 redirector.go:106: [error] Get http://10.1.0.5:2379/pd/health: dial tcp 10.1.0.5:2379: connect: cannot assign requested address
2018/03/01 19:09:26.604 redirector.go:106: [error] Get http://10.1.0.5:2379/pd/api/v1/stores: dial tcp 10.1.0.5:2379: connect: cannot assign requested address
2018/03/01 19:09:26.629 redirector.go:106: [error] Get http://10.1.0.5:2379/pd/ping: dial tcp 10.1.0.5:2379: connect: cannot assign requested address
2018/03/01 19:09:26.648 redirector.go:106: [error] Get http://10.1.0.5:2379/pd/api/v1/stores: dial tcp 10.1.0.5:2379: connect: cannot assign requested address
2018/03/01 19:09:26.656 redirector.go:106: [error] Get http://10.1.0.5:2379/pd/health: dial tcp 10.1.0.5:2379: connect: cannot assign requested address
2018/03/01 19:09:26.691 redirector.go:106: [error] Get http://10.1.0.5:2379/pd/api/v1/stores: dial tcp 10.1.0.5:2379: connect: cannot assign requested address
2018/03/01 19:09:26.700 redirector.go:106: [error] Get http://10.1.0.5:2379/pd/ping: dial tcp 10.1.0.5:2379: connect: cannot assign requested address
```