### PR TITLE
pdctl: fix usage template.

### DIFF
--- a/pdctl/command/global.go
+++ b/pdctl/command/global.go
@@ -178,7 +178,7 @@ Examples:
 Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
 
-Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableSubCommands }}
 
 Use "{{if .HasParent}}help {{.Name}} [command] {{else}}help [command]{{end}}" for more information about a command.{{end}}


### PR DESCRIPTION
Fix pdctl error message:
```
Additional help topics:template: top:15:47: executing "top" at <.IsHelpCommand>: can't evaluate field IsHelpCommand in type *cobra.Command
```
