### PR TITLE
pd-ctl: fix always show help info after using --help once

### DIFF
--- a/pdctl/ctl.go
+++ b/pdctl/ctl.go
@@ -29,14 +29,19 @@ type CommandFlags struct {
 }
 
 var (
-	rootCmd = &cobra.Command{
-		Use:   "pdctl",
-		Short: "Placement Driver control",
-	}
 	commandFlags = CommandFlags{}
 )
 
 func init() {
+	cobra.EnablePrefixMatching = true
+}
+
+// Start run Command
+func Start(args []string) {
+	rootCmd := &cobra.Command{
+		Use:   "pdctl",
+		Short: "Placement Driver control",
+	}
 	rootCmd.PersistentFlags().StringVarP(&commandFlags.URL, "pd", "u", "http://127.0.0.1:2379", "pd address")
 	rootCmd.Flags().StringVar(&commandFlags.CAPath, "cacert", "", "path of file that contains list of trusted SSL CAs.")
 	rootCmd.Flags().StringVar(&commandFlags.CertPath, "cert", "", "path of file that contains X509 certificate in PEM format.")
@@ -58,11 +63,7 @@ func init() {
 		command.NewHealthCommand(),
 		command.NewLogCommand(),
 	)
-	cobra.EnablePrefixMatching = true
-}
 
-// Start run Command
-func Start(args []string) {
 	rootCmd.SetArgs(args)
 	rootCmd.SilenceErrors = true
 	rootCmd.ParseFlags(args)


### PR DESCRIPTION
Take `config show ` command as an example:
when first call `config show --help`, it will save help flag in config-show command struct . And we reuse the rootCmd, thus when call `config show`, it still get the command struct which has saved help flag and print help info. So initialing rootCmd every time we call pd-ctl.Start()