### PR TITLE
schedule: balance scheduler do not depend on average score.

### DIFF
--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -14,8 +14,6 @@
 package schedulers
 
 import (
-	"math"
-
 	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/server/schedule"
 	log "github.com/sirupsen/logrus"
@@ -82,7 +80,7 @@ func (l *balanceLeaderScheduler) Schedule(cluster schedule.Cluster, opInfluence 
 
 	sourceSize := source.LeaderSize + int64(opInfluence.GetStoreInfluence(source.GetId()).LeaderSize)
 	targetSize := target.LeaderSize + int64(opInfluence.GetStoreInfluence(target.GetId()).LeaderSize)
-	regionSize := math.Max(1.0, float64(region.ApproximateSize)) * cluster.GetTolerantSizeRatio()
+	regionSize := float64(region.ApproximateSize) * cluster.GetTolerantSizeRatio()
 	if !shouldBalance(sourceSize, source.LeaderWeight, targetSize, target.LeaderWeight, regionSize) {
 		log.Debugf("[%s] skip balance region%d, source size: %v, source weight: %v, target size: %v, target weight: %v, region size: %v", l.GetName(), region.GetId(), sourceSize, source.LeaderWeight, targetSize, target.LeaderWeight, region.ApproximateSize)
 		schedulerCounter.WithLabelValues(l.GetName(), "skip").Inc()

--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -84,6 +84,7 @@ func (l *balanceLeaderScheduler) Schedule(cluster schedule.Cluster, opInfluence 
 	targetSize := target.LeaderSize + int64(opInfluence.GetStoreInfluence(target.GetId()).LeaderSize)
 	regionSize := math.Max(1.0, float64(region.ApproximateSize)) * cluster.GetTolerantSizeRatio()
 	if !shouldBalance(sourceSize, source.LeaderWeight, targetSize, target.LeaderWeight, regionSize) {
+		log.Debugf("[%s] skip balance region%d, source size: %v, source weight: %v, target size: %v, target weight: %v, region size: %v", l.GetName(), region.GetId(), sourceSize, source.LeaderWeight, targetSize, target.LeaderWeight, region.ApproximateSize)
 		schedulerCounter.WithLabelValues(l.GetName(), "skip").Inc()
 		return nil
 	}

--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -14,6 +14,8 @@
 package schedulers
 
 import (
+	"math"
+
 	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/server/schedule"
 	log "github.com/sirupsen/logrus"
@@ -76,9 +78,12 @@ func (l *balanceLeaderScheduler) Schedule(cluster schedule.Cluster, opInfluence 
 
 	source := cluster.GetStore(region.Leader.GetStoreId())
 	target := cluster.GetStore(newLeader.GetStoreId())
-	avgScore := cluster.GetStoresAverageScore(core.LeaderKind, l.selector.GetFilters()...)
-	log.Debugf("[region %d] source store id is %v, target store id is %v, average store score is %f", region.GetId(), source.GetId(), target.GetId(), avgScore)
-	if !shouldBalance(source, target, avgScore, core.LeaderKind, region, opInfluence, cluster.GetTolerantSizeRatio()) {
+	log.Debugf("[region %d] source store id is %v, target store id is %v", region.GetId(), source.GetId(), target.GetId())
+
+	sourceSize := source.LeaderSize + int64(opInfluence.GetStoreInfluence(source.GetId()).LeaderSize)
+	targetSize := target.LeaderSize + int64(opInfluence.GetStoreInfluence(target.GetId()).LeaderSize)
+	regionSize := math.Max(1.0, float64(region.ApproximateSize)) * cluster.GetTolerantSizeRatio()
+	if !shouldBalance(sourceSize, source.LeaderWeight, targetSize, target.LeaderWeight, regionSize) {
 		schedulerCounter.WithLabelValues(l.GetName(), "skip").Inc()
 		return nil
 	}

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -124,6 +124,7 @@ func (s *balanceRegionScheduler) transferPeer(cluster schedule.Cluster, region *
 	targetSize := target.RegionSize + int64(opInfluence.GetStoreInfluence(target.GetId()).RegionSize)
 	regionSize := math.Max(1.0, float64(region.ApproximateSize)) * cluster.GetTolerantSizeRatio()
 	if !shouldBalance(sourceSize, source.RegionWeight, targetSize, target.RegionWeight, regionSize) {
+		log.Debugf("[%s] skip balance region%d, source size: %v, source weight: %v, target size: %v, target weight: %v, region size: %v", s.GetName(), region.GetId(), sourceSize, source.LeaderWeight, targetSize, target.LeaderWeight, region.ApproximateSize)
 		schedulerCounter.WithLabelValues(s.GetName(), "skip").Inc()
 		return nil
 	}

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -124,7 +124,7 @@ func (s *balanceRegionScheduler) transferPeer(cluster schedule.Cluster, region *
 	targetSize := target.RegionSize + int64(opInfluence.GetStoreInfluence(target.GetId()).RegionSize)
 	regionSize := math.Max(1.0, float64(region.ApproximateSize)) * cluster.GetTolerantSizeRatio()
 	if !shouldBalance(sourceSize, source.RegionWeight, targetSize, target.RegionWeight, regionSize) {
-		log.Debugf("[%s] skip balance region%d, source size: %v, source weight: %v, target size: %v, target weight: %v, region size: %v", s.GetName(), region.GetId(), sourceSize, source.LeaderWeight, targetSize, target.LeaderWeight, region.ApproximateSize)
+		log.Debugf("[%s] skip balance region%d, source size: %v, source weight: %v, target size: %v, target weight: %v, region size: %v", s.GetName(), region.GetId(), sourceSize, source.RegionWeight, targetSize, target.RegionWeight, region.ApproximateSize)
 		schedulerCounter.WithLabelValues(s.GetName(), "skip").Inc()
 		return nil
 	}

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -14,7 +14,6 @@
 package schedulers
 
 import (
-	"math"
 	"time"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -122,7 +121,7 @@ func (s *balanceRegionScheduler) transferPeer(cluster schedule.Cluster, region *
 
 	sourceSize := source.RegionSize + int64(opInfluence.GetStoreInfluence(source.GetId()).RegionSize)
 	targetSize := target.RegionSize + int64(opInfluence.GetStoreInfluence(target.GetId()).RegionSize)
-	regionSize := math.Max(1.0, float64(region.ApproximateSize)) * cluster.GetTolerantSizeRatio()
+	regionSize := float64(region.ApproximateSize) * cluster.GetTolerantSizeRatio()
 	if !shouldBalance(sourceSize, source.RegionWeight, targetSize, target.RegionWeight, regionSize) {
 		log.Debugf("[%s] skip balance region%d, source size: %v, source weight: %v, target size: %v, target weight: %v, region size: %v", s.GetName(), region.GetId(), sourceSize, source.RegionWeight, targetSize, target.RegionWeight, region.ApproximateSize)
 		schedulerCounter.WithLabelValues(s.GetName(), "skip").Inc()

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -46,81 +46,28 @@ type testBalanceSpeedCase struct {
 	expectedResult bool
 }
 
-func (s *testBalanceSpeedSuite) TestBalanceSpeed(c *C) {
-	testCases := []testBalanceSpeedCase{
-		// source > avg > target
-		{2, 0, 10, 1, 0, true},
-		{2, 0, 10, 1, 10, false},
-		{2, 0, 10, 10, 0, false},
-		{10, 10, 100, 1, 0, false},
-		{20, 10, 150, 20, 0, true},
-		{20, 10, 150, 20, 50, false},
-		{20, 10, 150, 30, 0, false},
-		{1000, 2, 7500, 1, 0, true},
-		{1000, 2, 7500, 20, 0, true},
-		{1000, 2, 7500, 300, 0, true},
-		{1000, 2, 7500, 300, 2000, false},
-		{1000, 2, 7500, 1000, 0, true},
-		{1000, 2, 7500, 1001, 0, false},
-		// source > target > avg
-		{5, 2, 10, 1, 0, false},
-		{5, 2, 10, 10, 0, false},
-		// avg > source > target
-		{4, 0, 50, 1, 0, false},
-		{4, 0, 50, 10, 0, false},
+func (s *testBalanceSpeedSuite) TestShouldBalance(c *C) {
+	testCases := []struct {
+		sourceSize   int64
+		sourceWeight float64
+		targetSize   int64
+		targetWeight float64
+		moveSize     float64
+		result       bool
+	}{
+		{100, 1, 80, 1, 5, true},
+		{100, 1, 80, 1, 15, false},
+		{100, 1, 120, 2, 10, true},
+		{100, 1, 180, 2, 10, false},
+		{100, 0.5, 180, 1, 10, false},
+		{100, 0.5, 180, 1, 5, true},
+		{100, 1, 10, 0, 10, false}, // targetWeight=0
+		{100, 0, 10, 0, 10, false},
+		{100, 0, 500, 1, 50, true}, // sourceWeight=0
 	}
 
-	s.testBalanceSpeed(c, testCases, 1)
-	s.testBalanceSpeed(c, testCases, 10)
-	s.testBalanceSpeed(c, testCases, 100)
-	s.testBalanceSpeed(c, testCases, 1000)
-}
-
-func newTestOpInfluence(source uint64, target uint64, kind core.ResourceKind, countDiff int) schedule.OpInfluence {
-	m := make(map[uint64]*schedule.StoreInfluence)
-	if kind == core.LeaderKind {
-		m[source] = &schedule.StoreInfluence{
-			LeaderCount: -countDiff,
-			LeaderSize:  -countDiff * 10,
-		}
-		m[target] = &schedule.StoreInfluence{
-			LeaderCount: countDiff,
-			LeaderSize:  countDiff * 10,
-		}
-	} else if kind == core.RegionKind {
-		m[source] = &schedule.StoreInfluence{
-			RegionCount: -countDiff,
-			RegionSize:  -countDiff * 10,
-		}
-		m[target] = &schedule.StoreInfluence{
-			RegionCount: countDiff,
-			RegionSize:  countDiff * 10,
-		}
-	}
-
-	return m
-}
-
-func (s *testBalanceSpeedSuite) testBalanceSpeed(c *C, tests []testBalanceSpeedCase, capaGB uint64) {
-	opt := newTestScheduleConfig()
-	tc := newMockCluster(opt)
-
-	for _, t := range tests {
-		tc.addLeaderStore(1, int(t.sourceCount))
-		tc.addLeaderStore(2, int(t.targetCount))
-		source := tc.GetStore(1)
-		target := tc.GetStore(2)
-		region := &core.RegionInfo{ApproximateSize: t.regionSize}
-		c.Assert(shouldBalance(source, target, t.avgScore, core.LeaderKind, region, newTestOpInfluence(1, 2, core.LeaderKind, t.diff), defaultTolerantSizeRatio), Equals, t.expectedResult)
-	}
-
-	for _, t := range tests {
-		tc.addRegionStore(1, int(t.sourceCount))
-		tc.addRegionStore(2, int(t.targetCount))
-		source := tc.GetStore(1)
-		target := tc.GetStore(2)
-		region := &core.RegionInfo{ApproximateSize: t.regionSize}
-		c.Assert(shouldBalance(source, target, t.avgScore, core.RegionKind, region, newTestOpInfluence(1, 2, core.RegionKind, t.diff), defaultTolerantSizeRatio), Equals, t.expectedResult)
+	for _, t := range testCases {
+		c.Assert(shouldBalance(t.sourceSize, t.sourceWeight, t.targetSize, t.targetWeight, t.moveSize), Equals, t.result)
 	}
 }
 
@@ -194,24 +141,27 @@ func (s *testBalanceLeaderSchedulerSuite) TestBalanceLimit(c *C) {
 
 func (s *testBalanceLeaderSchedulerSuite) TestScheduleWithOpInfluence(c *C) {
 	// Stores:     1    2    3    4
-	// Leaders:    7    8    9   16
+	// Leaders:    7    8    9   14
 	// Region1:    F    F    F    L
 	s.tc.addLeaderStore(1, 7)
 	s.tc.addLeaderStore(2, 8)
 	s.tc.addLeaderStore(3, 9)
-	s.tc.addLeaderStore(4, 16)
+	s.tc.addLeaderStore(4, 14)
 	s.tc.addLeaderRegion(1, 4, 1, 2, 3)
 	op := s.schedule(nil)
 	c.Check(op, NotNil)
+	// After considering the scheduled operator, leaders of store1 and store4 are 8
+	// and 13 respectively. As the `TolerantSizeRatio` is 2.5, `shouldBalance`
+	// returns false when leader differece is not greater than 5.
 	c.Check(s.schedule([]*schedule.Operator{op}), IsNil)
 
 	// Stores:     1    2    3    4
-	// Leaders:    8    8    9   15
+	// Leaders:    8    8    9   13
 	// Region1:    F    F    F    L
 	s.tc.updateLeaderCount(1, 8)
 	s.tc.updateLeaderCount(2, 8)
 	s.tc.updateLeaderCount(3, 9)
-	s.tc.updateLeaderCount(4, 15)
+	s.tc.updateLeaderCount(4, 13)
 	s.tc.addLeaderRegion(1, 4, 1, 2, 3)
 	c.Check(s.schedule(nil), IsNil)
 }
@@ -391,7 +341,7 @@ func (s *testBalanceRegionSchedulerSuite) TestReplicas3(c *C) {
 	cache.Remove(1)
 
 	// Store 9 has different zone with other stores but larger region score than store 1.
-	tc.addLabelsStore(9, 9, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"})
+	tc.addLabelsStore(9, 20, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"})
 	c.Assert(sb.Schedule(tc, schedule.NewOpInfluence(nil, tc)), IsNil)
 }
 


### PR DESCRIPTION
In some scenarios, the leader scores or region scores cannot eventually converge on the average. We have to give up using average score to determine whether to schedule.