### PR TITLE
core: fix region size calculation.

### DIFF
--- a/server/core/region.go
+++ b/server/core/region.go
@@ -16,7 +16,6 @@ package core
 import (
 	"bytes"
 	"fmt"
-	"math"
 	"math/rand"
 	"reflect"
 	"strings"
@@ -52,6 +51,12 @@ const EmptyRegionApproximateSize = 1
 
 // RegionFromHeartbeat constructs a Region from region heartbeat.
 func RegionFromHeartbeat(heartbeat *pdpb.RegionHeartbeatRequest) *RegionInfo {
+	// Convert unit to MB.
+	// If region is empty or less than 1MB, use 1MB instead.
+	regionSize := heartbeat.GetApproximateSize() / (1 << 20)
+	if regionSize < EmptyRegionApproximateSize {
+		regionSize = EmptyRegionApproximateSize
+	}
 	return &RegionInfo{
 		Region:          heartbeat.GetRegion(),
 		Leader:          heartbeat.GetLeader(),
@@ -59,7 +64,7 @@ func RegionFromHeartbeat(heartbeat *pdpb.RegionHeartbeatRequest) *RegionInfo {
 		PendingPeers:    heartbeat.GetPendingPeers(),
 		WrittenBytes:    heartbeat.GetBytesWritten(),
 		ReadBytes:       heartbeat.GetBytesRead(),
-		ApproximateSize: int64(math.Ceil(float64(heartbeat.GetApproximateSize()) / 1e6)), // use size of MB as unit
+		ApproximateSize: int64(regionSize),
 	}
 }
 

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -106,20 +106,12 @@ const minWeight = 1e-6
 
 // LeaderScore returns the store's leader score: leaderCount / leaderWeight.
 func (s *StoreInfo) LeaderScore() float64 {
-	size := math.Max(1, float64(s.LeaderSize))
-	if s.LeaderWeight <= 0 {
-		return size / minWeight
-	}
-	return size / s.LeaderWeight
+	return float64(s.LeaderSize) / math.Max(s.LeaderWeight, minWeight)
 }
 
 // RegionScore returns the store's region score: regionSize / regionWeight.
 func (s *StoreInfo) RegionScore() float64 {
-	size := math.Max(1, float64(s.RegionSize))
-	if s.RegionWeight <= 0 {
-		return size / minWeight
-	}
-	return size / s.RegionWeight
+	return float64(s.RegionSize) / math.Max(s.RegionWeight, minWeight)
 }
 
 // StorageSize returns store's used storage size reported from tikv.


### PR DESCRIPTION
1. Make sure region's size won't be 0. Balance a region with 0 size will make no effect on the store's score.
2. The store's score does not need to be non-zero.