### PR TITLE
Transfer leader to new peer when scattering regions

### DIFF
--- a/server/schedule/region_scatterer.go
+++ b/server/schedule/region_scatterer.go
@@ -123,6 +123,7 @@ func (r *RegionScatterer) scatterRegion(region *core.RegionInfo) *Operator {
 		op := CreateMovePeerOperator("scatter-peer", r.cluster, region, OpAdmin,
 			peer.GetStoreId(), newPeer.GetStoreId(), newPeer.GetId())
 		steps = append(steps, op.steps...)
+		steps = append(steps, TransferLeader{ToStore: newPeer.GetStoreId()})
 	}
 
 	if len(steps) == 0 {


### PR DESCRIPTION
TiKV will refuse to remove a peer if that peer is a leader. So in order to remove old peers when scattering regions, we can simply transfer leader to the new peer after it has been added.

Without transfer leader:
![image](https://user-images.githubusercontent.com/7806468/37574810-734b0ece-2b5e-11e8-9950-3683f43ad5d5.png)

With transfer leader:
![image](https://user-images.githubusercontent.com/7806468/37574840-99572a30-2b5e-11e8-931d-827e989e5066.png)
