### PR TITLE
server: endpoints includes join members

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -156,6 +156,9 @@ func (s *Server) startEtcd() error {
 	}
 
 	endpoints := []string{s.etcdCfg.ACUrls[0].String()}
+	if s.cfg.Join != "" {
+		endpoints = append(endpoints, strings.Split(s.cfg.Join, ",")...)
+	}
 	log.Infof("create etcd v3 client with endpoints %v", endpoints)
 
 	client, err := clientv3.New(clientv3.Config{


### PR DESCRIPTION
We should consider already existing members when joining a cluster.others it will meet error in the case that when k8s restart an join PD, the k8s pod's IP will change but the domain name point to the old pod IP.