### PR TITLE
ThreadSafeCache Get method lock bug

### DIFF
--- a/server/cache/cache.go
+++ b/server/cache/cache.go
@@ -68,8 +68,8 @@ func (c *threadSafeCache) Put(key uint64, value interface{}) {
 
 // Get retrives an item from cache.
 func (c *threadSafeCache) Get(key uint64) (interface{}, bool) {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	return c.cache.Get(key)
 }
 

--- a/server/cache/cache.go
+++ b/server/cache/cache.go
@@ -67,6 +67,8 @@ func (c *threadSafeCache) Put(key uint64, value interface{}) {
 }
 
 // Get retrives an item from cache.
+// When Get method called, LRU and TwoQueue cache will rearrange entries
+// so we must use write lock.
 func (c *threadSafeCache) Get(key uint64) (interface{}, bool) {
 	c.lock.Lock()
 	defer c.lock.Unlock()


### PR DESCRIPTION
Make cache.Get use write lock because Get method will rearrange cache's entry.