### PR TITLE
core: adjust capacity to fit for more cases

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -62,8 +62,6 @@ region-schedule-limit = 4
 replica-schedule-limit = 8
 merge-schedule-limit = 8
 tolerant-size-ratio = 5
-high-space-reatio = 0.8
-low-space-ratio = 0.6
 
 # customized schedulers, the format is as below
 # if empty, it will use balance-leader, balance-region, hot-region as default

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -159,7 +159,7 @@ func (s *StoreInfo) StorageSize() uint64 {
 
 // AvailableRatio is store's freeSpace/capacity.
 func (s *StoreInfo) AvailableRatio() float64 {
-	if float64(s.Stats.GetCapacity()) == 0 {
+	if s.Stats.GetCapacity() == 0 {
 		return 0
 	}
 	return float64(s.Stats.GetAvailable()) / float64(s.Stats.GetCapacity())

--- a/server/store_statistics.go
+++ b/server/store_statistics.go
@@ -80,10 +80,8 @@ func (s *storeStatistics) Observe(store *core.StoreInfo) {
 	storeStatusGauge.WithLabelValues(s.namespace, id, "region_count").Set(float64(store.RegionCount))
 	storeStatusGauge.WithLabelValues(s.namespace, id, "leader_size").Set(float64(store.LeaderSize))
 	storeStatusGauge.WithLabelValues(s.namespace, id, "leader_count").Set(float64(store.LeaderCount))
-	storeStatusGauge.WithLabelValues(s.namespace, id, "storage_available").Set(float64(store.Stats.GetAvailable()))
-	storeStatusGauge.WithLabelValues(s.namespace, id, "storage_capacity").Set(float64(store.Stats.GetCapacity()))
-	storeStatusGauge.WithLabelValues(s.namespace, id, "storage_used").Set(float64(store.Stats.GetUsedSize()))
-	storeStatusGauge.WithLabelValues(s.namespace, id, "score_amplify").Set(float64(store.RegionSize) / float64(store.Stats.GetUsedSize()) * (1 << 20))
+	storeStatusGauge.WithLabelValues(s.namespace, id, "store_available").Set(float64(store.Stats.GetAvailable()))
+	storeStatusGauge.WithLabelValues(s.namespace, id, "store_used").Set(float64(store.Stats.GetUsedSize()))
 }
 
 func (s *storeStatistics) Collect() {

--- a/server/store_statistics.go
+++ b/server/store_statistics.go
@@ -82,6 +82,7 @@ func (s *storeStatistics) Observe(store *core.StoreInfo) {
 	storeStatusGauge.WithLabelValues(s.namespace, id, "leader_count").Set(float64(store.LeaderCount))
 	storeStatusGauge.WithLabelValues(s.namespace, id, "store_available").Set(float64(store.Stats.GetAvailable()))
 	storeStatusGauge.WithLabelValues(s.namespace, id, "store_used").Set(float64(store.Stats.GetUsedSize()))
+	storeStatusGauge.WithLabelValues(s.namespace, id, "store_capacity").Set(float64(store.Stats.GetCapacity()))
 }
 
 func (s *storeStatistics) Collect() {


### PR DESCRIPTION
if tikv uses whole storage capacity as capacity, it is probably available ratio is too small cause there are  so many other irrelative files in the storage, namely, `capacity == available + used + irrelative `. So pd need take it into consideration.