### PR TITLE
server: resign pd leader when it is not same as etcd leader.

### DIFF
--- a/server/api/member_test.go
+++ b/server/api/member_test.go
@@ -242,6 +242,7 @@ func (s *testMemberAPISuite) TestLeaderPriority(c *C) {
 func (s *testMemberAPISuite) post(c *C, url string, body io.Reader) {
 	testutil.WaitUntil(c, func(c *C) bool {
 		res, err := http.Post(url, "", body)
+		c.Logf("post res: %v, err: %v", res.StatusCode, err)
 		c.Assert(err, IsNil)
 		return res.StatusCode == http.StatusOK
 	})

--- a/server/api/member_test.go
+++ b/server/api/member_test.go
@@ -242,8 +242,11 @@ func (s *testMemberAPISuite) TestLeaderPriority(c *C) {
 func (s *testMemberAPISuite) post(c *C, url string, body io.Reader) {
 	testutil.WaitUntil(c, func(c *C) bool {
 		res, err := http.Post(url, "", body)
-		c.Logf("post res: %v, err: %v", res.StatusCode, err)
 		c.Assert(err, IsNil)
+		b, err := ioutil.ReadAll(res.Body)
+		res.Body.Close()
+		c.Assert(err, IsNil)
+		c.Logf("post %s, status: %v res: %s", url, res.StatusCode, string(b))
 		return res.StatusCode == http.StatusOK
 	})
 }

--- a/server/api/member_test.go
+++ b/server/api/member_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -211,9 +210,9 @@ func (s *testMemberAPISuite) TestLeaderResign(c *C) {
 	leader1, err := svrs[0].GetLeader()
 	c.Assert(err, IsNil)
 
-	s.post(c, addrs[leader1.GetMemberId()]+apiPrefix+"/api/v1/leader/resign", nil)
+	s.post(c, addrs[leader1.GetMemberId()]+apiPrefix+"/api/v1/leader/resign", "")
 	leader2 := s.waitLeaderChange(c, svrs[0], leader1)
-	s.post(c, addrs[leader2.GetMemberId()]+apiPrefix+"/api/v1/leader/transfer/"+leader1.GetName(), nil)
+	s.post(c, addrs[leader2.GetMemberId()]+apiPrefix+"/api/v1/leader/transfer/"+leader1.GetName(), "")
 	leader3 := s.waitLeaderChange(c, svrs[0], leader2)
 	c.Assert(leader3.GetMemberId(), Equals, leader1.GetMemberId())
 }
@@ -230,18 +229,18 @@ func (s *testMemberAPISuite) TestLeaderPriority(c *C) {
 	leader1, err := s.getEtcdLeader(svrs[0])
 	c.Assert(err, IsNil)
 	s.waitLeaderSync(c, svrs[0], leader1)
-	s.post(c, addrs[leader1.GetMemberId()]+apiPrefix+"/api/v1/members/name/"+leader1.GetName(), bytes.NewBufferString(`{"leader-priority": -1}`))
+	s.post(c, addrs[leader1.GetMemberId()]+apiPrefix+"/api/v1/members/name/"+leader1.GetName(), `{"leader-priority": -1}`)
 	leader2 := s.waitEtcdLeaderChange(c, svrs[0], leader1)
 	s.waitLeaderSync(c, svrs[0], leader2)
-	s.post(c, addrs[leader1.GetMemberId()]+apiPrefix+"/api/v1/members/name/"+leader1.GetName(), bytes.NewBufferString(`{"leader-priority": 100}`))
+	s.post(c, addrs[leader1.GetMemberId()]+apiPrefix+"/api/v1/members/name/"+leader1.GetName(), `{"leader-priority": 100}`)
 	leader3 := s.waitEtcdLeaderChange(c, svrs[0], leader2)
 	s.waitLeaderSync(c, svrs[0], leader3)
 	c.Assert(leader3.GetMemberId(), Equals, leader1.GetMemberId())
 }
 
-func (s *testMemberAPISuite) post(c *C, url string, body io.Reader) {
+func (s *testMemberAPISuite) post(c *C, url string, body string) {
 	testutil.WaitUntil(c, func(c *C) bool {
-		res, err := http.Post(url, "", body)
+		res, err := http.Post(url, "", bytes.NewBufferString(body))
 		c.Assert(err, IsNil)
 		b, err := ioutil.ReadAll(res.Body)
 		res.Body.Close()
@@ -299,7 +298,11 @@ func (s *testMemberAPISuite) waitEtcdLeaderChange(c *C, svr *server.Server, old 
 func (s *testMemberAPISuite) waitLeaderSync(c *C, svr *server.Server, etcdLeader *pdpb.Member) {
 	testutil.WaitUntil(c, func(c *C) bool {
 		leader, err := svr.GetLeader()
-		c.Assert(err, IsNil)
+		if err != nil {
+			c.Logf("GetLeader err: %v", err)
+			return false
+		}
+		c.Logf("leader is %v", leader.GetMemberId())
 		return leader.GetMemberId() == etcdLeader.GetMemberId()
 	})
 }

--- a/server/leader.go
+++ b/server/leader.go
@@ -100,6 +100,7 @@ func (s *Server) leaderLoop() {
 
 		etcdLeader := s.etcd.Server.Lead()
 		if etcdLeader != s.ID() {
+			log.Infof("%v is not etcd leader, skip campaign leader and check later", s.Name())
 			time.Sleep(200 * time.Millisecond)
 			continue
 		}

--- a/server/leader.go
+++ b/server/leader.go
@@ -282,6 +282,11 @@ func (s *Server) campaignLeader() error {
 			if err = s.updateTimestamp(); err != nil {
 				return errors.Trace(err)
 			}
+			etcdLeader := s.etcd.Server.Lead()
+			if etcdLeader != s.ID() {
+				log.Info("etcd leader changed, %s resigns leadership", s.Name())
+				return nil
+			}
 		case <-s.resignCh:
 			log.Infof("%s resigns leadership", s.Name())
 			return nil

--- a/server/server.go
+++ b/server/server.go
@@ -87,8 +87,6 @@ type Server struct {
 	// For tso, set after pd becomes leader.
 	ts            atomic.Value
 	lastSavedTime time.Time
-	// For resign notify.
-	resignCh chan struct{}
 	// For async region heartbeat.
 	hbStreams *heartbeatStreams
 }
@@ -101,7 +99,6 @@ func CreateServer(cfg *Config, apiRegister func(*Server) http.Handler) (*Server,
 	s := &Server{
 		cfg:         cfg,
 		scheduleOpt: newScheduleOption(cfg),
-		resignCh:    make(chan struct{}),
 	}
 	s.handler = newHandler(s)
 


### PR DESCRIPTION
When leader priority is updated on the fly, etcd leader is transferred to the one has the highest priority, while PD leader is not changed. This PR makes sure PD leader switches the same instance.