### PR TITLE
server, schedule: use ttl cache for limiter

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -361,13 +361,13 @@ type ScheduleConfig struct {
 	// MaxStoreDownTime is the max duration after which
 	// a store will be considered to be down if it hasn't reported heartbeats.
 	MaxStoreDownTime typeutil.Duration `toml:"max-store-down-time,omitempty" json:"max-store-down-time"`
-	// LeaderScheduleLimit is the max coexist leader schedules.
+	// LeaderScheduleLimit is the max coexist leader schedules for one store within one minute.
 	LeaderScheduleLimit uint64 `toml:"leader-schedule-limit,omitempty" json:"leader-schedule-limit"`
-	// RegionScheduleLimit is the max coexist region schedules.
+	// RegionScheduleLimit is the max coexist region schedules for one store within one minute.
 	RegionScheduleLimit uint64 `toml:"region-schedule-limit,omitempty" json:"region-schedule-limit"`
-	// ReplicaScheduleLimit is the max coexist replica schedules.
+	// ReplicaScheduleLimit is the max coexist replica schedules for one store within one minute.
 	ReplicaScheduleLimit uint64 `toml:"replica-schedule-limit,omitempty" json:"replica-schedule-limit"`
-	// MergeScheduleLimit is the max coexist merge schedules.
+	// MergeScheduleLimit is the max coexist merge schedules for one store within one minute.
 	MergeScheduleLimit uint64 `toml:"merge-schedule-limit,omitempty" json:"merge-schedule-limit"`
 	// TolerantSizeRatio is the ratio of buffer size for balance scheduler.
 	TolerantSizeRatio float64 `toml:"tolerant-size-ratio,omitempty" json:"tolerant-size-ratio"`
@@ -458,10 +458,10 @@ const (
 	defaultMaxPendingPeerCount  = 16
 	defaultMaxMergeRegionSize   = 0
 	defaultMaxStoreDownTime     = 30 * time.Minute
-	defaultLeaderScheduleLimit  = 4
-	defaultRegionScheduleLimit  = 4
-	defaultReplicaScheduleLimit = 8
-	defaultMergeScheduleLimit   = 8
+	defaultLeaderScheduleLimit  = 1000
+	defaultRegionScheduleLimit  = 30
+	defaultReplicaScheduleLimit = 30
+	defaultMergeScheduleLimit   = 10
 	defaultTolerantSizeRatio    = 5
 	defaultLowSpaceRatio        = 0.8
 	defaultHighSpaceRatio       = 0.6

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -94,6 +94,7 @@ func (c *coordinator) dispatch(region *core.RegionInfo) {
 		timeout := op.IsTimeout()
 		if step := op.Check(region); step != nil && !timeout {
 			operatorCounter.WithLabelValues(op.Desc(), "check").Inc()
+			c.limiter.UpdateCounts(op, region)
 			c.sendScheduleCommand(region, step)
 			return
 		}
@@ -106,6 +107,7 @@ func (c *coordinator) dispatch(region *core.RegionInfo) {
 		} else if timeout {
 			log.Infof("[region %v] operator timeout: %s", region.GetId(), op)
 			operatorCounter.WithLabelValues(op.Desc(), "timeout").Inc()
+			c.limiter.Remove(op, region)
 			c.removeOperator(op)
 		}
 	}
@@ -415,11 +417,7 @@ func (c *coordinator) runScheduler(s *scheduleController) {
 			}
 			opInfluence := schedule.NewOpInfluence(c.getOperators(), c.cluster)
 			if op := s.Schedule(c.cluster, opInfluence); op != nil {
-				if len(op) == 1 {
-					c.addOperator(op[0])
-				} else {
-					c.addOperators(op...)
-				}
+				c.addOperators(op...)
 			}
 
 		case <-s.Ctx().Done():
@@ -444,19 +442,26 @@ func (c *coordinator) addOperatorLocked(op *schedule.Operator) bool {
 		}
 		log.Infof("[region %v] replace old operator: %s", regionID, old)
 		operatorCounter.WithLabelValues(old.Desc(), "replaced").Inc()
+		if region := c.cluster.GetRegion(old.RegionID()); region != nil {
+			c.limiter.Remove(old, region)
+		} else {
+			log.Warnf("add operator %v on nonexistent region %d", op, regionID)
+			operatorCounter.WithLabelValues(old.Desc(), "no_region").Inc()
+		}
 		c.removeOperatorLocked(old)
 	}
-
 	c.operators[regionID] = op
-	c.limiter.UpdateCounts(c.operators)
 
 	if region := c.cluster.GetRegion(op.RegionID()); region != nil {
 		if step := op.Check(region); step != nil {
 			c.sendScheduleCommand(region, step)
 		}
+		c.limiter.UpdateCounts(op, region)
+		operatorCounter.WithLabelValues(op.Desc(), "create").Inc()
+	} else {
+		log.Warnf("add operator %v on nonexistent region %d", op, regionID)
+		operatorCounter.WithLabelValues(op.Desc(), "no_region").Inc()
 	}
-
-	operatorCounter.WithLabelValues(op.Desc(), "create").Inc()
 	return true
 }
 
@@ -515,9 +520,7 @@ func (c *coordinator) removeOperator(op *schedule.Operator) {
 }
 
 func (c *coordinator) removeOperatorLocked(op *schedule.Operator) {
-	regionID := op.RegionID()
-	delete(c.operators, regionID)
-	c.limiter.UpdateCounts(c.operators)
+	delete(c.operators, op.RegionID())
 	operatorCounter.WithLabelValues(op.Desc(), "remove").Inc()
 }
 

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -444,9 +444,6 @@ func (c *coordinator) addOperatorLocked(op *schedule.Operator) bool {
 		operatorCounter.WithLabelValues(old.Desc(), "replaced").Inc()
 		if region := c.cluster.GetRegion(old.RegionID()); region != nil {
 			c.limiter.Remove(old, region)
-		} else {
-			log.Warnf("add operator %v on nonexistent region %d", op, regionID)
-			operatorCounter.WithLabelValues(old.Desc(), "no_region").Inc()
 		}
 		c.removeOperatorLocked(old)
 	}

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/pingcap/pd/server/schedulers"
 )
 
-func newTestOperator(regionID uint64, kind schedule.OperatorKind) *schedule.Operator {
-	return schedule.NewOperator("test", regionID, kind)
+func newTestOperator(regionID uint64, kind schedule.OperatorKind, steps ...schedule.OperatorStep) *schedule.Operator {
+	return schedule.NewOperator("test", regionID, kind, steps...)
 }
 
 func newTestScheduleConfig() (*ScheduleConfig, *scheduleOption) {
@@ -134,13 +134,13 @@ func (s *testCoordinatorSuite) TestBasic(c *C) {
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
 	l := co.limiter
 
-	op1 := newTestOperator(1, schedule.OpLeader)
+	op1 := newTestOperator(1, schedule.OpLeader, schedule.TransferLeader{FromStore: 1, ToStore: 2})
 	co.addOperator(op1)
 	c.Assert(l.OperatorCount(op1.Kind()), Equals, uint64(1))
 	c.Assert(co.getOperator(1).RegionID(), Equals, op1.RegionID())
 
 	// Region 1 already has an operator, cannot add another one.
-	op2 := newTestOperator(1, schedule.OpRegion)
+	op2 := newTestOperator(1, schedule.OpLeader, schedule.TransferLeader{FromStore: 2, ToStore: 1})
 	co.addOperator(op2)
 	c.Assert(l.OperatorCount(op2.Kind()), Equals, uint64(0))
 
@@ -545,37 +545,6 @@ func waitOperator(c *C, co *coordinator, regionID uint64) {
 	})
 }
 
-var _ = Suite(&testScheduleLimiterSuite{})
-
-type testScheduleLimiterSuite struct{}
-
-func (s *testScheduleLimiterSuite) TestOperatorCount(c *C) {
-	l := schedule.NewLimiter()
-	c.Assert(l.OperatorCount(schedule.OpLeader), Equals, uint64(0))
-	c.Assert(l.OperatorCount(schedule.OpRegion), Equals, uint64(0))
-
-	operators := make(map[uint64]*schedule.Operator)
-
-	operators[1] = newTestOperator(1, schedule.OpLeader)
-	l.UpdateCounts(operators)
-	c.Assert(l.OperatorCount(schedule.OpLeader), Equals, uint64(1)) // 1:leader
-	operators[2] = newTestOperator(2, schedule.OpLeader)
-	l.UpdateCounts(operators)
-	c.Assert(l.OperatorCount(schedule.OpLeader), Equals, uint64(2)) // 1:leader, 2:leader
-	delete(operators, 1)
-	l.UpdateCounts(operators)
-	c.Assert(l.OperatorCount(schedule.OpLeader), Equals, uint64(1)) // 2:leader
-
-	operators[1] = newTestOperator(1, schedule.OpRegion)
-	l.UpdateCounts(operators)
-	c.Assert(l.OperatorCount(schedule.OpRegion), Equals, uint64(1)) // 1:region 2:leader
-	c.Assert(l.OperatorCount(schedule.OpLeader), Equals, uint64(1))
-	operators[2] = newTestOperator(2, schedule.OpRegion)
-	l.UpdateCounts(operators)
-	c.Assert(l.OperatorCount(schedule.OpRegion), Equals, uint64(2)) // 1:region 2:region
-	c.Assert(l.OperatorCount(schedule.OpLeader), Equals, uint64(0))
-}
-
 var _ = Suite(&testScheduleControllerSuite{})
 
 type testScheduleControllerSuite struct{}
@@ -586,6 +555,10 @@ type mockLimitScheduler struct {
 	limit   uint64
 	counter *schedule.Limiter
 	kind    schedule.OperatorKind
+}
+
+func (s *mockLimitScheduler) SetUpSuite(c *C) {
+
 }
 
 func (s *mockLimitScheduler) IsScheduleAllowed(cluster schedule.Cluster) bool {
@@ -615,25 +588,26 @@ func (s *testScheduleControllerSuite) TestController(c *C) {
 	}
 	// limit = 2
 	lb.limit = 2
+
+	// put region info
+	tc.addLeaderRegion(1, 1, 2)
+	tc.addLeaderRegion(2, 2, 1)
+
 	// count = 0
 	c.Assert(sc.AllowSchedule(), IsTrue)
-	op1 := newTestOperator(1, schedule.OpLeader)
+	op1 := newTestOperator(1, schedule.OpLeader, schedule.TransferLeader{FromStore: 1, ToStore: 2})
 	c.Assert(co.addOperator(op1), IsTrue)
 	// count = 1
 	c.Assert(sc.AllowSchedule(), IsTrue)
-	op2 := newTestOperator(2, schedule.OpLeader)
+	op2 := newTestOperator(2, schedule.OpLeader, schedule.TransferLeader{FromStore: 2, ToStore: 1})
 	c.Assert(co.addOperator(op2), IsTrue)
 	// count = 2
 	c.Assert(sc.AllowSchedule(), IsFalse)
 	co.removeOperator(op1)
-	// count = 1
-	c.Assert(sc.AllowSchedule(), IsTrue)
 
 	// add a PriorityKind operator will remove old operator
 	op3 := newTestOperator(2, schedule.OpHotRegion)
 	op3.SetPriorityLevel(core.HighPriority)
-	c.Assert(co.addOperator(op1), IsTrue)
-	c.Assert(sc.AllowSchedule(), IsFalse)
 	c.Assert(co.addOperator(op3), IsTrue)
 	c.Assert(sc.AllowSchedule(), IsTrue)
 	co.removeOperator(op3)

--- a/server/schedule/limiter.go
+++ b/server/schedule/limiter.go
@@ -1,0 +1,109 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schedule
+
+import (
+	"sync"
+	"time"
+
+	"github.com/pingcap/pd/server/cache"
+	"github.com/pingcap/pd/server/core"
+)
+
+// Limiter is a counter that limits the number of operators
+type Limiter struct {
+	sync.RWMutex
+	counts map[OperatorKind]map[uint64]*cache.TTLUint64
+}
+
+// NewLimiter creates a schedule limiter
+func NewLimiter() *Limiter {
+	return &Limiter{
+		counts: make(map[OperatorKind]map[uint64]*cache.TTLUint64),
+	}
+}
+
+var (
+	limiterCacheGCInterval = time.Second * 5
+	limiterCacheTTL        = time.Minute * 1
+)
+
+// UpdateCounts updates resouce counts using current pending operators.
+func (l *Limiter) UpdateCounts(op *Operator, region *core.RegionInfo) {
+	l.Lock()
+	defer l.Unlock()
+
+	if _, ok := l.counts[op.Kind()]; !ok {
+		l.counts[op.Kind()] = make(map[uint64]*cache.TTLUint64)
+	}
+
+	for _, store := range op.InvolvedStores(region) {
+		ttl, ok := l.counts[op.Kind()][store]
+		if !ok {
+			ttl = cache.NewIDTTL(limiterCacheGCInterval, limiterCacheTTL)
+			l.counts[op.Kind()][store] = ttl
+		}
+		ttl.Put(op.RegionID())
+	}
+}
+
+// Remove deletes related items from all involved stores cache.
+func (l *Limiter) Remove(op *Operator, region *core.RegionInfo) {
+	l.Lock()
+	defer l.Unlock()
+
+	for _, store := range op.InvolvedStores(region) {
+		ttl, ok := l.counts[op.Kind()][store]
+		if ok {
+			ttl.Remove(op.RegionID())
+			if ttl.Len() == 0 {
+				delete(l.counts[op.Kind()], store)
+			}
+		}
+	}
+}
+
+// OperatorCount gets the max count of operators of all involved stores filtered by mask.
+func (l *Limiter) OperatorCount(mask OperatorKind) uint64 {
+	l.RLock()
+	defer l.RUnlock()
+
+	var max uint64
+	for k, stores := range l.counts {
+		if k&mask != 0 {
+			for _, store := range stores {
+				if max < uint64(store.Len()) {
+					max = uint64(store.Len())
+				}
+			}
+		}
+	}
+	return max
+}
+
+// StoreOperatorCount gets the count of operators for specific store filtered by mask.
+func (l *Limiter) StoreOperatorCount(mask OperatorKind, storeID uint64) uint64 {
+	l.RLock()
+	defer l.RUnlock()
+
+	var total uint64
+	for k, stores := range l.counts {
+		if k&mask != 0 {
+			if store, ok := stores[storeID]; ok {
+				total += uint64(store.Len())
+			}
+		}
+	}
+	return total
+}

--- a/server/schedule/limiter_test.go
+++ b/server/schedule/limiter_test.go
@@ -1,0 +1,101 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schedule
+
+import (
+	"time"
+
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testLimiterSuite{})
+
+type testLimiterSuite struct{}
+
+func (s testLimiterSuite) SetUpSuite(c *C) {
+	limiterCacheGCInterval = time.Second * 1
+	limiterCacheTTL = time.Second * 2
+}
+
+func (s *testLimiterSuite) TestUpdateCounts(c *C) {
+	l := NewLimiter()
+	c.Assert(l.OperatorCount(OpLeader), Equals, uint64(0))
+	c.Assert(l.OperatorCount(OpRegion), Equals, uint64(0))
+
+	// init region and operator
+	for i := uint64(1); i <= 3; i++ {
+		op := newTestOperator(i, OpLeader, TransferLeader{FromStore: i + 1, ToStore: 1})
+		region := newTestRegion(i, i+1, [2]uint64{1, 1}, [2]uint64{i + 1, i + 1})
+		l.UpdateCounts(op, region)
+	}
+
+	c.Assert(l.OperatorCount(OpLeader), Equals, uint64(3))
+	c.Assert(l.StoreOperatorCount(OpLeader, 1), Equals, uint64(3))
+	c.Assert(l.StoreOperatorCount(OpLeader, 2), Equals, uint64(1))
+	c.Assert(l.StoreOperatorCount(OpLeader, 3), Equals, uint64(1))
+	c.Assert(l.StoreOperatorCount(OpLeader, 4), Equals, uint64(1))
+
+	time.Sleep(time.Second * 1)
+	// operator not finished
+	op := newTestOperator(3, OpLeader, TransferLeader{FromStore: 4, ToStore: 1})
+	region := newTestRegion(3, 4, [2]uint64{1, 1}, [2]uint64{4, 4})
+	l.UpdateCounts(op, region)
+	c.Assert(l.OperatorCount(OpLeader), Equals, uint64(3))
+	c.Assert(l.StoreOperatorCount(OpLeader, 4), Equals, uint64(1))
+	// operator finished
+	op = newTestOperator(2, OpLeader, TransferLeader{FromStore: 3, ToStore: 1})
+	region = newTestRegion(2, 1, [2]uint64{1, 1}, [2]uint64{3, 3})
+	l.UpdateCounts(op, region)
+	c.Assert(l.OperatorCount(OpLeader), Equals, uint64(3))
+	c.Assert(l.StoreOperatorCount(OpLeader, 3), Equals, uint64(1))
+
+	// wait for ttl
+	// cause there is an unfinished operator updating the counts, so expire updated.
+	time.Sleep(time.Second * 2)
+	c.Assert(l.OperatorCount(OpLeader), Equals, uint64(1))
+	c.Assert(l.StoreOperatorCount(OpLeader, 1), Equals, uint64(1))
+	c.Assert(l.StoreOperatorCount(OpLeader, 2), Equals, uint64(0))
+	c.Assert(l.StoreOperatorCount(OpLeader, 3), Equals, uint64(0))
+	c.Assert(l.StoreOperatorCount(OpLeader, 4), Equals, uint64(1))
+
+	// wait for ttl
+	time.Sleep(time.Second * 2)
+	c.Assert(l.OperatorCount(OpLeader), Equals, uint64(0))
+	c.Assert(l.StoreOperatorCount(OpLeader, 1), Equals, uint64(0))
+	c.Assert(l.StoreOperatorCount(OpLeader, 2), Equals, uint64(0))
+	c.Assert(l.StoreOperatorCount(OpLeader, 3), Equals, uint64(0))
+	c.Assert(l.StoreOperatorCount(OpLeader, 4), Equals, uint64(0))
+}
+
+func (s *testLimiterSuite) TestRemove(c *C) {
+	l := NewLimiter()
+
+	op := newTestOperator(100, OpLeader, TransferLeader{FromStore: 100, ToStore: 1})
+	region := newTestRegion(100, 100, [2]uint64{1, 1}, [2]uint64{100, 100})
+	l.UpdateCounts(op, region)
+	op = newTestOperator(1, OpLeader, TransferLeader{FromStore: 2, ToStore: 1})
+	region = newTestRegion(1, 2, [2]uint64{1, 1}, [2]uint64{2, 2})
+	l.UpdateCounts(op, region)
+
+	c.Assert(l.OperatorCount(OpLeader), Equals, uint64(2))
+	c.Assert(l.StoreOperatorCount(OpLeader, 1), Equals, uint64(2))
+	c.Assert(l.StoreOperatorCount(OpLeader, 2), Equals, uint64(1))
+	c.Assert(l.StoreOperatorCount(OpLeader, 100), Equals, uint64(1))
+	l.Remove(op, region)
+	c.Assert(l.OperatorCount(OpLeader), Equals, uint64(1))
+	c.Assert(l.StoreOperatorCount(OpLeader, 1), Equals, uint64(1))
+	c.Assert(l.StoreOperatorCount(OpLeader, 2), Equals, uint64(0))
+	c.Assert(l.StoreOperatorCount(OpLeader, 100), Equals, uint64(1))
+	c.Assert(l.counts[op.Kind()][2], IsNil)
+}

--- a/server/schedule/limiter_test.go
+++ b/server/schedule/limiter_test.go
@@ -24,8 +24,8 @@ var _ = Suite(&testLimiterSuite{})
 type testLimiterSuite struct{}
 
 func (s testLimiterSuite) SetUpSuite(c *C) {
-	limiterCacheGCInterval = time.Second * 1
-	limiterCacheTTL = time.Second * 2
+	limiterCacheGCInterval = time.Millisecond * 100
+	limiterCacheTTL = time.Millisecond * 500
 }
 
 func (s *testLimiterSuite) TestUpdateCounts(c *C) {
@@ -46,7 +46,7 @@ func (s *testLimiterSuite) TestUpdateCounts(c *C) {
 	c.Assert(l.StoreOperatorCount(OpLeader, 3), Equals, uint64(1))
 	c.Assert(l.StoreOperatorCount(OpLeader, 4), Equals, uint64(1))
 
-	time.Sleep(time.Second * 1)
+	time.Sleep(time.Millisecond * 200)
 	// operator not finished
 	op := newTestOperator(3, OpLeader, TransferLeader{FromStore: 4, ToStore: 1})
 	region := newTestRegion(3, 4, [2]uint64{1, 1}, [2]uint64{4, 4})
@@ -62,7 +62,7 @@ func (s *testLimiterSuite) TestUpdateCounts(c *C) {
 
 	// wait for ttl
 	// cause there is an unfinished operator updating the counts, so expire updated.
-	time.Sleep(time.Millisecond * 150)
+	time.Sleep(time.Millisecond * 500)
 	c.Assert(l.OperatorCount(OpLeader), Equals, uint64(1))
 	c.Assert(l.StoreOperatorCount(OpLeader, 1), Equals, uint64(1))
 	c.Assert(l.StoreOperatorCount(OpLeader, 2), Equals, uint64(0))
@@ -70,7 +70,7 @@ func (s *testLimiterSuite) TestUpdateCounts(c *C) {
 	c.Assert(l.StoreOperatorCount(OpLeader, 4), Equals, uint64(1))
 
 	// wait for ttl
-	time.Sleep(time.Millisecond * 100)
+	time.Sleep(time.Millisecond * 500)
 	c.Assert(l.OperatorCount(OpLeader), Equals, uint64(0))
 	c.Assert(l.StoreOperatorCount(OpLeader, 1), Equals, uint64(0))
 	c.Assert(l.StoreOperatorCount(OpLeader, 2), Equals, uint64(0))

--- a/server/schedule/limiter_test.go
+++ b/server/schedule/limiter_test.go
@@ -62,7 +62,7 @@ func (s *testLimiterSuite) TestUpdateCounts(c *C) {
 
 	// wait for ttl
 	// cause there is an unfinished operator updating the counts, so expire updated.
-	time.Sleep(time.Second * 2)
+	time.Sleep(time.Millisecond * 150)
 	c.Assert(l.OperatorCount(OpLeader), Equals, uint64(1))
 	c.Assert(l.StoreOperatorCount(OpLeader, 1), Equals, uint64(1))
 	c.Assert(l.StoreOperatorCount(OpLeader, 2), Equals, uint64(0))
@@ -70,7 +70,7 @@ func (s *testLimiterSuite) TestUpdateCounts(c *C) {
 	c.Assert(l.StoreOperatorCount(OpLeader, 4), Equals, uint64(1))
 
 	// wait for ttl
-	time.Sleep(time.Second * 2)
+	time.Sleep(time.Millisecond * 100)
 	c.Assert(l.OperatorCount(OpLeader), Equals, uint64(0))
 	c.Assert(l.StoreOperatorCount(OpLeader, 1), Equals, uint64(0))
 	c.Assert(l.StoreOperatorCount(OpLeader, 2), Equals, uint64(0))

--- a/server/schedule/mockcluster.go
+++ b/server/schedule/mockcluster.go
@@ -375,10 +375,10 @@ const (
 	defaultMaxPendingPeerCount  = 16
 	defaultMaxStoreDownTime     = 30 * time.Minute
 	defaultMaxMergeRegionSize   = 0
-	defaultLeaderScheduleLimit  = 4
-	defaultRegionScheduleLimit  = 4
-	defaultReplicaScheduleLimit = 8
-	defaultMergeScheduleLimit   = 8
+	defaultLeaderScheduleLimit  = 1000
+	defaultRegionScheduleLimit  = 30
+	defaultReplicaScheduleLimit = 30
+	defaultMergeScheduleLimit   = 10
 	defaultTolerantSizeRatio    = 2.5
 	defaultLowSpaceRatio        = 0.8
 	defaultHighSpaceRatio       = 0.6

--- a/server/schedule/operator.go
+++ b/server/schedule/operator.go
@@ -410,6 +410,10 @@ func (o *Operator) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
 
 // InvolvedStores returns the stores invloved in operator steps.
 func (o *Operator) InvolvedStores(region *core.RegionInfo) []uint64 {
+	if region == nil || region.Leader == nil {
+		return nil
+	}
+
 	res := []uint64{}
 	for step := atomic.LoadInt32(&o.currentStep); int(step) < len(o.steps); step++ {
 		if !o.steps[int(step)].IsFinish(region) {

--- a/server/schedule/operator.go
+++ b/server/schedule/operator.go
@@ -36,6 +36,7 @@ type OperatorStep interface {
 	fmt.Stringer
 	IsFinish(region *core.RegionInfo) bool
 	Influence(opInfluence OpInfluence, region *core.RegionInfo)
+	InvolvedStores(region *core.RegionInfo) []uint64
 }
 
 // TransferLeader is an OperatorStep that transfers a region's leader.
@@ -52,7 +53,7 @@ func (tl TransferLeader) IsFinish(region *core.RegionInfo) bool {
 	return region.Leader.GetStoreId() == tl.ToStore
 }
 
-// Influence calculates the store difference that current step make
+// Influence calculates the store difference that current step make.
 func (tl TransferLeader) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
 	from := opInfluence.GetStoreInfluence(tl.FromStore)
 	to := opInfluence.GetStoreInfluence(tl.ToStore)
@@ -61,6 +62,11 @@ func (tl TransferLeader) Influence(opInfluence OpInfluence, region *core.RegionI
 	from.LeaderCount--
 	to.LeaderSize += region.ApproximateSize
 	to.LeaderCount++
+}
+
+// InvolvedStores returns the stores invloved in this operator step.
+func (tl TransferLeader) InvolvedStores(region *core.RegionInfo) []uint64 {
+	return []uint64{tl.FromStore, tl.ToStore}
 }
 
 // AddPeer is an OperatorStep that adds a region peer.
@@ -84,12 +90,17 @@ func (ap AddPeer) IsFinish(region *core.RegionInfo) bool {
 	return false
 }
 
-// Influence calculates the store difference that current step make
+// Influence calculates the store difference that current step make.
 func (ap AddPeer) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
 	to := opInfluence.GetStoreInfluence(ap.ToStore)
 
 	to.RegionSize += region.ApproximateSize
 	to.RegionCount++
+}
+
+// InvolvedStores returns the stores invloved in this operator step.
+func (ap AddPeer) InvolvedStores(region *core.RegionInfo) []uint64 {
+	return []uint64{region.Leader.StoreId, ap.ToStore}
 }
 
 // AddLearner is an OperatorStep that adds a region learner peer.
@@ -113,12 +124,17 @@ func (al AddLearner) IsFinish(region *core.RegionInfo) bool {
 	return false
 }
 
-// Influence calculates the store difference that current step make
+// Influence calculates the store difference that current step make.
 func (al AddLearner) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
 	to := opInfluence.GetStoreInfluence(al.ToStore)
 
 	to.RegionSize += region.ApproximateSize
 	to.RegionCount++
+}
+
+// InvolvedStores returns the stores invloved in this operator step.
+func (al AddLearner) InvolvedStores(region *core.RegionInfo) []uint64 {
+	return []uint64{region.Leader.StoreId, al.ToStore}
 }
 
 // PromoteLearner is an OperatorStep that promotes a region learner peer to normal voter.
@@ -141,8 +157,13 @@ func (pl PromoteLearner) IsFinish(region *core.RegionInfo) bool {
 	return false
 }
 
-// Influence calculates the store difference that current step make
+// Influence calculates the store difference that current step make.
 func (pl PromoteLearner) Influence(opInfluence OpInfluence, region *core.RegionInfo) {}
+
+// InvolvedStores returns the stores invloved in this operator step.
+func (pl PromoteLearner) InvolvedStores(region *core.RegionInfo) []uint64 {
+	return []uint64{pl.ToStore}
+}
 
 // RemovePeer is an OperatorStep that removes a region peer.
 type RemovePeer struct {
@@ -158,12 +179,17 @@ func (rp RemovePeer) IsFinish(region *core.RegionInfo) bool {
 	return region.GetStorePeer(rp.FromStore) == nil
 }
 
-// Influence calculates the store difference that current step make
+// Influence calculates the store difference that current step make.
 func (rp RemovePeer) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
 	from := opInfluence.GetStoreInfluence(rp.FromStore)
 
 	from.RegionSize -= region.ApproximateSize
 	from.RegionCount--
+}
+
+// InvolvedStores returns the stores invloved in this operator step.
+func (rp RemovePeer) InvolvedStores(region *core.RegionInfo) []uint64 {
+	return []uint64{rp.FromStore}
 }
 
 // MergeRegion is an OperatorStep that merge two regions.
@@ -183,7 +209,7 @@ func (mr MergeRegion) String() string {
 	return fmt.Sprintf("merge region %v into region %v", mr.FromRegion.GetId(), mr.ToRegion.GetId())
 }
 
-// IsFinish checks if current step is finished
+// IsFinish checks if current step is finished.
 func (mr MergeRegion) IsFinish(region *core.RegionInfo) bool {
 	if mr.IsPassive {
 		return bytes.Compare(region.Region.StartKey, mr.ToRegion.StartKey) != 0 || bytes.Compare(region.Region.EndKey, mr.ToRegion.EndKey) != 0
@@ -191,7 +217,7 @@ func (mr MergeRegion) IsFinish(region *core.RegionInfo) bool {
 	return false
 }
 
-// Influence calculates the store difference that current step make
+// Influence calculates the store difference that current step make.
 func (mr MergeRegion) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
 	if mr.IsPassive {
 		for _, p := range region.GetPeers() {
@@ -202,6 +228,18 @@ func (mr MergeRegion) Influence(opInfluence OpInfluence, region *core.RegionInfo
 			}
 		}
 	}
+}
+
+// InvolvedStores returns the stores invloved in this operator step.
+func (mr MergeRegion) InvolvedStores(region *core.RegionInfo) []uint64 {
+	if mr.IsPassive {
+		res := []uint64{}
+		for _, p := range region.GetPeers() {
+			res = append(res, p.StoreId)
+		}
+		return res
+	}
+	return nil
 }
 
 // SplitRegion is an OperatorStep that splits a region.
@@ -227,6 +265,15 @@ func (sr SplitRegion) Influence(opInfluence OpInfluence, region *core.RegionInfo
 			inf.LeaderCount++
 		}
 	}
+}
+
+// InvolvedStores returns the stores invloved in this operator step.
+func (sr SplitRegion) InvolvedStores(region *core.RegionInfo) []uint64 {
+	res := []uint64{}
+	for _, p := range region.GetPeers() {
+		res = append(res, p.StoreId)
+	}
+	return res
 }
 
 // Operator contains execution steps generated by scheduler.
@@ -349,6 +396,17 @@ func (o *Operator) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
 			o.steps[int(step)].Influence(opInfluence, region)
 		}
 	}
+}
+
+// InvolvedStores returns the stores invloved in operator steps.
+func (o *Operator) InvolvedStores(region *core.RegionInfo) []uint64 {
+	res := []uint64{}
+	for step := atomic.LoadInt32(&o.currentStep); int(step) < len(o.steps); step++ {
+		if !o.steps[int(step)].IsFinish(region) {
+			res = append(res, o.steps[int(step)].InvolvedStores(region)...)
+		}
+	}
+	return res
 }
 
 // OperatorHistory is used to log and visualize completed operators.

--- a/server/schedule/operator_test.go
+++ b/server/schedule/operator_test.go
@@ -18,47 +18,20 @@ import (
 	"sync/atomic"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/kvproto/pkg/metapb"
-	"github.com/pingcap/pd/server/core"
 )
 
 var _ = Suite(&testOperatorSuite{})
 
 type testOperatorSuite struct{}
 
-func (s *testOperatorSuite) newTestRegion(regionID uint64, leaderPeer uint64, peers ...[2]uint64) *core.RegionInfo {
-	var (
-		region metapb.Region
-		leader *metapb.Peer
-	)
-	region.Id = regionID
-	for i := range peers {
-		peer := &metapb.Peer{
-			Id:      peers[i][1],
-			StoreId: peers[i][0],
-		}
-		region.Peers = append(region.Peers, peer)
-		if peer.GetId() == leaderPeer {
-			leader = peer
-		}
-	}
-	regionInfo := core.NewRegionInfo(&region, leader)
-	regionInfo.ApproximateSize = 10
-	return regionInfo
-}
-
 func (s *testOperatorSuite) TestOperatorStep(c *C) {
-	region := s.newTestRegion(1, 1, [2]uint64{1, 1}, [2]uint64{2, 2})
+	region := newTestRegion(1, 1, [2]uint64{1, 1}, [2]uint64{2, 2})
 	c.Assert(TransferLeader{FromStore: 1, ToStore: 2}.IsFinish(region), IsFalse)
 	c.Assert(TransferLeader{FromStore: 2, ToStore: 1}.IsFinish(region), IsTrue)
 	c.Assert(AddPeer{ToStore: 3, PeerID: 3}.IsFinish(region), IsFalse)
 	c.Assert(AddPeer{ToStore: 1, PeerID: 1}.IsFinish(region), IsTrue)
 	c.Assert(RemovePeer{FromStore: 1}.IsFinish(region), IsFalse)
 	c.Assert(RemovePeer{FromStore: 3}.IsFinish(region), IsTrue)
-}
-
-func (s *testOperatorSuite) newTestOperator(regionID uint64, steps ...OperatorStep) *Operator {
-	return NewOperator("testOperator", regionID, OpAdmin, steps...)
 }
 
 func (s *testOperatorSuite) checkSteps(c *C, op *Operator, steps []OperatorStep) {
@@ -69,14 +42,14 @@ func (s *testOperatorSuite) checkSteps(c *C, op *Operator, steps []OperatorStep)
 }
 
 func (s *testOperatorSuite) TestOperator(c *C) {
-	region := s.newTestRegion(1, 1, [2]uint64{1, 1}, [2]uint64{2, 2})
+	region := newTestRegion(1, 1, [2]uint64{1, 1}, [2]uint64{2, 2})
 	// addPeer1, transferLeader1, removePeer3
 	steps := []OperatorStep{
 		AddPeer{ToStore: 1, PeerID: 1},
 		TransferLeader{FromStore: 3, ToStore: 1},
 		RemovePeer{FromStore: 3},
 	}
-	op := s.newTestOperator(1, steps...)
+	op := newTestOperator(1, OpAdmin, steps...)
 	s.checkSteps(c, op, steps)
 	c.Assert(op.Check(region), IsNil)
 	c.Assert(op.IsFinish(), IsTrue)
@@ -89,7 +62,7 @@ func (s *testOperatorSuite) TestOperator(c *C) {
 		TransferLeader{FromStore: 2, ToStore: 1},
 		RemovePeer{FromStore: 2},
 	}
-	op = s.newTestOperator(1, steps...)
+	op = newTestOperator(1, OpAdmin, steps...)
 	s.checkSteps(c, op, steps)
 	c.Assert(op.Check(region), Equals, RemovePeer{FromStore: 2})
 	c.Assert(atomic.LoadInt32(&op.currentStep), Equals, int32(2))
@@ -102,7 +75,7 @@ func (s *testOperatorSuite) TestOperator(c *C) {
 }
 
 func (s *testOperatorSuite) TestInfluence(c *C) {
-	region := s.newTestRegion(1, 1, [2]uint64{1, 1}, [2]uint64{2, 2})
+	region := newTestRegion(1, 1, [2]uint64{1, 1}, [2]uint64{2, 2})
 	opInfluence := make(map[uint64]*StoreInfluence)
 	opInfluence[1] = &StoreInfluence{}
 	opInfluence[2] = &StoreInfluence{}

--- a/server/schedule/scheduler.go
+++ b/server/schedule/scheduler.go
@@ -14,12 +14,10 @@
 package schedule
 
 import (
-	"sync"
 	"time"
 
 	"github.com/juju/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
-	"github.com/pingcap/pd/server/cache"
 	"github.com/pingcap/pd/server/core"
 	log "github.com/sirupsen/logrus"
 )
@@ -91,80 +89,3 @@ func CreateScheduler(name string, limiter *Limiter, args ...string) (Scheduler, 
 	return fn(limiter, args)
 }
 
-// Limiter a counter that limits the number of operators
-type Limiter struct {
-	sync.RWMutex
-	counts map[OperatorKind]map[uint64]*cache.TTLUint64
-}
-
-// NewLimiter create a schedule limiter
-func NewLimiter() *Limiter {
-	return &Limiter{
-		counts: make(map[OperatorKind]map[uint64]*cache.TTLUint64),
-	}
-}
-
-const (
-	limiterCacheGCInterval = time.Second * 5
-	limiterCacheTTL        = time.Minute * 1
-)
-
-// UpdateCounts updates resouce counts using current pending operators.
-func (l *Limiter) UpdateCounts(op *Operator, region *core.RegionInfo) {
-	l.Lock()
-	defer l.Unlock()
-
-	for _, store := range op.InvolvedStores(region) {
-		ttl, ok := l.counts[op.Kind()][store]
-		if !ok {
-			ttl = cache.NewIDTTL(limiterCacheGCInterval, limiterCacheTTL)
-			l.counts[op.Kind()][store] = ttl
-		}
-		ttl.Put(op.RegionID())
-	}
-}
-
-// Remove deletes related items from all involved stores cache.
-func (l *Limiter) Remove(op *Operator, region *core.RegionInfo) {
-	l.Lock()
-	defer l.Unlock()
-
-	for _, store := range op.InvolvedStores(region) {
-		ttl, ok := l.counts[op.Kind()][store]
-		if ok {
-			ttl.Remove(op.RegionID())
-		}
-	}
-}
-
-// OperatorCount gets the max count of operators of all involved stores filtered by mask.
-func (l *Limiter) OperatorCount(mask OperatorKind) uint64 {
-	l.RLock()
-	defer l.RUnlock()
-
-	var max uint64 = 1
-	for k, stores := range l.counts {
-		if k&mask != 0 {
-			for _, store := range stores {
-				if max < uint64(store.Len()) {
-					max = uint64(store.Len())
-				}
-			}
-		}
-	}
-	return max
-}
-
-// StoreOperatorCount gets the count of operators for specific store filtered by mask.
-func (l *Limiter) StoreOperatorCount(mask OperatorKind, storeID uint64) uint64 {
-	l.RLock()
-	defer l.RUnlock()
-
-	var total uint64
-	for k, stores := range l.counts {
-		if k&mask != 0 {
-			total += uint64(stores[storeID].Len())
-		}
-	}
-	return total
-}

--- a/server/schedule/scheduler.go
+++ b/server/schedule/scheduler.go
@@ -88,4 +88,3 @@ func CreateScheduler(name string, limiter *Limiter, args ...string) (Scheduler, 
 	}
 	return fn(limiter, args)
 }
-

--- a/server/schedule/testutil.go
+++ b/server/schedule/testutil.go
@@ -1,0 +1,44 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schedule
+
+import (
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/pd/server/core"
+)
+
+func newTestOperator(regionID uint64, kind OperatorKind, steps ...OperatorStep) *Operator {
+	return NewOperator("test", regionID, kind, steps...)
+}
+
+func newTestRegion(regionID uint64, leaderPeer uint64, peers ...[2]uint64) *core.RegionInfo {
+	var (
+		region metapb.Region
+		leader *metapb.Peer
+	)
+	region.Id = regionID
+	for i := range peers {
+		peer := &metapb.Peer{
+			Id:      peers[i][1],
+			StoreId: peers[i][0],
+		}
+		region.Peers = append(region.Peers, peer)
+		if peer.GetId() == leaderPeer {
+			leader = peer
+		}
+	}
+	regionInfo := core.NewRegionInfo(&region, leader)
+	regionInfo.ApproximateSize = 10
+	return regionInfo
+}


### PR DESCRIPTION
**Problem:**
Now tikv will report heartbeat at soon as finishing conf_change, and then pd will finish operator and decrease limiter count and schedule a new operator. For this reason, tikv will always be busy for conf_change even though limit is small, namely, limiter can't control schedule speed anymore. 

**Solution:**
we introduce ttl(one minute) cache for limiter and it records operator count grouping by store. When operator has finished, pd don't remove it from ttl cache.  So limit now can represent concrete schedule speed that the max count of changed region/leader for one store every minute.