### PR TITLE
server: fix the valid scheduler was deleted when start coordinator

### DIFF
--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -208,7 +208,7 @@ func (c *coordinator) run() {
 		if schedulerCfg.Disable {
 			scheduleCfg.Schedulers[k] = schedulerCfg
 			k++
-			log.Warning("skip create ", schedulerCfg.Type)
+			log.Info("skip create ", schedulerCfg.Type)
 			continue
 		}
 		s, err := schedule.CreateScheduler(schedulerCfg.Type, c.limiter, schedulerCfg.Args...)

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -206,6 +206,9 @@ func (c *coordinator) run() {
 	scheduleCfg := c.cluster.opt.load()
 	for _, schedulerCfg := range scheduleCfg.Schedulers {
 		if schedulerCfg.Disable {
+			scheduleCfg.Schedulers[k] = schedulerCfg
+			k++
+			log.Warning("skip create ", schedulerCfg.Type)
 			continue
 		}
 		s, err := schedule.CreateScheduler(schedulerCfg.Type, c.limiter, schedulerCfg.Args...)

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -482,6 +482,14 @@ func (s *testCoordinatorSuite) TestPersistScheduler(c *C) {
 	co = newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
 	co.run()
 	c.Assert(co.schedulers, HasLen, 3)
+	co.stop()
+	// suppose restart PD again
+	_, newOpt = newTestScheduleConfig()
+	newOpt.reload(tc.kv)
+	tc.clusterInfo.opt = newOpt
+	co = newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
+	co.run()
+	c.Assert(co.schedulers, HasLen, 3)
 	bls, err := schedule.CreateScheduler("balance-leader", co.limiter)
 	c.Assert(err, IsNil)
 	c.Assert(co.addScheduler(bls), IsNil)


### PR DESCRIPTION
if disable a default scheduler and restart PD, it will delete the scheduler whether it is valid or not. and then restart PD, it will create the default scheduler again because of it think that is a newly added default scheduler.