### PR TITLE
dep: enable auto prune

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -19,6 +19,10 @@
 #  name = "github.com/x/y"
 #  version = "2.4.0"
 
+[prune]
+  go-tests = true
+  unused-packages = true
+
 [[constraint]]
   name = "github.com/coreos/etcd"
   version = "=3.2.18"

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ else
 	dep ensure -update
 endif
 	@echo "removing test files"
-	dep prune
 	bash ./hack/clean_vendor.sh
 
 simulator:


### PR DESCRIPTION
As dep official [suggests](https://golang.github.io/dep/docs/Gopkg.toml.html#prune), enable auto `prune` when `ensure`.