### PR TITLE
schedule: merge checker skips recently split regions.

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -54,6 +54,7 @@ address = ""
 
 [schedule]
 max-merge-region-size = 0
+split-merge-interval = "1h"
 max-snapshot-count = 3
 max-pending-peer-count = 16
 max-store-down-time = "30m"

--- a/server/cache.go
+++ b/server/cache.go
@@ -562,6 +562,10 @@ func (c *clusterInfo) GetMaxMergeRegionSize() uint64 {
 	return c.opt.GetMaxMergeRegionSize()
 }
 
+func (c *clusterInfo) GetSplitMergeInterval() time.Duration {
+	return c.opt.GetSplitMergeInterval()
+}
+
 func (c *clusterInfo) GetMaxStoreDownTime() time.Duration {
 	return c.opt.GetMaxStoreDownTime()
 }

--- a/server/cluster_worker.go
+++ b/server/cluster_worker.go
@@ -65,6 +65,10 @@ func (c *RaftCluster) handleAskSplit(request *pdpb.AskSplitRequest) (*pdpb.AskSp
 		}
 	}
 
+	// Disable merge for the 2 regions in a period of time.
+	c.coordinator.mergeChecker.RecordRegionSplit(reqRegion.GetId())
+	c.coordinator.mergeChecker.RecordRegionSplit(newRegionID)
+
 	split := &pdpb.AskSplitResponse{
 		NewRegionId: newRegionID,
 		NewPeerIds:  peerIDs,

--- a/server/config.go
+++ b/server/config.go
@@ -364,6 +364,8 @@ type ScheduleConfig struct {
 	// If the size of region is smaller than this value,
 	// it will try to merge with adjacent regions.
 	MaxMergeRegionSize uint64 `toml:"max-merge-region-size,omitempty" json:"max-merge-region-size"`
+	// SplitMergeInterval is the minimum interval time to permit merge after split.
+	SplitMergeInterval typeutil.Duration `toml:"split-merge-interval,omitempty" json:"split-merge-interval"`
 	// MaxStoreDownTime is the max duration after which
 	// a store will be considered to be down if it hasn't reported heartbeats.
 	MaxStoreDownTime typeutil.Duration `toml:"max-store-down-time,omitempty" json:"max-store-down-time"`
@@ -401,8 +403,9 @@ func (c *ScheduleConfig) clone() *ScheduleConfig {
 	return &ScheduleConfig{
 		MaxSnapshotCount:     c.MaxSnapshotCount,
 		MaxPendingPeerCount:  c.MaxPendingPeerCount,
-		MaxStoreDownTime:     c.MaxStoreDownTime,
 		MaxMergeRegionSize:   c.MaxMergeRegionSize,
+		SplitMergeInterval:   c.SplitMergeInterval,
+		MaxStoreDownTime:     c.MaxStoreDownTime,
 		LeaderScheduleLimit:  c.LeaderScheduleLimit,
 		RegionScheduleLimit:  c.RegionScheduleLimit,
 		ReplicaScheduleLimit: c.ReplicaScheduleLimit,
@@ -415,11 +418,28 @@ func (c *ScheduleConfig) clone() *ScheduleConfig {
 	}
 }
 
+const (
+	defaultMaxReplicas          = 3
+	defaultMaxSnapshotCount     = 3
+	defaultMaxPendingPeerCount  = 16
+	defaultMaxMergeRegionSize   = 0
+	defaultSplitMergeInterval   = 1 * time.Hour
+	defaultMaxStoreDownTime     = 30 * time.Minute
+	defaultLeaderScheduleLimit  = 4
+	defaultRegionScheduleLimit  = 4
+	defaultReplicaScheduleLimit = 8
+	defaultMergeScheduleLimit   = 8
+	defaultTolerantSizeRatio    = 5
+	defaultLowSpaceRatio        = 0.8
+	defaultHighSpaceRatio       = 0.6
+)
+
 func (c *ScheduleConfig) adjust() error {
 	adjustUint64(&c.MaxSnapshotCount, defaultMaxSnapshotCount)
 	adjustUint64(&c.MaxPendingPeerCount, defaultMaxPendingPeerCount)
-	adjustDuration(&c.MaxStoreDownTime, defaultMaxStoreDownTime)
 	adjustUint64(&c.MaxMergeRegionSize, defaultMaxMergeRegionSize)
+	adjustDuration(&c.SplitMergeInterval, defaultSplitMergeInterval)
+	adjustDuration(&c.MaxStoreDownTime, defaultMaxStoreDownTime)
 	adjustUint64(&c.LeaderScheduleLimit, defaultLeaderScheduleLimit)
 	adjustUint64(&c.RegionScheduleLimit, defaultRegionScheduleLimit)
 	adjustUint64(&c.ReplicaScheduleLimit, defaultReplicaScheduleLimit)
@@ -457,21 +477,6 @@ type SchedulerConfig struct {
 	Args    []string `toml:"args,omitempty" json:"args"`
 	Disable bool     `toml:"disable" json:"disable"`
 }
-
-const (
-	defaultMaxReplicas          = 3
-	defaultMaxSnapshotCount     = 3
-	defaultMaxPendingPeerCount  = 16
-	defaultMaxMergeRegionSize   = 0
-	defaultMaxStoreDownTime     = 30 * time.Minute
-	defaultLeaderScheduleLimit  = 4
-	defaultRegionScheduleLimit  = 4
-	defaultReplicaScheduleLimit = 8
-	defaultMergeScheduleLimit   = 8
-	defaultTolerantSizeRatio    = 5
-	defaultLowSpaceRatio        = 0.8
-	defaultHighSpaceRatio       = 0.6
-)
 
 var defaultSchedulers = SchedulerConfigs{
 	{Type: "balance-region"},

--- a/server/option.go
+++ b/server/option.go
@@ -80,12 +80,16 @@ func (o *scheduleOption) GetMaxPendingPeerCount() uint64 {
 	return o.load().MaxPendingPeerCount
 }
 
-func (o *scheduleOption) GetMaxStoreDownTime() time.Duration {
-	return o.load().MaxStoreDownTime.Duration
-}
-
 func (o *scheduleOption) GetMaxMergeRegionSize() uint64 {
 	return o.load().MaxMergeRegionSize
+}
+
+func (o *scheduleOption) GetSplitMergeInterval() time.Duration {
+	return o.load().SplitMergeInterval.Duration
+}
+
+func (o *scheduleOption) GetMaxStoreDownTime() time.Duration {
+	return o.load().MaxStoreDownTime.Duration
 }
 
 func (o *scheduleOption) GetLeaderScheduleLimit(name string) uint64 {

--- a/server/schedule/mockcluster.go
+++ b/server/schedule/mockcluster.go
@@ -391,8 +391,9 @@ const (
 	defaultMaxReplicas          = 3
 	defaultMaxSnapshotCount     = 3
 	defaultMaxPendingPeerCount  = 16
-	defaultMaxStoreDownTime     = 30 * time.Minute
 	defaultMaxMergeRegionSize   = 0
+	defaultSplitMergeInterval   = 0
+	defaultMaxStoreDownTime     = 30 * time.Minute
 	defaultLeaderScheduleLimit  = 4
 	defaultRegionScheduleLimit  = 4
 	defaultReplicaScheduleLimit = 8
@@ -411,9 +412,10 @@ type MockSchedulerOptions struct {
 	MergeScheduleLimit    uint64
 	MaxSnapshotCount      uint64
 	MaxPendingPeerCount   uint64
+	MaxMergeRegionSize    uint64
+	SplitMergeInterval    time.Duration
 	MaxStoreDownTime      time.Duration
 	MaxReplicas           int
-	MaxMergeRegionSize    uint64
 	LocationLabels        []string
 	HotRegionLowThreshold int
 	TolerantSizeRatio     float64
@@ -431,11 +433,12 @@ func NewMockSchedulerOptions() *MockSchedulerOptions {
 	mso.ReplicaScheduleLimit = defaultReplicaScheduleLimit
 	mso.MergeScheduleLimit = defaultMergeScheduleLimit
 	mso.MaxSnapshotCount = defaultMaxSnapshotCount
+	mso.MaxMergeRegionSize = defaultMaxMergeRegionSize
+	mso.SplitMergeInterval = defaultSplitMergeInterval
 	mso.MaxStoreDownTime = defaultMaxStoreDownTime
 	mso.MaxReplicas = defaultMaxReplicas
 	mso.HotRegionLowThreshold = HotRegionLowThreshold
 	mso.MaxPendingPeerCount = defaultMaxPendingPeerCount
-	mso.MaxMergeRegionSize = defaultMaxMergeRegionSize
 	mso.TolerantSizeRatio = defaultTolerantSizeRatio
 	mso.LowSpaceRatio = defaultLowSpaceRatio
 	mso.HighSpaceRatio = defaultHighSpaceRatio
@@ -472,6 +475,16 @@ func (mso *MockSchedulerOptions) GetMaxPendingPeerCount() uint64 {
 	return mso.MaxPendingPeerCount
 }
 
+// GetMaxMergeRegionSize mock method
+func (mso *MockSchedulerOptions) GetMaxMergeRegionSize() uint64 {
+	return mso.MaxMergeRegionSize
+}
+
+// GetSplitMergeInterval mock method
+func (mso *MockSchedulerOptions) GetSplitMergeInterval() time.Duration {
+	return mso.SplitMergeInterval
+}
+
 // GetMaxStoreDownTime mock method
 func (mso *MockSchedulerOptions) GetMaxStoreDownTime() time.Duration {
 	return mso.MaxStoreDownTime
@@ -480,11 +493,6 @@ func (mso *MockSchedulerOptions) GetMaxStoreDownTime() time.Duration {
 // GetMaxReplicas mock method
 func (mso *MockSchedulerOptions) GetMaxReplicas(name string) int {
 	return mso.MaxReplicas
-}
-
-// GetMaxMergeRegionSize mock method
-func (mso *MockSchedulerOptions) GetMaxMergeRegionSize() uint64 {
-	return mso.MaxMergeRegionSize
 }
 
 // GetLocationLabels mock method

--- a/server/schedule/opts.go
+++ b/server/schedule/opts.go
@@ -34,6 +34,7 @@ type Options interface {
 	GetMaxPendingPeerCount() uint64
 	GetMaxStoreDownTime() time.Duration
 	GetMaxMergeRegionSize() uint64
+	GetSplitMergeInterval() time.Duration
 
 	GetMaxReplicas() int
 	GetLocationLabels() []string

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -779,6 +780,8 @@ func (s *testMergeCheckerSuite) SetUpSuite(c *C) {
 }
 
 func (s *testMergeCheckerSuite) TestBasic(c *C) {
+	s.cluster.MockSchedulerOptions.SplitMergeInterval = time.Hour
+
 	// should with same peer count
 	op1, op2 := s.mc.Check(s.regions[0])
 	c.Assert(op1, IsNil)
@@ -790,6 +793,11 @@ func (s *testMergeCheckerSuite) TestBasic(c *C) {
 	op1, op2 = s.mc.Check(s.regions[2])
 	c.Assert(op1, NotNil)
 	c.Assert(op2, NotNil)
+	// Skip recently split regions.
+	s.mc.RecordRegionSplit(s.regions[2].GetId())
+	op1, op2 = s.mc.Check(s.regions[2])
+	c.Assert(op1, IsNil)
+	c.Assert(op2, IsNil)
 	op1, op2 = s.mc.Check(s.regions[3])
 	c.Assert(op1, IsNil)
 	c.Assert(op2, IsNil)

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -712,7 +712,7 @@ type testMergeCheckerSuite struct {
 	regions []*core.RegionInfo
 }
 
-func (s *testMergeCheckerSuite) SetUpSuite(c *C) {
+func (s *testMergeCheckerSuite) SetUpTest(c *C) {
 	cfg := schedule.NewMockSchedulerOptions()
 	cfg.MaxMergeRegionSize = 2
 	s.cluster = schedule.NewMockCluster(cfg)
@@ -815,7 +815,7 @@ func (s *testMergeCheckerSuite) TestMatchPeers(c *C) {
 	// partial store overlap not including leader
 	op1, op2 := s.mc.Check(s.regions[2])
 	s.checkSteps(c, op1, []schedule.OperatorStep{
-		schedule.AddPeer{ToStore: 4, PeerID: 2},
+		schedule.AddPeer{ToStore: 4, PeerID: 1},
 		schedule.TransferLeader{FromStore: 6, ToStore: 4},
 		schedule.RemovePeer{FromStore: 6},
 		schedule.MergeRegion{
@@ -837,7 +837,7 @@ func (s *testMergeCheckerSuite) TestMatchPeers(c *C) {
 	s.cluster.PutRegion(s.regions[2])
 	op1, op2 = s.mc.Check(s.regions[2])
 	s.checkSteps(c, op1, []schedule.OperatorStep{
-		schedule.AddPeer{ToStore: 4, PeerID: 3},
+		schedule.AddPeer{ToStore: 4, PeerID: 2},
 		schedule.RemovePeer{FromStore: 6},
 		schedule.MergeRegion{
 			FromRegion: s.regions[2].Region,


### PR DESCRIPTION
Another approach of https://github.com/pingcap/pd/pull/1048. The difference is it does not need to update region meta.

Close #1048 