### PR TITLE
*: adjust load region range limit.

### DIFF
--- a/server/etcd_kv.go
+++ b/server/etcd_kv.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	kvRangeLimit      = 10000
+	kvRangeLimit      = 1000
 	kvRequestTimeout  = time.Second * 10
 	kvSlowRequestTime = time.Second * 1
 )


### PR DESCRIPTION
Fix the error that load region failed due to message size exceeds 4M limit.

Don't merge it. We need a decent fix.