### PR TITLE
schedule: filter disconnected stores for leader transfer.

### DIFF
--- a/server/schedule/filters.go
+++ b/server/schedule/filters.go
@@ -125,6 +125,21 @@ func (f *healthFilter) FilterTarget(opt Options, store *core.StoreInfo) bool {
 	return f.filter(opt, store)
 }
 
+type disconnectFilter struct{}
+
+// NewDisconnectFilter creates a Filter that filters all stores that are disconnected.
+func NewDisconnectFilter() Filter {
+	return &disconnectFilter{}
+}
+
+func (f *disconnectFilter) FilterSource(opt Options, store *core.StoreInfo) bool {
+	return store.IsDisconnected()
+}
+
+func (f *disconnectFilter) FilterTarget(opt Options, store *core.StoreInfo) bool {
+	return store.IsDisconnected()
+}
+
 type pendingPeerCountFilter struct{}
 
 // NewPendingPeerCountFilter creates a Filter that filters all stores that are

--- a/server/schedule/mockcluster.go
+++ b/server/schedule/mockcluster.go
@@ -94,6 +94,14 @@ func (mc *MockCluster) SetStoreUp(storeID uint64) {
 	mc.PutStore(store)
 }
 
+// SetStoreDisconnect changes a store's state to disconnected.
+func (mc *MockCluster) SetStoreDisconnect(storeID uint64) {
+	store := mc.GetStore(storeID)
+	store.State = metapb.StoreState_Up
+	store.LastHeartbeatTS = time.Now().Add(-time.Second * 30)
+	mc.PutStore(store)
+}
+
 // SetStoreDown sets store down.
 func (mc *MockCluster) SetStoreDown(storeID uint64) {
 	store := mc.GetStore(storeID)

--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -46,6 +46,7 @@ func newBalanceLeaderScheduler(limiter *schedule.Limiter) schedule.Scheduler {
 		schedule.NewBlockFilter(),
 		schedule.NewStateFilter(),
 		schedule.NewHealthFilter(),
+		schedule.NewDisconnectFilter(),
 		schedule.NewRejectLeaderFilter(),
 		schedule.NewCacheFilter(taintStores),
 	}

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -215,6 +215,11 @@ func (s *testBalanceLeaderSchedulerSuite) TestBalanceFilter(c *C) {
 	// store 3 becomes the store with least leaders.
 	s.tc.SetStoreBusy(2, true)
 	CheckTransferLeader(c, s.schedule(nil)[0], schedule.OpBalance, 4, 3)
+
+	// Test disconnectFilter.
+	// If store 3 is disconnected, no operator can be created.
+	s.tc.SetStoreDisconnect(3)
+	c.Assert(s.schedule(nil), HasLen, 0)
 }
 
 func (s *testBalanceLeaderSchedulerSuite) TestLeaderWeight(c *C) {

--- a/server/schedulers/evict_leader.go
+++ b/server/schedulers/evict_leader.go
@@ -48,6 +48,7 @@ func newEvictLeaderScheduler(limiter *schedule.Limiter, storeID uint64) schedule
 	filters := []schedule.Filter{
 		schedule.NewStateFilter(),
 		schedule.NewHealthFilter(),
+		schedule.NewDisconnectFilter(),
 	}
 	base := newBaseScheduler(limiter)
 	return &evictLeaderScheduler{

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -311,6 +311,7 @@ func (h *balanceHotRegionsScheduler) balanceByLeader(cluster schedule.Cluster, s
 		filters := []schedule.Filter{
 			schedule.NewHealthFilter(),
 			schedule.NewStateFilter(),
+			schedule.NewDisconnectFilter(),
 			schedule.NewBlockFilter(),
 			schedule.NewRejectLeaderFilter(),
 		}

--- a/server/schedulers/label.go
+++ b/server/schedulers/label.go
@@ -35,6 +35,7 @@ func newLabelScheduler(limiter *schedule.Limiter) schedule.Scheduler {
 		schedule.NewBlockFilter(),
 		schedule.NewStateFilter(),
 		schedule.NewHealthFilter(),
+		schedule.NewDisconnectFilter(),
 		schedule.NewRejectLeaderFilter(),
 	}
 	return &labelScheduler{

--- a/server/schedulers/shuffle_leader.go
+++ b/server/schedulers/shuffle_leader.go
@@ -36,6 +36,7 @@ func newShuffleLeaderScheduler(limiter *schedule.Limiter) schedule.Scheduler {
 		schedule.NewBlockFilter(),
 		schedule.NewStateFilter(),
 		schedule.NewHealthFilter(),
+		schedule.NewDisconnectFilter(),
 		schedule.NewRejectLeaderFilter(),
 	}
 	base := newBaseScheduler(limiter)


### PR DESCRIPTION
When a store's state is _disconnected_, it is likely to be either down, isolated, or busy, so we better not transfer leader to it.