### PR TITLE
scheduler: evict-leader-scheduler checks reject-leader property.

### DIFF
--- a/server/schedulers/evict_leader.go
+++ b/server/schedulers/evict_leader.go
@@ -49,6 +49,7 @@ func newEvictLeaderScheduler(limiter *schedule.Limiter, storeID uint64) schedule
 		schedule.NewStateFilter(),
 		schedule.NewHealthFilter(),
 		schedule.NewDisconnectFilter(),
+		schedule.NewRejectLeaderFilter(),
 	}
 	base := newBaseScheduler(limiter)
 	return &evictLeaderScheduler{

--- a/server/schedulers/scheduler_test.go
+++ b/server/schedulers/scheduler_test.go
@@ -216,4 +216,9 @@ func (s *testRejectLeaderSuite) TestRejectLeader(c *C) {
 	c.Assert(err, IsNil)
 	op = sl.Schedule(tc, schedule.NewOpInfluence(nil, tc))
 	c.Assert(op, IsNil)
+	// Can't evict leader from store2, neither.
+	sl, err = schedule.CreateScheduler("evict-leader", schedule.NewLimiter(), "2")
+	c.Assert(err, IsNil)
+	op = sl.Schedule(tc, schedule.NewOpInfluence(nil, tc))
+	c.Assert(op, IsNil)
 }

--- a/server/schedulers/scheduler_test.go
+++ b/server/schedulers/scheduler_test.go
@@ -218,9 +218,9 @@ func (s *testRejectLeaderSuite) TestRejectLeader(c *C) {
 	c.Assert(op, IsNil)
 
 	// Can't evict leader from store2, neither.
-	sl, err = schedule.CreateScheduler("evict-leader", schedule.NewLimiter(), "2")
+	el, err := schedule.CreateScheduler("evict-leader", schedule.NewLimiter(), "2")
 	c.Assert(err, IsNil)
-	op = sl.Schedule(tc, schedule.NewOpInfluence(nil, tc))
+	op = el.Schedule(tc, schedule.NewOpInfluence(nil, tc))
 	c.Assert(op, IsNil)
 
 	// If the peer on store3 is pending, not trasnfer to store3 neither.


### PR DESCRIPTION
To prevent evict-leader-scheduler from breaking reject-leader property.