### PR TITLE
schedule: adjust timeout for operator contains only leader transfer.

### DIFF
--- a/server/schedule/operator.go
+++ b/server/schedule/operator.go
@@ -27,9 +27,14 @@ import (
 	"github.com/pingcap/pd/server/core"
 )
 
-// MaxOperatorWaitTime is the duration that if an operator lives longer that it,
-// the operator is considered timeout.
-const MaxOperatorWaitTime = 10 * time.Minute
+const (
+	// LeaderOperatorWaitTime is the duration that when a leader operator lives
+	// longer than it, the operator will be considered timeout.
+	LeaderOperatorWaitTime = 10 * time.Second
+	// RegionOperatorWaitTime is the duration that when a region operator lives
+	// longer than it, the operator will be considered timeout.
+	RegionOperatorWaitTime = 10 * time.Minute
+)
 
 // OperatorStep describes the basic scheduling steps that can not be subdivided.
 type OperatorStep interface {
@@ -349,7 +354,10 @@ func (o *Operator) IsTimeout() bool {
 	if o.IsFinish() {
 		return false
 	}
-	return time.Since(o.createTime) > MaxOperatorWaitTime
+	if o.kind&OpRegion != 0 {
+		return time.Since(o.createTime) > RegionOperatorWaitTime
+	}
+	return time.Since(o.createTime) > LeaderOperatorWaitTime
 }
 
 // Influence calculates the store difference which unfinished operator steps make


### PR DESCRIPTION
If _TransferLeader_ can't be executed quickly, it usually means that it cannot be successfully executed for some reason (such as the target store down). So we can use a shorter timeout in order to release schedule limit earlier.