### PR TITLE
scheduleres: label scheduler takes care of unhealthy regions.

### DIFF
--- a/server/schedulers/label.go
+++ b/server/schedulers/label.go
@@ -71,9 +71,17 @@ func (s *labelScheduler) Schedule(cluster schedule.Cluster, opInfluence schedule
 	}
 	log.Debugf("label scheduler reject leader store list: %v", rejectLeaderStores)
 	for id := range rejectLeaderStores {
-		if region := cluster.RandLeaderRegion(id, core.HealthRegion()); region != nil {
+		if region := cluster.RandLeaderRegion(id); region != nil {
 			log.Debugf("label scheduler selects region %d to transfer leader", region.GetId())
-			target := s.selector.SelectTarget(cluster, cluster.GetFollowerStores(region))
+			excludeStores := make(map[uint64]struct{})
+			for _, p := range region.DownPeers {
+				excludeStores[p.GetPeer().GetStoreId()] = struct{}{}
+			}
+			for _, p := range region.PendingPeers {
+				excludeStores[p.GetStoreId()] = struct{}{}
+			}
+			filter := schedule.NewExcludedFilter(nil, excludeStores)
+			target := s.selector.SelectTarget(cluster, cluster.GetFollowerStores(region), filter)
 			if target == nil {
 				log.Debugf("label scheduler no target found for region %d", region.GetId())
 				schedulerCounter.WithLabelValues(s.GetName(), "no_target").Inc()


### PR DESCRIPTION
Currently unhealthy regions are ignored by label scheduler.

Consider we have IDC1, IDC2, IDC3. IDC3 is configured as 'reject leader'. If IDC1 and IDC3 have network problem or one of IDC1's tikv is down, regions whose leader in IDC3 will be unhealthy, so they will not be able to transfer leader to IDC2.