### PR TITLE
server/config: use json output to make the config log more readable

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"net/url"
@@ -343,10 +344,11 @@ func (c *Config) clone() *Config {
 }
 
 func (c *Config) String() string {
-	if c == nil {
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
 		return "<nil>"
 	}
-	return fmt.Sprintf("Config(%+v)", *c)
+	return string(data)
 }
 
 // configFromFile loads config from file.


### PR DESCRIPTION
Like TiKV, Make the config log more readable.

New output:

```
2018/06/11 17:00:15.915 server.go:99: [info] PD config - {
  "client-urls": "http://127.0.0.1:2379",
  "peer-urls": "http://127.0.0.1:2380",
  "advertise-client-urls": "http://127.0.0.1:2379",
  "advertise-peer-urls": "http://127.0.0.1:2380",
  "name": "pd",
  "data-dir": "default.pd",
  "initial-cluster": "pd=http://127.0.0.1:2380",
  "initial-cluster-state": "new",
  "join": "",
  "lease": 3,
  "log": {
    "level": "",
    "format": "text",
    "disable-timestamp": false,
    "file": {
      "filename": "",
      "log-rotate": true,
      "max-size": 0,
      "max-days": 0,
      "max-backups": 0
    }
  },
  "log-file": "",
  "log-level": "",
  "tso-save-interval": "3s",
  "metric": {
    "job": "pd",
    "address": "",
    "interval": "0s"
  },
  "schedule": {
    "max-snapshot-count": 3,
    "max-pending-peer-count": 16,
    "max-merge-region-size": 20,
    "split-merge-interval": "1h0m0s",
    "patrol-region-interval": "100ms",
    "max-store-down-time": "30m0s",
    "leader-schedule-limit": 4,
    "region-schedule-limit": 4,
    "replica-schedule-limit": 8,
    "merge-schedule-limit": 8,
    "tolerant-size-ratio": 5,
    "low-space-ratio": 0.8,
    "high-space-ratio": 0.6,
    "disable-raft-learner": "false",
    "schedulers-v2": [
      {
        "type": "balance-region",
        "args": null,
        "disable": false
      },
      {
        "type": "balance-leader",
        "args": null,
        "disable": false
      },
      {
        "type": "hot-region",
        "args": null,
        "disable": false
      },
      {
        "type": "label",
        "args": null,
        "disable": false
      }
    ]
  },
  "replication": {
    "max-replicas": 3,
    "location-labels": ""
  },
  "namespace": {},
  "quota-backend-bytes": "0 B",
  "auto-compaction-mode": "periodic",
  "auto-compaction-retention-v2": "1h",
  "TickInterval": "500ms",
  "ElectionInterval": "3s",
  "security": {
    "cacert-path": "",
    "cert-path": "",
    "key-path": ""
  },
  "label-property": null,
  "WarningMsgs": null,
  "namespace-classifier": "table"
}
```
PTAL @disksing @nolouch 
