### PR TITLE
ci: skip integration tests in CI environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ matrix:
     env:
       - TRAVIS_COVERAGE=1
     script:
-      - make dev
+      - make ci
     after_success:
       - travis_wait make travis_coverage


### PR DESCRIPTION
The script of travis Ci was not correctly updated by https://github.com/pingcap/pd/pull/1102.