### PR TITLE
server: handle heartbeat of the region with peers change

### DIFF
--- a/server/cluster_info.go
+++ b/server/cluster_info.go
@@ -447,6 +447,9 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 		if len(origin.DownPeers) > 0 || len(origin.PendingPeers) > 0 {
 			saveCache = true
 		}
+		if len(region.GetPeers()) != len(origin.GetPeers()) {
+			saveKV, saveCache = true, true
+		}
 		if region.ApproximateSize != origin.ApproximateSize {
 			saveCache = true
 		}


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (required)

<!--
Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- Summarize your change (required)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

Please **NOTE** that:
- Do not assume the code is self-evident
- Do not assume reviewers understand the original issue
-->
 After TiKV unsafe recover some regions, the region epoch not changed but the peers number have changed, we should update it.

## What are the type of the changes (required)?

<!--
The currently defined types are listed below, please pick one of the types for this PR by removing the others:
-->
- Bug fix 

## How has this PR been tested (required)?
<!--
Please describe the tests that you ran to verify your changes. Have you finished unit tests, integration tests, or manual tests?
-->
- Unit tests

