### PR TITLE
core: fix the unit in rolling store stats

### DIFF
--- a/server/core/store.go
+++ b/server/core/store.go
@@ -507,9 +507,12 @@ func newRollingStoreStats() *RollingStoreStats {
 	}
 }
 
+const msToSec = uint64(time.Second / time.Millisecond)
+
 // Observe records current statistics.
 func (r *RollingStoreStats) Observe(stats *pdpb.StoreStats) {
-	interval := stats.GetInterval().GetEndTimestamp() - stats.GetInterval().GetStartTimestamp()
+	interval := (stats.GetInterval().GetEndTimestamp() - stats.GetInterval().GetStartTimestamp()) / msToSec
+
 	if interval == 0 {
 		return
 	}


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (required)
The unit of the interval will change from second to milliseconds. make a corresponding change.
<!--
Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- Summarize your change (required)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional).

Please **NOTE** that:
- Do not assume the code is self-evident
- Do not assume reviewers understand the original issue
-->

## What are the type of the changes (required)?
<!--
The currently defined types are listed below, please pick one of the types for this PR by removing the others:
-->
- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested (required)?
<!--
Please describe the tests that you ran to verify your changes. Have you finished unit tests, integration tests, or manual tests?
-->
unit test
## Does this PR affect documentation (docs/docs-cn) update? (optional)
<!--
If there is document change, please file a PR in ([docs](https://github.com/pingcap/docs) and [docs-cn](https://github.com/pingcap/docs-cn)) and add the PR number here.
-->
## Refer to a related PR or issue link (optional)
https://github.com/pingcap/tikv/pull/3256
## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

