### PR TITLE
send back HTTP 400 where there is a client error

### DIFF
--- a/server/api/admin.go
+++ b/server/api/admin.go
@@ -45,7 +45,7 @@ func (h *adminHandler) HandleDropCacheRegion(w http.ResponseWriter, r *http.Requ
 	regionIDStr := vars["id"]
 	regionID, err := strconv.ParseUint(regionIDStr, 10, 64)
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	cluster.DropCacheRegion(regionID)

--- a/server/api/config.go
+++ b/server/api/config.go
@@ -74,9 +74,7 @@ func (h *confHandler) GetSchedule(w http.ResponseWriter, r *http.Request) {
 
 func (h *confHandler) SetSchedule(w http.ResponseWriter, r *http.Request) {
 	config := h.svr.GetScheduleConfig()
-	err := readJSON(r.Body, config)
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+	if err := jsonRespondError(h.rd, w, r.Body, &config); err != nil {
 		return
 	}
 
@@ -93,9 +91,7 @@ func (h *confHandler) GetReplication(w http.ResponseWriter, r *http.Request) {
 
 func (h *confHandler) SetReplication(w http.ResponseWriter, r *http.Request) {
 	config := h.svr.GetReplicationConfig()
-	err := readJSON(r.Body, config)
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+	if err := jsonRespondError(h.rd, w, r.Body, &config); err != nil {
 		return
 	}
 
@@ -108,7 +104,7 @@ func (h *confHandler) GetNamespace(w http.ResponseWriter, r *http.Request) {
 	name := vars["name"]
 
 	if !h.svr.IsNamespaceExist(name) {
-		h.rd.JSON(w, http.StatusInternalServerError, fmt.Sprintf("invalid namespace Name %s, not found", name))
+		h.rd.JSON(w, http.StatusNotFound, fmt.Sprintf("invalid namespace Name %s, not found", name))
 		return
 	}
 
@@ -122,14 +118,12 @@ func (h *confHandler) SetNamespace(w http.ResponseWriter, r *http.Request) {
 	name := vars["name"]
 
 	if !h.svr.IsNamespaceExist(name) {
-		h.rd.JSON(w, http.StatusInternalServerError, fmt.Sprintf("invalid namespace Name %s, not found", name))
+		h.rd.JSON(w, http.StatusNotFound, fmt.Sprintf("invalid namespace Name %s, not found", name))
 		return
 	}
 
 	config := h.svr.GetNamespaceConfig(name)
-	err := readJSON(r.Body, config)
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+	if err := jsonRespondError(h.rd, w, r.Body, &config); err != nil {
 		return
 	}
 
@@ -142,7 +136,7 @@ func (h *confHandler) DeleteNamespace(w http.ResponseWriter, r *http.Request) {
 	name := vars["name"]
 
 	if !h.svr.IsNamespaceExist(name) {
-		h.rd.JSON(w, http.StatusInternalServerError, fmt.Sprintf("invalid namespace Name %s, not found", name))
+		h.rd.JSON(w, http.StatusNotFound, fmt.Sprintf("invalid namespace Name %s, not found", name))
 		return
 	}
 	h.svr.DeleteNamespaceConfig(name)
@@ -156,11 +150,10 @@ func (h *confHandler) GetLabelProperty(w http.ResponseWriter, r *http.Request) {
 
 func (h *confHandler) SetLabelProperty(w http.ResponseWriter, r *http.Request) {
 	input := make(map[string]string)
-	err := readJSON(r.Body, &input)
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+	if err := jsonRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
+	var err error
 	switch input["action"] {
 	case "set":
 		err = h.svr.SetLabelProperty(input["type"], input["label-key"], input["label-value"])

--- a/server/api/config.go
+++ b/server/api/config.go
@@ -74,7 +74,7 @@ func (h *confHandler) GetSchedule(w http.ResponseWriter, r *http.Request) {
 
 func (h *confHandler) SetSchedule(w http.ResponseWriter, r *http.Request) {
 	config := h.svr.GetScheduleConfig()
-	if err := jsonRespondError(h.rd, w, r.Body, &config); err != nil {
+	if err := readJSONRespondError(h.rd, w, r.Body, &config); err != nil {
 		return
 	}
 
@@ -91,7 +91,7 @@ func (h *confHandler) GetReplication(w http.ResponseWriter, r *http.Request) {
 
 func (h *confHandler) SetReplication(w http.ResponseWriter, r *http.Request) {
 	config := h.svr.GetReplicationConfig()
-	if err := jsonRespondError(h.rd, w, r.Body, &config); err != nil {
+	if err := readJSONRespondError(h.rd, w, r.Body, &config); err != nil {
 		return
 	}
 
@@ -123,7 +123,7 @@ func (h *confHandler) SetNamespace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	config := h.svr.GetNamespaceConfig(name)
-	if err := jsonRespondError(h.rd, w, r.Body, &config); err != nil {
+	if err := readJSONRespondError(h.rd, w, r.Body, &config); err != nil {
 		return
 	}
 
@@ -150,7 +150,7 @@ func (h *confHandler) GetLabelProperty(w http.ResponseWriter, r *http.Request) {
 
 func (h *confHandler) SetLabelProperty(w http.ResponseWriter, r *http.Request) {
 	input := make(map[string]string)
-	if err := jsonRespondError(h.rd, w, r.Body, &input); err != nil {
+	if err := readJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
 	var err error

--- a/server/api/log.go
+++ b/server/api/log.go
@@ -46,7 +46,7 @@ func (h *logHandler) Handle(w http.ResponseWriter, r *http.Request) {
 	}
 	err = json.Unmarshal(data, &level)
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/server/api/member.go
+++ b/server/api/member.go
@@ -96,7 +96,7 @@ func (h *memberHandler) DeleteByID(w http.ResponseWriter, r *http.Request) {
 	idStr := mux.Vars(r)["id"]
 	id, err := strconv.ParseUint(idStr, 10, 64)
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -117,9 +117,9 @@ func (h *memberHandler) DeleteByID(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *memberHandler) SetMemberPropertyByName(w http.ResponseWriter, r *http.Request) {
-	members, err := h.listMembers()
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+	members, membersErr := h.listMembers()
+	if membersErr != nil {
+		h.rd.JSON(w, http.StatusInternalServerError, membersErr.Error())
 		return
 	}
 
@@ -137,8 +137,7 @@ func (h *memberHandler) SetMemberPropertyByName(w http.ResponseWriter, r *http.R
 	}
 
 	var input map[string]interface{}
-	if err = readJSON(r.Body, &input); err != nil {
-		h.rd.JSON(w, http.StatusBadRequest, err.Error())
+	if err := jsonRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
 	for k, v := range input {
@@ -149,7 +148,7 @@ func (h *memberHandler) SetMemberPropertyByName(w http.ResponseWriter, r *http.R
 				h.rd.JSON(w, http.StatusBadRequest, "bad format leader priority")
 				return
 			}
-			err = h.svr.SetMemberLeaderPriority(memberID, int(priority))
+			err := h.svr.SetMemberLeaderPriority(memberID, int(priority))
 			if err != nil {
 				h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 				return

--- a/server/api/member.go
+++ b/server/api/member.go
@@ -137,7 +137,7 @@ func (h *memberHandler) SetMemberPropertyByName(w http.ResponseWriter, r *http.R
 	}
 
 	var input map[string]interface{}
-	if err := jsonRespondError(h.rd, w, r.Body, &input); err != nil {
+	if err := readJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
 	for k, v := range input {

--- a/server/api/operator.go
+++ b/server/api/operator.go
@@ -40,7 +40,7 @@ func (h *operatorHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 	regionID, err := strconv.ParseUint(id, 10, 64)
 	if err != nil {
-		h.r.JSON(w, http.StatusInternalServerError, err.Error())
+		h.r.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -90,14 +90,13 @@ func (h *operatorHandler) List(w http.ResponseWriter, r *http.Request) {
 
 func (h *operatorHandler) Post(w http.ResponseWriter, r *http.Request) {
 	var input map[string]interface{}
-	if err := readJSON(r.Body, &input); err != nil {
-		h.r.JSON(w, http.StatusInternalServerError, err.Error())
+	if err := jsonRespondError(h.r, w, r.Body, &input); err != nil {
 		return
 	}
 
 	name, ok := input["name"].(string)
 	if !ok {
-		h.r.JSON(w, http.StatusInternalServerError, "missing operator name")
+		h.r.JSON(w, http.StatusBadRequest, "missing operator name")
 		return
 	}
 
@@ -234,7 +233,7 @@ func (h *operatorHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 	regionID, err := strconv.ParseUint(id, 10, 64)
 	if err != nil {
-		h.r.JSON(w, http.StatusInternalServerError, err.Error())
+		h.r.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/server/api/operator.go
+++ b/server/api/operator.go
@@ -90,7 +90,7 @@ func (h *operatorHandler) List(w http.ResponseWriter, r *http.Request) {
 
 func (h *operatorHandler) Post(w http.ResponseWriter, r *http.Request) {
 	var input map[string]interface{}
-	if err := jsonRespondError(h.r, w, r.Body, &input); err != nil {
+	if err := readJSONRespondError(h.r, w, r.Body, &input); err != nil {
 		return
 	}
 

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -92,7 +92,7 @@ func (h *regionHandler) GetRegionByID(w http.ResponseWriter, r *http.Request) {
 	regionIDStr := vars["id"]
 	regionID, err := strconv.ParseUint(regionIDStr, 10, 64)
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -203,12 +203,12 @@ func (h *regionsHandler) GetRegionSiblings(w http.ResponseWriter, r *http.Reques
 	vars := mux.Vars(r)
 	id, err := strconv.Atoi(vars["id"])
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	region := cluster.GetRegionInfoByID(uint64(id))
 	if region == nil {
-		h.rd.JSON(w, http.StatusInternalServerError, server.ErrRegionNotFound(uint64(id)).Error())
+		h.rd.JSON(w, http.StatusNotFound, server.ErrRegionNotFound(uint64(id)).Error())
 		return
 	}
 

--- a/server/api/scheduler.go
+++ b/server/api/scheduler.go
@@ -44,8 +44,7 @@ func (h *schedulerHandler) List(w http.ResponseWriter, r *http.Request) {
 
 func (h *schedulerHandler) Post(w http.ResponseWriter, r *http.Request) {
 	var input map[string]interface{}
-	if err := readJSON(r.Body, &input); err != nil {
-		h.r.JSON(w, http.StatusInternalServerError, err.Error())
+	if err := jsonRespondError(h.r, w, r.Body, &input); err != nil {
 		return
 	}
 

--- a/server/api/scheduler.go
+++ b/server/api/scheduler.go
@@ -44,7 +44,7 @@ func (h *schedulerHandler) List(w http.ResponseWriter, r *http.Request) {
 
 func (h *schedulerHandler) Post(w http.ResponseWriter, r *http.Request) {
 	var input map[string]interface{}
-	if err := jsonRespondError(h.r, w, r.Body, &input); err != nil {
+	if err := readJSONRespondError(h.r, w, r.Body, &input); err != nil {
 		return
 	}
 

--- a/server/api/store.go
+++ b/server/api/store.go
@@ -141,7 +141,7 @@ func (h *storeHandler) Get(w http.ResponseWriter, r *http.Request) {
 	storeIDStr := vars["id"]
 	storeID, err := strconv.ParseUint(storeIDStr, 10, 64)
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -166,7 +166,7 @@ func (h *storeHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	storeIDStr := vars["id"]
 	storeID, err := strconv.ParseUint(storeIDStr, 10, 64)
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -196,7 +196,7 @@ func (h *storeHandler) SetState(w http.ResponseWriter, r *http.Request) {
 	storeIDStr := vars["id"]
 	storeID, err := strconv.ParseUint(storeIDStr, 10, 64)
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -227,13 +227,12 @@ func (h *storeHandler) SetLabels(w http.ResponseWriter, r *http.Request) {
 	storeIDStr := vars["id"]
 	storeID, err := strconv.ParseUint(storeIDStr, 10, 64)
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
 	var input map[string]string
-	if err := readJSON(r.Body, &input); err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+	if err := jsonRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
 
@@ -264,13 +263,12 @@ func (h *storeHandler) SetWeight(w http.ResponseWriter, r *http.Request) {
 	storeIDStr := vars["id"]
 	storeID, err := strconv.ParseUint(storeIDStr, 10, 64)
 	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
 	var input map[string]interface{}
-	if err := readJSON(r.Body, &input); err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+	if err := jsonRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
 

--- a/server/api/store.go
+++ b/server/api/store.go
@@ -232,7 +232,7 @@ func (h *storeHandler) SetLabels(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var input map[string]string
-	if err := jsonRespondError(h.rd, w, r.Body, &input); err != nil {
+	if err := readJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
 
@@ -268,7 +268,7 @@ func (h *storeHandler) SetWeight(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var input map[string]interface{}
-	if err := jsonRespondError(h.rd, w, r.Body, &input); err != nil {
+	if err := readJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
 

--- a/server/api/util.go
+++ b/server/api/util.go
@@ -21,8 +21,23 @@ import (
 	"net/http"
 
 	"github.com/juju/errors"
+	"github.com/pingcap/pd/pkg/apiutil"
 	"github.com/pingcap/pd/server"
+	"github.com/unrolled/render"
 )
+
+func jsonRespondError(r *render.Render, w http.ResponseWriter, body io.ReadCloser, data interface{}) (err error) {
+	if err = apiutil.ReadJSON(body, data); err != nil {
+		switch err.(type) {
+		case apiutil.JSONError:
+			r.JSON(w, http.StatusBadRequest, err.Error())
+		default:
+			r.JSON(w, http.StatusInternalServerError, err.Error())
+
+		}
+	}
+	return
+}
 
 func readJSON(r io.ReadCloser, data interface{}) error {
 	defer r.Close()

--- a/server/api/util.go
+++ b/server/api/util.go
@@ -26,17 +26,18 @@ import (
 	"github.com/unrolled/render"
 )
 
-func jsonRespondError(r *render.Render, w http.ResponseWriter, body io.ReadCloser, data interface{}) (err error) {
-	if err = apiutil.ReadJSON(body, data); err != nil {
-		switch err.(type) {
-		case apiutil.JSONError:
-			r.JSON(w, http.StatusBadRequest, err.Error())
-		default:
-			r.JSON(w, http.StatusInternalServerError, err.Error())
-
-		}
+func jsonRespondError(r *render.Render, w http.ResponseWriter, body io.ReadCloser, data interface{}) error {
+	err := apiutil.ReadJSON(body, data)
+	if err == nil {
+		return nil
 	}
-	return
+	switch err.(type) {
+	case apiutil.JSONError:
+		r.JSON(w, http.StatusBadRequest, err.Error())
+	default:
+		r.JSON(w, http.StatusInternalServerError, err.Error())
+	}
+	return err
 }
 
 func readJSON(r io.ReadCloser, data interface{}) error {

--- a/server/api/util.go
+++ b/server/api/util.go
@@ -26,7 +26,7 @@ import (
 	"github.com/unrolled/render"
 )
 
-func jsonRespondError(r *render.Render, w http.ResponseWriter, body io.ReadCloser, data interface{}) error {
+func readJSONRespondError(r *render.Render, w http.ResponseWriter, body io.ReadCloser, data interface{}) error {
 	err := apiutil.ReadJSON(body, data)
 	if err == nil {
 		return nil

--- a/server/api/util_test.go
+++ b/server/api/util_test.go
@@ -1,0 +1,73 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http/httptest"
+
+	. "github.com/pingcap/check"
+	"github.com/unrolled/render"
+)
+
+var _ = Suite(&testUtilSuite{})
+
+type testUtilSuite struct{}
+
+type nopCloser struct {
+	io.Reader
+}
+
+func (nopCloser) Close() error { return nil }
+
+func (s *testUtilSuite) TestJsonRespondErrorOk(c *C) {
+	rd := render.New(render.Options{
+		IndentJSON: true,
+	})
+	response := httptest.NewRecorder()
+	body := nopCloser{bytes.NewBufferString("{\"zone\":\"cn\", \"host\":\"local\"}")}
+	var input map[string]string
+	output := map[string]string{"zone": "cn", "host": "local"}
+	err := jsonRespondError(rd, response, body, &input)
+	c.Assert(err, IsNil)
+	c.Assert(input["zone"], Equals, output["zone"])
+	c.Assert(input["host"], Equals, output["host"])
+	result := response.Result()
+	c.Assert(result.StatusCode, Equals, 200)
+}
+
+func (s *testUtilSuite) TestJsonRespondErrorBadInput(c *C) {
+	rd := render.New(render.Options{
+		IndentJSON: true,
+	})
+	response := httptest.NewRecorder()
+	body := nopCloser{bytes.NewBufferString("{\"zone\":\"cn\", \"host\":\"local\"}")}
+	var input []string
+	err := jsonRespondError(rd, response, body, &input)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "json: cannot unmarshal object into Go value of type []string")
+	result := response.Result()
+	c.Assert(result.StatusCode, Equals, 400)
+
+	{
+		body := nopCloser{bytes.NewBufferString("{\"zone\":\"cn\",")}
+		var input []string
+		err := jsonRespondError(rd, response, body, &input)
+		c.Assert(err, NotNil)
+		c.Assert(err.Error(), Equals, "unexpected end of JSON input")
+		result := response.Result()
+		c.Assert(result.StatusCode, Equals, 400)
+	}
+}

--- a/server/api/util_test.go
+++ b/server/api/util_test.go
@@ -15,7 +15,7 @@ package api
 
 import (
 	"bytes"
-	"io"
+	"io/ioutil"
 	"net/http/httptest"
 
 	. "github.com/pingcap/check"
@@ -26,18 +26,12 @@ var _ = Suite(&testUtilSuite{})
 
 type testUtilSuite struct{}
 
-type nopCloser struct {
-	io.Reader
-}
-
-func (nopCloser) Close() error { return nil }
-
 func (s *testUtilSuite) TestJsonRespondErrorOk(c *C) {
 	rd := render.New(render.Options{
 		IndentJSON: true,
 	})
 	response := httptest.NewRecorder()
-	body := nopCloser{bytes.NewBufferString("{\"zone\":\"cn\", \"host\":\"local\"}")}
+	body := ioutil.NopCloser(bytes.NewBufferString("{\"zone\":\"cn\", \"host\":\"local\"}"))
 	var input map[string]string
 	output := map[string]string{"zone": "cn", "host": "local"}
 	err := jsonRespondError(rd, response, body, &input)
@@ -53,7 +47,7 @@ func (s *testUtilSuite) TestJsonRespondErrorBadInput(c *C) {
 		IndentJSON: true,
 	})
 	response := httptest.NewRecorder()
-	body := nopCloser{bytes.NewBufferString("{\"zone\":\"cn\", \"host\":\"local\"}")}
+	body := ioutil.NopCloser(bytes.NewBufferString("{\"zone\":\"cn\", \"host\":\"local\"}"))
 	var input []string
 	err := jsonRespondError(rd, response, body, &input)
 	c.Assert(err, NotNil)
@@ -62,7 +56,7 @@ func (s *testUtilSuite) TestJsonRespondErrorBadInput(c *C) {
 	c.Assert(result.StatusCode, Equals, 400)
 
 	{
-		body := nopCloser{bytes.NewBufferString("{\"zone\":\"cn\",")}
+		body := ioutil.NopCloser(bytes.NewBufferString("{\"zone\":\"cn\","))
 		var input []string
 		err := jsonRespondError(rd, response, body, &input)
 		c.Assert(err, NotNil)

--- a/server/api/util_test.go
+++ b/server/api/util_test.go
@@ -34,7 +34,7 @@ func (s *testUtilSuite) TestJsonRespondErrorOk(c *C) {
 	body := ioutil.NopCloser(bytes.NewBufferString("{\"zone\":\"cn\", \"host\":\"local\"}"))
 	var input map[string]string
 	output := map[string]string{"zone": "cn", "host": "local"}
-	err := jsonRespondError(rd, response, body, &input)
+	err := readJSONRespondError(rd, response, body, &input)
 	c.Assert(err, IsNil)
 	c.Assert(input["zone"], Equals, output["zone"])
 	c.Assert(input["host"], Equals, output["host"])
@@ -49,7 +49,7 @@ func (s *testUtilSuite) TestJsonRespondErrorBadInput(c *C) {
 	response := httptest.NewRecorder()
 	body := ioutil.NopCloser(bytes.NewBufferString("{\"zone\":\"cn\", \"host\":\"local\"}"))
 	var input []string
-	err := jsonRespondError(rd, response, body, &input)
+	err := readJSONRespondError(rd, response, body, &input)
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "json: cannot unmarshal object into Go value of type []string")
 	result := response.Result()
@@ -58,7 +58,7 @@ func (s *testUtilSuite) TestJsonRespondErrorBadInput(c *C) {
 	{
 		body := ioutil.NopCloser(bytes.NewBufferString("{\"zone\":\"cn\","))
 		var input []string
-		err := jsonRespondError(rd, response, body, &input)
+		err := readJSONRespondError(rd, response, body, &input)
 		c.Assert(err, NotNil)
 		c.Assert(err.Error(), Equals, "unexpected end of JSON input")
 		result := response.Result()

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 PingCAP, Inc.
+// Copyright 2018 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/table/namespace_handler.go
+++ b/table/namespace_handler.go
@@ -14,6 +14,7 @@
 package table
 
 import (
+	"io"
 	"net/http"
 	"strconv"
 
@@ -56,11 +57,23 @@ func (h *tableNamespaceHandler) Get(w http.ResponseWriter, r *http.Request) {
 	h.rd.JSON(w, http.StatusOK, nsInfo)
 }
 
+func jsonRespondError(r *render.Render, w http.ResponseWriter, body io.ReadCloser, data interface{}) (err error) {
+	if err = apiutil.ReadJSON(body, &data); err != nil {
+		switch err.(type) {
+		case apiutil.JSONError:
+			r.JSON(w, http.StatusBadRequest, err.Error())
+		default:
+			r.JSON(w, http.StatusInternalServerError, err.Error())
+
+		}
+	}
+	return
+}
+
 // Post creates a namespace.
 func (h *tableNamespaceHandler) Post(w http.ResponseWriter, r *http.Request) {
 	var input map[string]string
-	if err := apiutil.ReadJSON(r.Body, &input); err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+	if err := jsonRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
 	ns := input["namespace"]
@@ -76,8 +89,7 @@ func (h *tableNamespaceHandler) Post(w http.ResponseWriter, r *http.Request) {
 
 func (h *tableNamespaceHandler) Update(w http.ResponseWriter, r *http.Request) {
 	var input map[string]string
-	if err := apiutil.ReadJSON(r.Body, &input); err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+	if err := jsonRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
 	tableIDStr := input["table_id"]
@@ -116,8 +128,7 @@ func (h *tableNamespaceHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 func (h *tableNamespaceHandler) SetMetaNamespace(w http.ResponseWriter, r *http.Request) {
 	var input map[string]string
-	if err := apiutil.ReadJSON(r.Body, &input); err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+	if err := jsonRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
 	ns := input["namespace"]
@@ -149,8 +160,7 @@ func (h *tableNamespaceHandler) SetNamespace(w http.ResponseWriter, r *http.Requ
 	}
 
 	var input map[string]string
-	if err := apiutil.ReadJSON(r.Body, &input); err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+	if err := jsonRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
 	ns := input["namespace"]

--- a/table/namespace_handler.go
+++ b/table/namespace_handler.go
@@ -57,7 +57,7 @@ func (h *tableNamespaceHandler) Get(w http.ResponseWriter, r *http.Request) {
 	h.rd.JSON(w, http.StatusOK, nsInfo)
 }
 
-func jsonRespondError(r *render.Render, w http.ResponseWriter, body io.ReadCloser, data interface{}) (err error) {
+func readJSONRespondError(r *render.Render, w http.ResponseWriter, body io.ReadCloser, data interface{}) (err error) {
 	if err = apiutil.ReadJSON(body, &data); err != nil {
 		switch err.(type) {
 		case apiutil.JSONError:
@@ -73,7 +73,7 @@ func jsonRespondError(r *render.Render, w http.ResponseWriter, body io.ReadClose
 // Post creates a namespace.
 func (h *tableNamespaceHandler) Post(w http.ResponseWriter, r *http.Request) {
 	var input map[string]string
-	if err := jsonRespondError(h.rd, w, r.Body, &input); err != nil {
+	if err := readJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
 	ns := input["namespace"]
@@ -89,7 +89,7 @@ func (h *tableNamespaceHandler) Post(w http.ResponseWriter, r *http.Request) {
 
 func (h *tableNamespaceHandler) Update(w http.ResponseWriter, r *http.Request) {
 	var input map[string]string
-	if err := jsonRespondError(h.rd, w, r.Body, &input); err != nil {
+	if err := readJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
 	tableIDStr := input["table_id"]
@@ -128,7 +128,7 @@ func (h *tableNamespaceHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 func (h *tableNamespaceHandler) SetMetaNamespace(w http.ResponseWriter, r *http.Request) {
 	var input map[string]string
-	if err := jsonRespondError(h.rd, w, r.Body, &input); err != nil {
+	if err := readJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
 	ns := input["namespace"]
@@ -160,7 +160,7 @@ func (h *tableNamespaceHandler) SetNamespace(w http.ResponseWriter, r *http.Requ
 	}
 
 	var input map[string]string
-	if err := jsonRespondError(h.rd, w, r.Body, &input); err != nil {
+	if err := readJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
 	ns := input["namespace"]


### PR DESCRIPTION
## What have you changed? (required)

pd server

We often send a 500 error where it should be 400 or 404.
It is important to get these right.
A client will assume it did nothing wrong when a 500 is received
and perhaps automatically retry the request.

This is a conservative change in that
there are many more places that should be changed from 500 to 400 or 404.
Mostly this is due to not investing more time to understand the entire code base.
In some cases, functions are called which don't differentiate error types properly.
A forthcoming PR will provide some help in this case.

A helper function `jsonRespondError` is added.


## What are the type of the changes (required)?

- Breaking change

I can only assume that most client code is not differentiating between 400 and 500 error codes. In that case there will not be any breakage.

## How has this PR been tested (required)?

There is a new test suite for the jsonRespondError helper.
Otherwise the test suite was ran and I was surprised that no tests broke.


## Does this PR affect documentation (docs/docs-cn) update? (optional)

There is a PR to add an API specification. That would need to be updated to add more 400 entries.

