### PR TITLE
schedulers: fix the panic issue when no operator produce by adjacent region scheduler (#1136)

### DIFF
--- a/server/schedulers/adjacent_region.go
+++ b/server/schedulers/adjacent_region.go
@@ -218,6 +218,7 @@ func (l *balanceAdjacentRegionScheduler) process(cluster schedule.Cluster) []*sc
 	if op == nil {
 		schedulerCounter.WithLabelValues(l.GetName(), "no_peer").Inc()
 		l.cacheRegions.assignedStoreIds = l.cacheRegions.assignedStoreIds[:0]
+		return nil
 	}
 	return []*schedule.Operator{op}
 }

--- a/server/schedulers/scheduler_test.go
+++ b/server/schedulers/scheduler_test.go
@@ -108,6 +108,24 @@ func (s *testBalanceAdjacentRegionSuite) TestBalance(c *C) {
 	}
 }
 
+func (s *testBalanceAdjacentRegionSuite) TestNoNeedToBalance(c *C) {
+	opt := schedule.NewMockSchedulerOptions()
+	tc := schedule.NewMockCluster(opt)
+
+	sc, err := schedule.CreateScheduler("adjacent-region", schedule.NewLimiter())
+	c.Assert(err, IsNil)
+	c.Assert(sc.Schedule(tc, schedule.NewOpInfluence(nil, tc)), IsNil)
+
+	// Add stores 1,2,3
+	tc.AddLeaderStore(1, 2)
+	tc.AddLeaderStore(2, 0)
+	tc.AddLeaderStore(3, 0)
+
+	tc.AddLeaderRegionWithRange(1, "", "a", 1, 2, 3)
+	tc.AddLeaderRegionWithRange(2, "a", "b", 1, 2, 3)
+	c.Assert(sc.Schedule(tc, schedule.NewOpInfluence(nil, tc)), IsNil)
+}
+
 type sequencer struct {
 	maxID uint64
 	curID uint64


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (required)
cherry-pick #1136
<!--
Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- Summarize your change (required)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

Please **NOTE** that:
- Do not assume the code is self-evident
- Do not assume reviewers understand the original issue
-->

## What are the type of the changes (required)?

<!--
The currently defined types are listed below, please pick one of the types for this PR by removing the others:
-->- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested (required)?
<!--
Please describe the tests that you ran to verify your changes. Have you finished unit tests, integration tests, or manual tests?
-->
make dev
## Does this PR affect documentation (docs/docs-cn) update? (optional)
<!--
If there is document change, please file a PR in ([docs](https://github.com/pingcap/docs) and [docs-cn](https://github.com/pingcap/docs-cn)) and add the PR number here.
-->
## Refer to a related PR or issue link (optional)
#1136
## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

