### PR TITLE
run errcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,14 @@ test:
 basic_test:
 	go test $(BASIC_TEST_PKGS)
 
+setup:
+	go get github.com/twitchtv/retool
+	retool add gopkg.in/alecthomas/gometalinter.v2 v2.0.5
+	retool add github.com/kisielk/errcheck v1.1.0
+
+check-slow:
+	CGO_ENABLED=0 retool do gometalinter.v2 --disable-all --enable errcheck server
+
 check:
 	go get github.com/golang/lint/golint
 


### PR DESCRIPTION
This is an example of running errcheck. It is not ready for merge but needs some changes to be ran against all packages efficiently.

```
CGO_ENABLED=0 retool do gometalinter.v2 --disable-all --enable errcheck server
server/coordinator.go:390:31:warning: error return value not checked (c.cluster.opt.AddSchedulerCfg(s.GetType(), args)) (errcheck)
server/join.go:97:20:warning: error return value not checked (defer client.Close()) (errcheck)
server/join.go:150:17:warning: error return value not checked (defer dir.Close()) (errcheck)
server/leader.go:208:20:warning: error return value not checked (defer lessor.Close()) (errcheck)
server/leader.go:297:21:warning: error return value not checked (defer watcher.Close()) (errcheck)
server/server.go:244:17:warning: error return value not checked (s.client.Close()) (errcheck)
server/server.go:461:23:warning: error return value not checked (s.scheduleOpt.persist(s.kv)) (errcheck)
server/server.go:497:24:warning: error return value not checked (s.scheduleOpt.persist(s.kv)) (errcheck)
server/server.go:501:24:warning: error return value not checked (s.scheduleOpt.persist(s.kv)) (errcheck)
server/server.go:511:24:warning: error return value not checked (s.scheduleOpt.persist(s.kv)) (errcheck)
server/server.go:646:20:warning: error return value not checked (resp.Body.Close()) (errcheck)
server/testutil.go:38:14:warning: error return value not checked (os.RemoveAll(cfg.DataDir)) (errcheck)
server/testutil.go:82:12:warning: error return value not checked (cfg.adjust(nil)) (errcheck)
retool: fatal err: failed on 'gometalinter.v2 --disable-all --enable errcheck server': exit status 1
Makefile:51: recipe for target 'check-slow' failed
make: *** [check-slow] Error 1
```