### PR TITLE
schedulers: make hot region scheduler respect schedule limit

### DIFF
--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -1034,6 +1034,13 @@ func (s *testBalanceHotWriteRegionSchedulerSuite) TestBalance(c *C) {
 			testutil.CheckTransferPeerWithLeaderTransfer(c, op[0], schedule.OpHotRegion, 1, 6)
 		}
 	}
+
+	// hot region scheduler is restricted by schedule limit.
+	opt.RegionScheduleLimit, opt.LeaderScheduleLimit = 0, 0
+	c.Assert(hb.Schedule(tc, schedule.NewOpInfluence(nil, tc)), HasLen, 0)
+	opt.LeaderScheduleLimit = schedule.NewMockSchedulerOptions().LeaderScheduleLimit
+	opt.RegionScheduleLimit = schedule.NewMockSchedulerOptions().RegionScheduleLimit
+
 	// After transfer a hot region from store 1 to store 5
 	//| region_id | leader_sotre | follower_store | follower_store | written_bytes |
 	//|-----------|--------------|----------------|----------------|---------------|
@@ -1056,6 +1063,11 @@ func (s *testBalanceHotWriteRegionSchedulerSuite) TestBalance(c *C) {
 	// We can find that the leader of all hot regions are on store 1,
 	// so one of the leader will transfer to another store.
 	testutil.CheckTransferLeaderFrom(c, hb.Schedule(tc, schedule.NewOpInfluence(nil, tc))[0], schedule.OpHotRegion, 1)
+
+	// hot region scheduler is restricted by schedule limit.
+	opt.LeaderScheduleLimit = 0
+	c.Assert(hb.Schedule(tc, schedule.NewOpInfluence(nil, tc)), HasLen, 0)
+	opt.LeaderScheduleLimit = schedule.NewMockSchedulerOptions().LeaderScheduleLimit
 
 	// Should not panic if region not found.
 	for i := uint64(1); i <= 3; i++ {

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -119,7 +119,17 @@ func (h *balanceHotRegionsScheduler) GetType() string {
 }
 
 func (h *balanceHotRegionsScheduler) IsScheduleAllowed(cluster schedule.Cluster) bool {
-	return h.limiter.OperatorCount(schedule.OpHotRegion) < h.limit
+	return h.allowBalanceLeader(cluster) || h.allowBalanceRegion(cluster)
+}
+
+func (h *balanceHotRegionsScheduler) allowBalanceLeader(cluster schedule.Cluster) bool {
+	return h.limiter.OperatorCount(schedule.OpHotRegion) < h.limit &&
+		h.limiter.OperatorCount(schedule.OpLeader) < cluster.GetLeaderScheduleLimit()
+}
+
+func (h *balanceHotRegionsScheduler) allowBalanceRegion(cluster schedule.Cluster) bool {
+	return h.limiter.OperatorCount(schedule.OpHotRegion) < h.limit &&
+		h.limiter.OperatorCount(schedule.OpRegion) < cluster.GetRegionScheduleLimit()
 }
 
 func (h *balanceHotRegionsScheduler) Schedule(cluster schedule.Cluster, opInfluence schedule.OpInfluence) []*schedule.Operator {
@@ -237,7 +247,7 @@ func (h *balanceHotRegionsScheduler) calcScore(items []*core.RegionStat, cluster
 }
 
 func (h *balanceHotRegionsScheduler) balanceByPeer(cluster schedule.Cluster, storesStat core.StoreHotRegionsStat) (*core.RegionInfo, *metapb.Peer, *metapb.Peer) {
-	if h.limiter.OperatorCount(schedule.OpRegion) >= cluster.GetRegionScheduleLimit() {
+	if !h.allowBalanceRegion(cluster) {
 		return nil, nil, nil
 	}
 
@@ -299,7 +309,7 @@ func (h *balanceHotRegionsScheduler) balanceByPeer(cluster schedule.Cluster, sto
 }
 
 func (h *balanceHotRegionsScheduler) balanceByLeader(cluster schedule.Cluster, storesStat core.StoreHotRegionsStat) (*core.RegionInfo, *metapb.Peer) {
-	if h.limiter.OperatorCount(schedule.OpLeader) >= cluster.GetLeaderScheduleLimit() {
+	if !h.allowBalanceLeader(cluster) {
 		return nil, nil
 	}
 

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -237,6 +237,10 @@ func (h *balanceHotRegionsScheduler) calcScore(items []*core.RegionStat, cluster
 }
 
 func (h *balanceHotRegionsScheduler) balanceByPeer(cluster schedule.Cluster, storesStat core.StoreHotRegionsStat) (*core.RegionInfo, *metapb.Peer, *metapb.Peer) {
+	if h.limiter.OperatorCount(schedule.OpRegion) >= cluster.GetRegionScheduleLimit() {
+		return nil, nil, nil
+	}
+
 	srcStoreID := h.selectSrcStore(storesStat)
 	if srcStoreID == 0 {
 		return nil, nil, nil
@@ -295,6 +299,10 @@ func (h *balanceHotRegionsScheduler) balanceByPeer(cluster schedule.Cluster, sto
 }
 
 func (h *balanceHotRegionsScheduler) balanceByLeader(cluster schedule.Cluster, storesStat core.StoreHotRegionsStat) (*core.RegionInfo, *metapb.Peer) {
+	if h.limiter.OperatorCount(schedule.OpLeader) >= cluster.GetLeaderScheduleLimit() {
+		return nil, nil
+	}
+
 	srcStoreID := h.selectSrcStore(storesStat)
 	if srcStoreID == 0 {
 		return nil, nil


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (required)
Currently, the HotRegionScheduler adjusts schedule limit by itself. See https://github.com/pingcap/pd/blob/1e8e857d365585af6841a54473a5aca071ede509/server/schedulers/hot_region.go#L393-L405
A problem was found in the test: when there are many hot regions, when some tikv-servers are added, the limit will be updated to a large value, causing in a large number of operators in a short period of time, resulting in a QPS drop.

<!--
Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- Summarize your change (required)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

Please **NOTE** that:
- Do not assume the code is self-evident
- Do not assume reviewers understand the original issue
-->

## What are the type of the changes (required)?

<!--
The currently defined types are listed below, please pick one of the types for this PR by removing the others:
-->
- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (required)?
<!--
Please describe the tests that you ran to verify your changes. Have you finished unit tests, integration tests, or manual tests?
-->
Unit test
## Does this PR affect documentation (docs/docs-cn) update? (optional)
<!--
If there is document change, please file a PR in ([docs](https://github.com/pingcap/docs) and [docs-cn](https://github.com/pingcap/docs-cn)) and add the PR number here.
-->
## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

