### PR TITLE
server/api: adjust the regular expression of the validation label

### DIFF
--- a/server/util.go
+++ b/server/util.go
@@ -252,11 +252,11 @@ func InitHTTPClient(svr *Server) error {
 	return nil
 }
 
-const matchRule = "^[A-Za-z]([A-Za-z0-9_-]*[A-Za-z0-9])?$"
+const matchRule = "^[A-Za-z0-9][-A-Za-z0-9_.]*[A-Za-z0-9]$"
 
 // ValidateLabelString checks the legality of the label string.
-// The valid label only contain alphanumeric characters, hyphens and underscores,
-// must start with a letter but not ending with a hyphen or underscore.
+// The valid label consist of alphanumeric characters, '-', '_' or '.',
+// and must start and end with an alphanumeric character.
 func ValidateLabelString(s string) error {
 	isValid, _ := regexp.MatchString(matchRule, s)
 	if !isValid {

--- a/server/util.go
+++ b/server/util.go
@@ -252,7 +252,7 @@ func InitHTTPClient(svr *Server) error {
 	return nil
 }
 
-const matchRule = "^[A-Za-z0-9][-A-Za-z0-9_.]*[A-Za-z0-9]$"
+const matchRule = "^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$"
 
 // ValidateLabelString checks the legality of the label string.
 // The valid label consist of alphanumeric characters, '-', '_' or '.',

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -59,13 +59,16 @@ func (s *testUtilSuite) TestVerifyLabels(c *C) {
 		{"z_1", false},
 		{"z_1&", true},
 		{"cn", false},
-		{"Zone", false},
+		{"Zo^ne", true},
 		{"z_", true},
 		{"hos&t-15", true},
 		{"_test1", true},
+		{"-test1", true},
+		{"192.168.199.1", false},
+		{"www.pingcap.com", false},
+		{"h_127.0.0.1", false},
 	}
 	for _, t := range tests {
-		err := ValidateLabelString(t.label)
-		c.Assert(err != nil, Equals, t.hasErr)
+		c.Assert(ValidateLabelString(t.label) != nil, Equals, t.hasErr)
 	}
 }

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -67,6 +67,7 @@ func (s *testUtilSuite) TestVerifyLabels(c *C) {
 		{"192.168.199.1", false},
 		{"www.pingcap.com", false},
 		{"h_127.0.0.1", false},
+		{"a", false},
 	}
 	for _, t := range tests {
 		c.Assert(ValidateLabelString(t.label) != nil, Equals, t.hasErr)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (required)
TiDB-Operator uses the hostname as a label value, so adjust the regular expression. same as kubernetes: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set

<!--
Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- Summarize your change (required)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

Please **NOTE** that:
- Do not assume the code is self-evident
- Do not assume reviewers understand the original issue
-->

## What are the type of the changes (required)?

<!--
The currently defined types are listed below, please pick one of the types for this PR by removing the others:
-->
- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (required)?
<!--
Please describe the tests that you ran to verify your changes. Have you finished unit tests, integration tests, or manual tests?
-->
unit test

