### PR TITLE
server: fix wrong log

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -454,7 +454,7 @@ func (c *RaftCluster) checkOperators() {
 		}
 
 		if op.IsTimeout() {
-			log.Infof("[region %v] operator timeout: %s", op.RegionID, op)
+			log.Infof("[region %v] operator timeout: %s", op.RegionID(), op)
 			operatorCounter.WithLabelValues(op.Desc(), "timeout").Inc()
 			co.removeOperator(op)
 		}


### PR DESCRIPTION
## What have you changed? (required)
Fix the wrong log message when an operator timeout.

## What are the type of the changes (required)?
- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested (required)?
None

## Does this PR affect documentation (docs/docs-cn) update? (optional)

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

