### PR TITLE
server: add etcd raft state metrics

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -147,6 +147,14 @@ var (
 			Help:      "Record critical metadata.",
 		}, []string{"type"})
 
+	etcdStateGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "server",
+			Name:      "etcd_state",
+			Help:      "Etcd raft states.",
+		}, []string{"type"})
+
 	patrolCheckRegionsHistogram = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: "pd",
@@ -173,5 +181,6 @@ func init() {
 	prometheus.MustRegister(regionStatusGauge)
 	prometheus.MustRegister(regionLabelLevelGauge)
 	prometheus.MustRegister(metadataGauge)
+	prometheus.MustRegister(etcdStateGauge)
 	prometheus.MustRegister(patrolCheckRegionsHistogram)
 }


### PR DESCRIPTION
## What have you changed? (required)
- add metrics to show etcd raft states
- rename 'leaderLoopXxx' to 'serverLoopXxx'

## What are the type of the changes (required)?
- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (required)?
Test in a cluster with grafana installed

## Does this PR affect documentation (docs/docs-cn) update? (optional)

## Refer to a related PR or issue link (optional)
https://github.com/pingcap/tidb-ansible/pull/480

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

