### PR TITLE
server: reduce the overhead of calculating bytes flow

### DIFF
--- a/server/cluster_info_test.go
+++ b/server/cluster_info_test.go
@@ -78,6 +78,17 @@ func (s *testStoresInfoSuite) TestStores(c *C) {
 	}
 
 	c.Assert(cache.GetStoreCount(), Equals, int(n))
+
+	bytesWritten := uint64(8 * 1024 * 1024)
+	bytesRead := uint64(128 * 1024 * 1024)
+	store := cache.GetStore(1)
+
+	store.Stats.BytesWritten = bytesWritten
+	store.Stats.BytesRead = bytesRead
+	store.Stats.Interval = &pdpb.TimeInterval{EndTimestamp: 10, StartTimestamp: 0}
+	cache.SetStore(store)
+	c.Assert(cache.TotalBytesWriteRate(), Equals, float64(bytesWritten/10))
+	c.Assert(cache.TotalBytesReadRate(), Equals, float64(bytesRead/10))
 }
 
 var _ = Suite(&testRegionsInfoSuite{})

--- a/server/core/region_tree.go
+++ b/server/core/region_tree.go
@@ -28,8 +28,8 @@ type regionItem struct {
 
 // Less returns true if the region start key is less than the other.
 func (r *regionItem) Less(other btree.Item) bool {
-	left := r.region.StartKey
-	right := other.(*regionItem).region.StartKey
+	left := r.region.GetStartKey()
+	right := other.(*regionItem).region.GetStartKey()
 	return bytes.Compare(left, right) < 0
 }
 

--- a/server/core/region_tree.go
+++ b/server/core/region_tree.go
@@ -28,8 +28,8 @@ type regionItem struct {
 
 // Less returns true if the region start key is less than the other.
 func (r *regionItem) Less(other btree.Item) bool {
-	left := r.region.GetStartKey()
-	right := other.(*regionItem).region.GetStartKey()
+	left := r.region.StartKey
+	right := other.(*regionItem).region.StartKey
 	return bytes.Compare(left, right) < 0
 }
 

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -327,7 +327,9 @@ func NewStoreNotFoundErr(storeID uint64) errcode.ErrorCode {
 
 // StoresInfo is a map of storeID to StoreInfo
 type StoresInfo struct {
-	stores map[uint64]*StoreInfo
+	stores         map[uint64]*StoreInfo
+	bytesReadRate  float64
+	bytesWriteRate float64
 }
 
 // NewStoresInfo create a StoresInfo with map of storeID to StoreInfo
@@ -348,8 +350,10 @@ func (s *StoresInfo) GetStore(storeID uint64) *StoreInfo {
 
 // SetStore set a StoreInfo with storeID
 func (s *StoresInfo) SetStore(store *StoreInfo) {
-	store.RollingStoreStats.Observe(store.Stats)
 	s.stores[store.GetId()] = store
+	store.RollingStoreStats.Observe(store.Stats)
+	s.updateTotalBytesReadRate()
+	s.updateTotalBytesWriteRate()
 }
 
 // BlockStore block a StoreInfo with storeID
@@ -432,26 +436,34 @@ func (s *StoresInfo) SetRegionSize(storeID uint64, regionSize int64) {
 	}
 }
 
-// TotalBytesWriteRate returns the total written bytes rate of all StoreInfo.
-func (s *StoresInfo) TotalBytesWriteRate() float64 {
-	var totalWriteBytes float64
+func (s *StoresInfo) updateTotalBytesWriteRate() {
+	var totalBytesWirteRate float64
 	for _, s := range s.stores {
 		if s.IsUp() {
-			totalWriteBytes += s.RollingStoreStats.GetBytesWriteRate()
+			totalBytesWirteRate += s.RollingStoreStats.GetBytesWriteRate()
 		}
 	}
-	return totalWriteBytes
+	s.bytesWriteRate = totalBytesWirteRate
+}
+
+// TotalBytesWriteRate returns the total written bytes rate of all StoreInfo.
+func (s *StoresInfo) TotalBytesWriteRate() float64 {
+	return s.bytesWriteRate
+}
+
+func (s *StoresInfo) updateTotalBytesReadRate() {
+	var totalBytesReadRate float64
+	for _, s := range s.stores {
+		if s.IsUp() {
+			totalBytesReadRate += s.RollingStoreStats.GetBytesReadRate()
+		}
+	}
+	s.bytesReadRate = totalBytesReadRate
 }
 
 // TotalBytesReadRate returns the total read bytes rate of all StoreInfo.
 func (s *StoresInfo) TotalBytesReadRate() float64 {
-	var totalReadBytes float64
-	for _, s := range s.stores {
-		if s.IsUp() {
-			totalReadBytes += s.RollingStoreStats.GetBytesReadRate()
-		}
-	}
-	return totalReadBytes
+	return s.bytesReadRate
 }
 
 // GetStoresBytesWriteStat returns the bytes write stat of all StoreInfo.

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -325,7 +325,7 @@ func NewStoreNotFoundErr(storeID uint64) errcode.ErrorCode {
 	return errcode.NewNotFoundErr(storeNotFoundErr{storeID})
 }
 
-// StoresInfo is a map of storeID to StoreInfo
+// StoresInfo contains information about all stores.
 type StoresInfo struct {
 	stores         map[uint64]*StoreInfo
 	bytesReadRate  float64


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (required)

<!--
Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- Summarize your change (required)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

Please **NOTE** that:
- Do not assume the code is self-evident
- Do not assume reviewers understand the original issue
-->
Now PD will calculate the total bytes flow once region heartbeat coming, this is an extra cost. After this change, only calculate the bytes flow when store heartbeat coming. 
## What are the type of the changes (required)?

<!--
The currently defined types are listed below, please pick one of the types for this PR by removing the others:
-->
- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (required)?
<!--
Please describe the tests that you ran to verify your changes. Have you finished unit tests, integration tests, or manual tests?
-->
unit test

