### PR TITLE
schedulers: fix the issue that the operator kind is not set correctly

### DIFF
--- a/server/schedule/operator.go
+++ b/server/schedule/operator.go
@@ -474,8 +474,8 @@ func CreateMergeRegionOperator(desc string, cluster Cluster, source *core.Region
 		IsPassive:  false,
 	})
 
-	op1 := NewOperator(desc, source.GetId(), source.GetRegionEpoch(), kinds|kind, steps...)
-	op2 := NewOperator(desc, target.GetId(), target.GetRegionEpoch(), kind, MergeRegion{
+	op1 := NewOperator(desc, source.GetId(), source.GetRegionEpoch(), kinds|kind|OpMerge, steps...)
+	op2 := NewOperator(desc, target.GetId(), target.GetRegionEpoch(), kind|OpMerge, MergeRegion{
 		FromRegion: source.Region,
 		ToRegion:   target.Region,
 		IsPassive:  true,

--- a/server/schedule/operator_kind.go
+++ b/server/schedule/operator_kind.go
@@ -31,7 +31,7 @@ const (
 	OpAdjacent                           // Initiated by adjacent region scheduler.
 	OpReplica                            // Initiated by replica checkers.
 	OpBalance                            // Initiated by balancers.
-	OpMerge                              // Initiated by merge checkers.
+	OpMerge                              // Initiated by merge checkers or merge schedulers.
 	OpRange                              // Initiated by range scheduler.
 	opMax
 )


### PR DESCRIPTION
## What have you changed? (required)
In `CreateMergeRegionOperator()` bind the kind `OpMerge` to generated operators.
Before this, the operator created by `RandomMergeScheduler` and HTTP API was not correctly set, resulting in a large number of operators.

## What are the type of the changes (required)?
- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested (required)?
- add test case
- make test

## Does this PR affect documentation (docs/docs-cn) update? (optional)

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

