### PR TITLE
move tool installs to a hack script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,22 +43,6 @@ test:
 basic_test:
 	go test $(BASIC_TEST_PKGS)
 
-tool-install: check-setup
-	# tool environment
-	# check runner
-	retool add gopkg.in/alecthomas/gometalinter.v2 v2.0.5
-	# check spelling
-	retool add github.com/client9/misspell/cmd/misspell v0.3.4
-	# checks correctness
-	retool add github.com/gordonklaus/ineffassign 7bae11eba15a3285c75e388f77eb6357a2d73ee2
-	retool add honnef.co/go/tools/cmd/megacheck master
-	retool add github.com/dnephin/govet 4a96d43e39d340b63daa8bc5576985aa599885f6
-	# slow checks
-	retool add github.com/kisielk/errcheck v1.1.0
-	# linter
-	retool add github.com/mgechev/revive 7773f47324c2bf1c8f7a5500aff2b6c01d3ed73b
-	retool add github.com/securego/gosec/cmd/gosec 1.0.0
-
 # These need to be fixed before they can be ran regularly
 check-fail:
 	CGO_ENABLED=0 retool do gometalinter.v2 --disable-all \

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,6 +16,7 @@ Official lints are ran with:
     make check
 
 This will use `go get` to install `retool` which then vendors the linter tools local to the project.
+Linter versions are changed with [hack/retool-install.sh](../hack/retool-install.sh).
 
 ## Testing
 

--- a/hack/retool-install.sh
+++ b/hack/retool-install.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script generates tools.json
+# It helps record what releases/branches are being used
+which retool >/dev/null || go get github.com/twitchtv/retool
+
+# tool environment
+# check runner
+retool add gopkg.in/alecthomas/gometalinter.v2 v2.0.5
+# check spelling
+retool add github.com/client9/misspell/cmd/misspell v0.3.4
+# checks correctness
+retool add github.com/gordonklaus/ineffassign 7bae11eba15a3285c75e388f77eb6357a2d73ee2
+retool add honnef.co/go/tools/cmd/megacheck master
+retool add github.com/dnephin/govet 4a96d43e39d340b63daa8bc5576985aa599885f6
+# slow checks
+retool add github.com/kisielk/errcheck v1.1.0
+# linter
+retool add github.com/mgechev/revive 7773f47324c2bf1c8f7a5500aff2b6c01d3ed73b
+retool add github.com/securego/gosec/cmd/gosec 1.0.0


### PR DESCRIPTION
This move unecessary tooling tasks out of the Makefile and matches the setup in the tidb repo.

## What are the type of the changes (required)?

Development tooling

## How has this PR been tested (required)?

`make check && ./hack/retool-install.sh`