### PR TITLE
server: adjust the log when receiving heartbeat

### DIFF
--- a/server/cluster_info.go
+++ b/server/cluster_info.go
@@ -442,7 +442,6 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 	// Mark isNew if the region in cache does not have leader.
 	var saveKV, saveCache, isNew bool
 	if origin == nil {
-		log.Infof("[region %d] Insert new region {%v}", region.GetId(), region)
 		saveKV, saveCache, isNew = true, true, true
 	} else {
 		r := region.GetRegionEpoch()
@@ -460,9 +459,10 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 			saveKV, saveCache = true, true
 		}
 		if region.Leader.GetId() != origin.Leader.GetId() {
-			log.Infof("[region %d] Leader changed from {%v} to {%v}", region.GetId(), origin.GetPeer(origin.Leader.GetId()), region.GetPeer(region.Leader.GetId()))
 			if origin.Leader.GetId() == 0 {
 				isNew = true
+			} else {
+				log.Infof("[region %d] Leader changed from store {%d} to {%d}", region.GetId(), origin.Leader.GetStoreId(), region.Leader.GetStoreId())
 			}
 			saveCache = true
 		}

--- a/server/cluster_info.go
+++ b/server/cluster_info.go
@@ -442,6 +442,7 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 	// Mark isNew if the region in cache does not have leader.
 	var saveKV, saveCache, isNew bool
 	if origin == nil {
+		log.Debugf("[region %d] Insert new region {%v}", region.GetId(), region)
 		saveKV, saveCache, isNew = true, true, true
 	} else {
 		r := region.GetRegionEpoch()

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -806,11 +806,15 @@ func DiffRegionKeyInfo(origin *RegionInfo, other *RegionInfo) string {
 		originKey := &metapb.Region{StartKey: origin.Region.StartKey}
 		otherKey := &metapb.Region{StartKey: other.Region.StartKey}
 		ret = append(ret, fmt.Sprintf("StartKey Changed:{%s} -> {%s}", originKey, otherKey))
+	} else {
+		ret = append(ret, fmt.Sprintf("StartKey:{%s}", origin.Region.StartKey))
 	}
 	if !bytes.Equal(origin.Region.EndKey, other.Region.EndKey) {
 		originKey := &metapb.Region{EndKey: origin.Region.EndKey}
 		otherKey := &metapb.Region{EndKey: other.Region.EndKey}
-		ret = append(ret, fmt.Sprintf("EndKey Changed:{%s} -> {%s}", originKey, otherKey))
+		ret = append(ret, fmt.Sprintf("EndKey Changed:{%s} -> {%s}, StartKey: {%s}", originKey, otherKey, origin.Region.StartKey))
+	} else {
+		ret = append(ret, fmt.Sprintf("EndKey:{%s}", origin.Region.EndKey))
 	}
 
 	return strings.Join(ret, ",")


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (required)

<!--
Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- Summarize your change (required)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

Please **NOTE** that:
- Do not assume the code is self-evident
- Do not assume reviewers understand the original issue
-->
 With bench the heartbeat. log costs a lot of CPU.
```
     flat  flat%   sum%        cum   cum%
    4420ms  8.02%  8.02%     4420ms  8.02%  runtime.cmpbody
    2660ms  4.82% 12.84%     2660ms  4.82%  github.com/pingcap/pd/vendor/github.com/pingcap/kvproto/pkg/metapb.(*Region).GetStartKey
    2370ms  4.30% 17.14%     2420ms  4.39%  runtime.heapBitsForObject
    2180ms  3.95% 21.09%    17310ms 31.39%  fmt.(*pp).doPrintf
    0.52s  0.94% 53.84%     14.81s 26.86%  github.com/pingcap/pd/vendor/github.com/golang/protobuf/proto.writeString
```
mainly due to the proto MashalText and io.write. This PR:
- Do not log the new region insert. the report split handler will log it.
- Do not log the leader change when startup the PD.
- log the all key when the `conf` changed
## What are the type of the changes (required)?
<!--
The currently defined types are listed below, please pick one of the types for this PR by removing the others:
-->

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (required)?
<!--
Please describe the tests that you ran to verify your changes. Have you finished unit tests, integration tests, or manual tests?
-->
Manual


