### PR TITLE
classifier: reload ns info after leader change

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -104,6 +104,12 @@ func (c *RaftCluster) start() error {
 	if cluster == nil {
 		return nil
 	}
+
+	err = c.s.classifier.ReloadNamespaces()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	c.cachedCluster = cluster
 	c.coordinator = newCoordinator(c.cachedCluster, c.s.hbStreams, c.s.classifier)
 	c.cachedCluster.regionStats = newRegionStatistics(c.s.scheduleOpt, c.s.classifier)

--- a/server/namespace/classifier.go
+++ b/server/namespace/classifier.go
@@ -36,6 +36,8 @@ type Classifier interface {
 	GetRegionNamespace(*core.RegionInfo) string
 	IsNamespaceExist(name string) bool
 	AllowMerge(*core.RegionInfo, *core.RegionInfo) bool
+	// Reload underlying namespaces
+	ReloadNamespaces() error
 }
 
 type defaultClassifier struct{}
@@ -58,6 +60,10 @@ func (c defaultClassifier) IsNamespaceExist(name string) bool {
 
 func (c defaultClassifier) AllowMerge(one *core.RegionInfo, other *core.RegionInfo) bool {
 	return true
+}
+
+func (c defaultClassifier) ReloadNamespaces() error {
+	return nil
 }
 
 // CreateClassifierFunc is for creating namespace classifier.

--- a/server/namespace_test.go
+++ b/server/namespace_test.go
@@ -234,6 +234,10 @@ func (c *mapClassifer) AllowMerge(one *core.RegionInfo, other *core.RegionInfo) 
 	return c.GetRegionNamespace(one) == c.GetRegionNamespace(other)
 }
 
+func (c *mapClassifer) ReloadNamespaces() error {
+	return nil
+}
+
 func (c *mapClassifer) setStore(id uint64, namespace string) {
 	c.stores[id] = namespace
 }

--- a/server/region_statistics_test.go
+++ b/server/region_statistics_test.go
@@ -45,6 +45,10 @@ func (c mockClassifier) AllowMerge(*core.RegionInfo, *core.RegionInfo) bool {
 	return true
 }
 
+func (c mockClassifier) ReloadNamespaces() error {
+	return nil
+}
+
 var _ = Suite(&testRegionStatisticsSuite{})
 
 type testRegionStatisticsSuite struct{}

--- a/table/namespace_classifier.go
+++ b/table/namespace_classifier.go
@@ -310,6 +310,20 @@ func (c *tableNamespaceClassifier) RemoveNamespaceStoreID(name string, storeID u
 	return c.putNamespaceLocked(n)
 }
 
+// ReloadNamespaces reloads ns info from kv storage
+func (c *tableNamespaceClassifier) ReloadNamespaces() error {
+	nsInfo := newNamespacesInfo()
+	c.Lock()
+	defer c.Unlock()
+
+	if err := nsInfo.loadNamespaces(c.kv, kvRangeLimit); err != nil {
+		return errors.Trace(err)
+	}
+
+	c.nsInfo = nsInfo
+	return nil
+}
+
 func (c *tableNamespaceClassifier) putNamespaceLocked(ns *Namespace) error {
 	if c.kv != nil {
 		if err := c.nsInfo.saveNamespace(c.kv, ns); err != nil {


### PR DESCRIPTION
When using table namespace classifier, the ns info should be reload from storage.

related issue: #1178

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (required)
Reload namespace info of table classifier after becoming leader.

The PR add a `ReloadNamespaces() error`  function into `Classifier` interface,
and table classifier rescans data from kv, default implementation does nothing.


## What are the type of the changes (required)?

- Fix #1178 

## How has this PR been tested (required)?
Reload function is tested, and `make dev` is passed.

## Does this PR affect documentation (docs/docs-cn) update? (optional)
no

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

