### PR TITLE
coordinator: make namespace checker honor the leader&region&replica limit

### DIFF
--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -173,11 +173,16 @@ func (c *coordinator) checkRegion(region *core.RegionInfo) bool {
 		}
 	}
 
-	if op := c.namespaceChecker.Check(region); op != nil {
-		if c.addOperator(op) {
-			return true
+	if c.limiter.OperatorCount(schedule.OpLeader) < c.cluster.GetLeaderScheduleLimit() &&
+		c.limiter.OperatorCount(schedule.OpRegion) < c.cluster.GetRegionScheduleLimit() &&
+		c.limiter.OperatorCount(schedule.OpReplica) < c.cluster.GetReplicaScheduleLimit() {
+		if op := c.namespaceChecker.Check(region); op != nil {
+			if c.addOperator(op) {
+				return true
+			}
 		}
 	}
+
 	if c.limiter.OperatorCount(schedule.OpReplica) < c.cluster.GetReplicaScheduleLimit() {
 		if op := c.replicaChecker.Check(region); op != nil {
 			if c.addOperator(op) {


### PR DESCRIPTION

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (required)


When adding a big table into namespace, the checker creates too many operators, which causes io/leader_change disasters.

this pr fix this.


## What are the type of the changes (required)?
- Improvement (non-breaking change which is an improvement to an existing feature)
  make namespace checker follows scheduler limits.

## How has this PR been tested (required)?
- `make dev` is passed.
- Manual tested.

## Does this PR affect documentation (docs/docs-cn) update? (optional)
no

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

