### PR TITLE
schedule: refactor Selector

### DIFF
--- a/server/schedule/selector.go
+++ b/server/schedule/selector.go
@@ -51,7 +51,7 @@ func (s *BalanceSelector) SelectSource(opt Options, stores []*core.StoreInfo) *c
 	return result
 }
 
-// SelectTarget selects the store that can pass all filters and hos the maximal
+// SelectTarget selects the store that can pass all filters and has the maximal
 // resource score.
 func (s *BalanceSelector) SelectTarget(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo {
 	filters = append(filters, s.filters...)
@@ -69,7 +69,7 @@ func (s *BalanceSelector) SelectTarget(opt Options, stores []*core.StoreInfo, fi
 	return result
 }
 
-// ReplicaSelector selects source/target store candidates based on their their
+// ReplicaSelector selects source/target store candidates based on their
 // distinct scores based on a region's peer stores.
 type ReplicaSelector struct {
 	regionStores []*core.StoreInfo
@@ -137,7 +137,7 @@ func NewRandomSelector(filters []Filter) *RandomSelector {
 	return &RandomSelector{filters: filters}
 }
 
-func (s *RandomSelector) rand(stores []*core.StoreInfo) *core.StoreInfo {
+func (s *RandomSelector) randStore(stores []*core.StoreInfo) *core.StoreInfo {
 	if len(stores) == 0 {
 		return nil
 	}
@@ -153,7 +153,7 @@ func (s *RandomSelector) SelectSource(opt Options, stores []*core.StoreInfo) *co
 		}
 		candidates = append(candidates, store)
 	}
-	return s.rand(candidates)
+	return s.randStore(candidates)
 }
 
 // SelectTarget randomly selects a target store from those can pass all filters.
@@ -167,5 +167,5 @@ func (s *RandomSelector) SelectTarget(opt Options, stores []*core.StoreInfo, fil
 		}
 		candidates = append(candidates, store)
 	}
-	return s.rand(candidates)
+	return s.randStore(candidates)
 }

--- a/server/schedule/selector.go
+++ b/server/schedule/selector.go
@@ -36,11 +36,10 @@ func NewBalanceSelector(kind core.ResourceKind, filters []Filter) *BalanceSelect
 
 // SelectSource selects the store that can pass all filters and has the minimal
 // resource score.
-func (s *BalanceSelector) SelectSource(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo {
-	filters = append(filters, s.filters...)
+func (s *BalanceSelector) SelectSource(opt Options, stores []*core.StoreInfo) *core.StoreInfo {
 	var result *core.StoreInfo
 	for _, store := range stores {
-		if FilterSource(opt, store, filters) {
+		if FilterSource(opt, store, s.filters) {
 			continue
 		}
 		if result == nil ||
@@ -89,15 +88,12 @@ func NewReplicaSelector(regionStores []*core.StoreInfo, labels []string, filters
 
 // SelectSource selects the store that can pass all filters and has the minimal
 // distinct score.
-func (s *ReplicaSelector) SelectSource(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo {
+func (s *ReplicaSelector) SelectSource(opt Options, stores []*core.StoreInfo) *core.StoreInfo {
 	var (
 		best      *core.StoreInfo
 		bestScore float64
 	)
 	for _, store := range stores {
-		if FilterSource(opt, store, filters) {
-			continue
-		}
 		score := DistinctScore(s.labels, s.regionStores, store)
 		if best == nil || compareStoreScore(opt, store, score, best, bestScore) < 0 {
 			best, bestScore = store, score
@@ -149,12 +145,10 @@ func (s *RandomSelector) rand(stores []*core.StoreInfo) *core.StoreInfo {
 }
 
 // SelectSource randomly selects a source store from those can pass all filters.
-func (s *RandomSelector) SelectSource(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo {
-	filters = append(filters, s.filters...)
-
+func (s *RandomSelector) SelectSource(opt Options, stores []*core.StoreInfo) *core.StoreInfo {
 	var candidates []*core.StoreInfo
 	for _, store := range stores {
-		if FilterSource(opt, store, filters) {
+		if FilterSource(opt, store, s.filters) {
 			continue
 		}
 		candidates = append(candidates, store)

--- a/server/schedule/selector.go
+++ b/server/schedule/selector.go
@@ -19,30 +19,25 @@ import (
 	"github.com/pingcap/pd/server/core"
 )
 
-// Selector is an interface to select source and target store to schedule.
-type Selector interface {
-	SelectSource(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo
-	SelectTarget(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo
-	GetFilters() []Filter
-}
-
-type balanceSelector struct {
+// BalanceSelector selects source/target from store candidates based on their
+// resource scores.
+type BalanceSelector struct {
 	kind    core.ResourceKind
 	filters []Filter
 }
 
-// NewBalanceSelector creates a Selector that select source/target store by their
-// resource scores.
-func NewBalanceSelector(kind core.ResourceKind, filters []Filter) Selector {
-	return &balanceSelector{
+// NewBalanceSelector creates a BalanceSelector instance.
+func NewBalanceSelector(kind core.ResourceKind, filters []Filter) *BalanceSelector {
+	return &BalanceSelector{
 		kind:    kind,
 		filters: filters,
 	}
 }
 
-func (s *balanceSelector) SelectSource(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo {
+// SelectSource selects the store that can pass all filters and has the minimal
+// resource score.
+func (s *BalanceSelector) SelectSource(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo {
 	filters = append(filters, s.filters...)
-
 	var result *core.StoreInfo
 	for _, store := range stores {
 		if FilterSource(opt, store, filters) {
@@ -57,9 +52,10 @@ func (s *balanceSelector) SelectSource(opt Options, stores []*core.StoreInfo, fi
 	return result
 }
 
-func (s *balanceSelector) SelectTarget(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo {
+// SelectTarget selects the store that can pass all filters and hos the maximal
+// resource score.
+func (s *BalanceSelector) SelectTarget(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo {
 	filters = append(filters, s.filters...)
-
 	var result *core.StoreInfo
 	for _, store := range stores {
 		if FilterTarget(opt, store, filters) {
@@ -74,27 +70,26 @@ func (s *balanceSelector) SelectTarget(opt Options, stores []*core.StoreInfo, fi
 	return result
 }
 
-func (s *balanceSelector) GetFilters() []Filter {
-	return s.filters
-}
-
-type replicaSelector struct {
+// ReplicaSelector selects source/target store candidates based on their their
+// distinct scores based on a region's peer stores.
+type ReplicaSelector struct {
 	regionStores []*core.StoreInfo
 	labels       []string
 	filters      []Filter
 }
 
-// NewReplicaSelector creates a Selector that select source/target store by their
-// distinct scores based on a region's peer stores.
-func NewReplicaSelector(regionStores []*core.StoreInfo, labels []string, filters ...Filter) Selector {
-	return &replicaSelector{
+// NewReplicaSelector creates a ReplicaSelector instance.
+func NewReplicaSelector(regionStores []*core.StoreInfo, labels []string, filters ...Filter) *ReplicaSelector {
+	return &ReplicaSelector{
 		regionStores: regionStores,
 		labels:       labels,
 		filters:      filters,
 	}
 }
 
-func (s *replicaSelector) SelectSource(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo {
+// SelectSource selects the store that can pass all filters and has the minimal
+// distinct score.
+func (s *ReplicaSelector) SelectSource(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo {
 	var (
 		best      *core.StoreInfo
 		bestScore float64
@@ -114,7 +109,9 @@ func (s *replicaSelector) SelectSource(opt Options, stores []*core.StoreInfo, fi
 	return best
 }
 
-func (s *replicaSelector) SelectTarget(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo {
+// SelectTarget selects the store that can pass all filters and has the maximal
+// distinct score.
+func (s *ReplicaSelector) SelectTarget(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo {
 	var (
 		best      *core.StoreInfo
 		bestScore float64
@@ -134,27 +131,25 @@ func (s *replicaSelector) SelectTarget(opt Options, stores []*core.StoreInfo, fi
 	return best
 }
 
-func (s *replicaSelector) GetFilters() []Filter {
-	return s.filters
-}
-
-type randomSelector struct {
+// RandomSelector selects source/target store randomly.
+type RandomSelector struct {
 	filters []Filter
 }
 
-// NewRandomSelector creates a selector that select store randomly.
-func NewRandomSelector(filters []Filter) Selector {
-	return &randomSelector{filters: filters}
+// NewRandomSelector creates a RandomSelector instance.
+func NewRandomSelector(filters []Filter) *RandomSelector {
+	return &RandomSelector{filters: filters}
 }
 
-func (s *randomSelector) Select(stores []*core.StoreInfo) *core.StoreInfo {
+func (s *RandomSelector) rand(stores []*core.StoreInfo) *core.StoreInfo {
 	if len(stores) == 0 {
 		return nil
 	}
 	return stores[rand.Int()%len(stores)]
 }
 
-func (s *randomSelector) SelectSource(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo {
+// SelectSource randomly selects a source store from those can pass all filters.
+func (s *RandomSelector) SelectSource(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo {
 	filters = append(filters, s.filters...)
 
 	var candidates []*core.StoreInfo
@@ -164,10 +159,11 @@ func (s *randomSelector) SelectSource(opt Options, stores []*core.StoreInfo, fil
 		}
 		candidates = append(candidates, store)
 	}
-	return s.Select(candidates)
+	return s.rand(candidates)
 }
 
-func (s *randomSelector) SelectTarget(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo {
+// SelectTarget randomly selects a target store from those can pass all filters.
+func (s *RandomSelector) SelectTarget(opt Options, stores []*core.StoreInfo, filters ...Filter) *core.StoreInfo {
 	filters = append(filters, s.filters...)
 
 	var candidates []*core.StoreInfo
@@ -177,9 +173,5 @@ func (s *randomSelector) SelectTarget(opt Options, stores []*core.StoreInfo, fil
 		}
 		candidates = append(candidates, store)
 	}
-	return s.Select(candidates)
-}
-
-func (s *randomSelector) GetFilters() []Filter {
-	return s.filters
+	return s.rand(candidates)
 }

--- a/server/schedulers/adjacent_region.go
+++ b/server/schedulers/adjacent_region.go
@@ -56,7 +56,7 @@ func init() {
 // 2. the two regions' leader will not in the public store of this two regions
 type balanceAdjacentRegionScheduler struct {
 	*baseScheduler
-	selector             schedule.Selector
+	selector             *schedule.RandomSelector
 	leaderLimit          uint64
 	peerLimit            uint64
 	lastKey              []byte

--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -34,7 +34,7 @@ const balanceLeaderRetryLimit = 10
 
 type balanceLeaderScheduler struct {
 	*baseScheduler
-	selector    schedule.Selector
+	selector    *schedule.BalanceSelector
 	taintStores *cache.TTLUint64
 }
 

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -35,7 +35,7 @@ const balanceRegionRetryLimit = 10
 
 type balanceRegionScheduler struct {
 	*baseScheduler
-	selector    schedule.Selector
+	selector    *schedule.BalanceSelector
 	taintStores *cache.TTLUint64
 }
 

--- a/server/schedulers/evict_leader.go
+++ b/server/schedulers/evict_leader.go
@@ -39,7 +39,7 @@ type evictLeaderScheduler struct {
 	*baseScheduler
 	name     string
 	storeID  uint64
-	selector schedule.Selector
+	selector *schedule.RandomSelector
 }
 
 // newEvictLeaderScheduler creates an admin scheduler that transfers all leaders

--- a/server/schedulers/label.go
+++ b/server/schedulers/label.go
@@ -27,7 +27,7 @@ func init() {
 
 type labelScheduler struct {
 	*baseScheduler
-	selector schedule.Selector
+	selector *schedule.BalanceSelector
 }
 
 func newLabelScheduler(limiter *schedule.Limiter) schedule.Scheduler {

--- a/server/schedulers/random_merge.go
+++ b/server/schedulers/random_merge.go
@@ -28,7 +28,7 @@ func init() {
 
 type randomMergeScheduler struct {
 	*baseScheduler
-	selector schedule.Selector
+	selector *schedule.RandomSelector
 }
 
 // newRandomMergeScheduler creates an admin scheduler that shuffles regions

--- a/server/schedulers/shuffle_leader.go
+++ b/server/schedulers/shuffle_leader.go
@@ -26,7 +26,7 @@ func init() {
 
 type shuffleLeaderScheduler struct {
 	*baseScheduler
-	selector schedule.Selector
+	selector *schedule.RandomSelector
 }
 
 // newShuffleLeaderScheduler creates an admin scheduler that shuffles leaders

--- a/server/schedulers/shuffle_region.go
+++ b/server/schedulers/shuffle_region.go
@@ -14,8 +14,10 @@
 package schedulers
 
 import (
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/server/schedule"
+	log "github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -54,14 +56,14 @@ func (s *shuffleRegionScheduler) IsScheduleAllowed(cluster schedule.Cluster) boo
 
 func (s *shuffleRegionScheduler) Schedule(cluster schedule.Cluster, opInfluence schedule.OpInfluence) []*schedule.Operator {
 	schedulerCounter.WithLabelValues(s.GetName(), "schedule").Inc()
-	region, oldPeer := scheduleRemovePeer(cluster, s.GetName(), s.selector)
+	region, oldPeer := s.scheduleRemovePeer(cluster)
 	if region == nil {
 		schedulerCounter.WithLabelValues(s.GetName(), "no_region").Inc()
 		return nil
 	}
 
 	excludedFilter := schedule.NewExcludedFilter(nil, region.GetStoreIds())
-	newPeer := scheduleAddPeer(cluster, s.selector, excludedFilter)
+	newPeer := s.scheduleAddPeer(cluster, excludedFilter)
 	if newPeer == nil {
 		schedulerCounter.WithLabelValues(s.GetName(), "no_new_peer").Inc()
 		return nil
@@ -71,4 +73,42 @@ func (s *shuffleRegionScheduler) Schedule(cluster schedule.Cluster, opInfluence 
 	op := schedule.CreateMovePeerOperator("shuffle-region", cluster, region, schedule.OpAdmin, oldPeer.GetStoreId(), newPeer.GetStoreId(), newPeer.GetId())
 	op.SetPriorityLevel(core.HighPriority)
 	return []*schedule.Operator{op}
+}
+
+func (s *shuffleRegionScheduler) scheduleRemovePeer(cluster schedule.Cluster) (*core.RegionInfo, *metapb.Peer) {
+	stores := cluster.GetStores()
+
+	source := s.selector.SelectSource(cluster, stores)
+	if source == nil {
+		schedulerCounter.WithLabelValues(s.GetName(), "no_store").Inc()
+		return nil, nil
+	}
+
+	region := cluster.RandFollowerRegion(source.GetId(), core.HealthRegion())
+	if region == nil {
+		region = cluster.RandLeaderRegion(source.GetId(), core.HealthRegion())
+	}
+	if region == nil {
+		schedulerCounter.WithLabelValues(s.GetName(), "no_region").Inc()
+		return nil, nil
+	}
+
+	return region, region.GetStorePeer(source.GetId())
+}
+
+func (s *shuffleRegionScheduler) scheduleAddPeer(cluster schedule.Cluster, filter schedule.Filter) *metapb.Peer {
+	stores := cluster.GetStores()
+
+	target := s.selector.SelectTarget(cluster, stores, filter)
+	if target == nil {
+		return nil
+	}
+
+	newPeer, err := cluster.AllocPeer(target.GetId())
+	if err != nil {
+		log.Errorf("failed to allocate peer: %v", err)
+		return nil
+	}
+
+	return newPeer
 }

--- a/server/schedulers/shuffle_region.go
+++ b/server/schedulers/shuffle_region.go
@@ -26,7 +26,7 @@ func init() {
 
 type shuffleRegionScheduler struct {
 	*baseScheduler
-	selector schedule.Selector
+	selector *schedule.RandomSelector
 }
 
 // newShuffleRegionScheduler creates an admin scheduler that shuffles regions

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -25,10 +25,10 @@ import (
 )
 
 // scheduleRemovePeer schedules a region to remove the peer.
-func scheduleRemovePeer(cluster schedule.Cluster, schedulerName string, s *schedule.RandomSelector, filters ...schedule.Filter) (*core.RegionInfo, *metapb.Peer) {
+func scheduleRemovePeer(cluster schedule.Cluster, schedulerName string, s *schedule.RandomSelector) (*core.RegionInfo, *metapb.Peer) {
 	stores := cluster.GetStores()
 
-	source := s.SelectSource(cluster, stores, filters...)
+	source := s.SelectSource(cluster, stores)
 	if source == nil {
 		schedulerCounter.WithLabelValues(schedulerName, "no_store").Inc()
 		return nil, nil

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -17,52 +17,10 @@ import (
 	"time"
 
 	"github.com/montanaflynn/stats"
-	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/server/cache"
 	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/server/schedule"
-	log "github.com/sirupsen/logrus"
 )
-
-// scheduleRemovePeer schedules a region to remove the peer.
-func scheduleRemovePeer(cluster schedule.Cluster, schedulerName string, s *schedule.RandomSelector) (*core.RegionInfo, *metapb.Peer) {
-	stores := cluster.GetStores()
-
-	source := s.SelectSource(cluster, stores)
-	if source == nil {
-		schedulerCounter.WithLabelValues(schedulerName, "no_store").Inc()
-		return nil, nil
-	}
-
-	region := cluster.RandFollowerRegion(source.GetId(), core.HealthRegion())
-	if region == nil {
-		region = cluster.RandLeaderRegion(source.GetId(), core.HealthRegion())
-	}
-	if region == nil {
-		schedulerCounter.WithLabelValues(schedulerName, "no_region").Inc()
-		return nil, nil
-	}
-
-	return region, region.GetStorePeer(source.GetId())
-}
-
-// scheduleAddPeer schedules a new peer.
-func scheduleAddPeer(cluster schedule.Cluster, s *schedule.RandomSelector, filters ...schedule.Filter) *metapb.Peer {
-	stores := cluster.GetStores()
-
-	target := s.SelectTarget(cluster, stores, filters...)
-	if target == nil {
-		return nil
-	}
-
-	newPeer, err := cluster.AllocPeer(target.GetId())
-	if err != nil {
-		log.Errorf("failed to allocate peer: %v", err)
-		return nil
-	}
-
-	return newPeer
-}
 
 func minUint64(a, b uint64) uint64 {
 	if a < b {

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -25,7 +25,7 @@ import (
 )
 
 // scheduleRemovePeer schedules a region to remove the peer.
-func scheduleRemovePeer(cluster schedule.Cluster, schedulerName string, s schedule.Selector, filters ...schedule.Filter) (*core.RegionInfo, *metapb.Peer) {
+func scheduleRemovePeer(cluster schedule.Cluster, schedulerName string, s *schedule.RandomSelector, filters ...schedule.Filter) (*core.RegionInfo, *metapb.Peer) {
 	stores := cluster.GetStores()
 
 	source := s.SelectSource(cluster, stores, filters...)
@@ -47,7 +47,7 @@ func scheduleRemovePeer(cluster schedule.Cluster, schedulerName string, s schedu
 }
 
 // scheduleAddPeer schedules a new peer.
-func scheduleAddPeer(cluster schedule.Cluster, s schedule.Selector, filters ...schedule.Filter) *metapb.Peer {
+func scheduleAddPeer(cluster schedule.Cluster, s *schedule.RandomSelector, filters ...schedule.Filter) *metapb.Peer {
 	stores := cluster.GetStores()
 
 	target := s.SelectTarget(cluster, stores, filters...)


### PR DESCRIPTION
## What have you changed? (required)

- Remove the `Selector` interface, use concrete Selector types instead
- Remove the redundant filters parameter in `SelectSource()` and `SelectTarget()`.
- Move `scheduleRemovePeer` and `scheduleAddPeer` out of `utils.go` since they are used only by `shuffleRegionScheduler`

## What are the type of the changes (required)?
- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (required)?
make dev

## Does this PR affect documentation (docs/docs-cn) update? (optional)

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

