### PR TITLE
simulator: wait PD leader election before simulator start

### DIFF
--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -76,6 +76,12 @@ func run(confName string) {
 		if err != nil {
 			simutil.Logger.Fatal("run server error:", err)
 		}
+		for {
+			if local.IsLeader() {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
 		tickInterval := 100 * time.Millisecond
 		simStart(local.GetAddr(), confName, tickInterval, clean)
 	}


### PR DESCRIPTION
## What have you changed? (required)
This PR makes the simulator run again. There is one case that the etcd's leader has been elected but the server' leader has not. If we start PD server from the simulator itself, the bootstrap will fail under the circumstance. 

## What are the type of the changes (required)?
- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (required)?
- Manual tests

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

