### PR TITLE
schedule: add option to disable namespace checker

### DIFF
--- a/server/cluster_info.go
+++ b/server/cluster_info.go
@@ -686,6 +686,10 @@ func (c *clusterInfo) IsLocationReplacementEnabled() bool {
 	return c.opt.IsLocationReplacementEnabled()
 }
 
+func (c *clusterInfo) IsNamespaceRelocationEnabled() bool {
+	return c.opt.IsNamespaceRelocationEnabled()
+}
+
 func (c *clusterInfo) CheckLabelProperty(typ string, labels []*metapb.StoreLabel) bool {
 	return c.opt.CheckLabelProperty(typ, labels)
 }

--- a/server/config.go
+++ b/server/config.go
@@ -431,6 +431,9 @@ type ScheduleConfig struct {
 	// DisableLocationReplacement is the option to prevent replica checker from
 	// moving replica to a better location.
 	DisableLocationReplacement bool `toml:"disable-location-replacement" json:"disable-location-replacement,string"`
+	// DisableNamespaceRelocation is the option to prevent namespace checker
+	// from moving replica to the target namespace.
+	DisableNamespaceRelocation bool `toml:"disable-namespace-relocation" json:"disable-namespace-relocation,string"`
 
 	// Schedulers support for loding customized schedulers
 	Schedulers SchedulerConfigs `toml:"schedulers,omitempty" json:"schedulers-v2"` // json v2 is for the sake of compatible upgrade

--- a/server/namespace_test.go
+++ b/server/namespace_test.go
@@ -24,14 +24,15 @@ import (
 var _ = Suite(&testNamespaceSuite{})
 
 type testNamespaceSuite struct {
-	classifier *mapClassifer
-	tc         *testClusterInfo
-	opt        *scheduleOption
+	classifier     *mapClassifer
+	tc             *testClusterInfo
+	opt            *scheduleOption
+	scheduleConfig *ScheduleConfig
 }
 
 func (s *testNamespaceSuite) SetUpTest(c *C) {
 	s.classifier = newMapClassifer()
-	_, s.opt = newTestScheduleConfig()
+	s.scheduleConfig, s.opt = newTestScheduleConfig()
 	s.tc = newTestClusterInfo(s.opt)
 }
 
@@ -103,6 +104,11 @@ func (s *testNamespaceSuite) TestNamespaceChecker(c *C) {
 	// Move the peer with questions to the right store if the region has multiple peers.
 	s.classifier.setRegion(5, "ns1")
 	s.tc.addLeaderRegion(5, 1, 1, 3)
+
+	s.scheduleConfig.DisableNamespaceRelocation = true
+	c.Assert(checker.Check(s.tc.GetRegion(5)), IsNil)
+	s.scheduleConfig.DisableNamespaceRelocation = false
+
 	op = checker.Check(s.tc.GetRegion(5))
 	testutil.CheckTransferPeer(c, op, schedule.OpReplica, 3, 2)
 }

--- a/server/option.go
+++ b/server/option.go
@@ -167,6 +167,10 @@ func (o *scheduleOption) IsLocationReplacementEnabled() bool {
 	return !o.load().DisableLocationReplacement
 }
 
+func (o *scheduleOption) IsNamespaceRelocationEnabled() bool {
+	return !o.load().DisableNamespaceRelocation
+}
+
 func (o *scheduleOption) GetSchedulers() SchedulerConfigs {
 	return o.load().Schedulers
 }

--- a/server/schedule/mockcluster.go
+++ b/server/schedule/mockcluster.go
@@ -454,6 +454,7 @@ type MockSchedulerOptions struct {
 	DisableMakeUpReplica         bool
 	DisableRemoveExtraReplica    bool
 	DisableLocationReplacement   bool
+	DisableNamespaceRelocation   bool
 	LabelProperties              map[string][]*metapb.StoreLabel
 }
 
@@ -591,4 +592,9 @@ func (mso *MockSchedulerOptions) IsRemoveExtraReplicaEnabled() bool {
 // IsLocationReplacementEnabled mock method.
 func (mso *MockSchedulerOptions) IsLocationReplacementEnabled() bool {
 	return !mso.DisableLocationReplacement
+}
+
+// IsNamespaceRelocationEnabled mock method.
+func (mso *MockSchedulerOptions) IsNamespaceRelocationEnabled() bool {
+	return !mso.DisableNamespaceRelocation
 }

--- a/server/schedule/namespace_checker.go
+++ b/server/schedule/namespace_checker.go
@@ -40,6 +40,10 @@ func NewNamespaceChecker(cluster Cluster, classifier namespace.Classifier) *Name
 
 // Check verifies a region's namespace, creating an Operator if need.
 func (n *NamespaceChecker) Check(region *core.RegionInfo) *Operator {
+	if !n.cluster.IsNamespaceRelocationEnabled() {
+		return nil
+	}
+
 	checkerCounter.WithLabelValues("namespace_checker", "check").Inc()
 
 	// fail-fast if there is only ONE namespace

--- a/server/schedule/opts.go
+++ b/server/schedule/opts.go
@@ -52,6 +52,7 @@ type Options interface {
 	IsMakeUpReplicaEnabled() bool
 	IsRemoveExtraReplicaEnabled() bool
 	IsLocationReplacementEnabled() bool
+	IsNamespaceRelocationEnabled() bool
 
 	CheckLabelProperty(typ string, labels []*metapb.StoreLabel) bool
 }


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (required)
This PR add an option to disable namespace checker's region relocation scheduling.

- disable-namespace-relocation

The implementation uses https://github.com/pingcap/pd/pull/1140 for reference.

## What are the type of the changes (required)?
- New feature (non-breaking change which adds functionality)

## How has this PR been tested (required)?
`make dev` and manual test.

## Does this PR affect documentation (docs/docs-cn) update? (optional)
<!--
If there is document change, please file a PR in ([docs](https://github.com/pingcap/docs) and [docs-cn](https://github.com/pingcap/docs-cn)) and add the PR number here.
-->

TODO: add later

## Refer to a related PR or issue link (optional)
#1199 

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

