### PR TITLE
server/core: fix DiffRegionKeyInfo no use escaped key

### DIFF
--- a/server/core/region.go
+++ b/server/core/region.go
@@ -816,14 +816,14 @@ func DiffRegionKeyInfo(origin *RegionInfo, other *RegionInfo) string {
 		otherKey := &metapb.Region{StartKey: other.Region.StartKey}
 		ret = append(ret, fmt.Sprintf("StartKey Changed:{%s} -> {%s}", originKey, otherKey))
 	} else {
-		ret = append(ret, fmt.Sprintf("StartKey:{%s}", origin.Region.StartKey))
+		ret = append(ret, fmt.Sprintf("StartKey:{%s}", &metapb.Region{EndKey: origin.Region.StartKey}))
 	}
 	if !bytes.Equal(origin.Region.EndKey, other.Region.EndKey) {
 		originKey := &metapb.Region{EndKey: origin.Region.EndKey}
 		otherKey := &metapb.Region{EndKey: other.Region.EndKey}
 		ret = append(ret, fmt.Sprintf("EndKey Changed:{%s} -> {%s}, StartKey: {%s}", originKey, otherKey, origin.Region.StartKey))
 	} else {
-		ret = append(ret, fmt.Sprintf("EndKey:{%s}", origin.Region.EndKey))
+		ret = append(ret, fmt.Sprintf("EndKey:{%s}", &metapb.Region{EndKey: origin.Region.EndKey}))
 	}
 
 	return strings.Join(ret, ",")

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -816,7 +816,7 @@ func DiffRegionKeyInfo(origin *RegionInfo, other *RegionInfo) string {
 		otherKey := &metapb.Region{StartKey: other.Region.StartKey}
 		ret = append(ret, fmt.Sprintf("StartKey Changed:{%s} -> {%s}", originKey, otherKey))
 	} else {
-		ret = append(ret, fmt.Sprintf("StartKey:{%s}", &metapb.Region{EndKey: origin.Region.StartKey}))
+		ret = append(ret, fmt.Sprintf("StartKey:{%s}", &metapb.Region{StartKey: origin.Region.StartKey}))
 	}
 	if !bytes.Equal(origin.Region.EndKey, other.Region.EndKey) {
 		originKey := &metapb.Region{EndKey: origin.Region.EndKey}

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -821,10 +821,10 @@ func DiffRegionKeyInfo(origin *RegionInfo, other *RegionInfo) string {
 	if !bytes.Equal(origin.Region.EndKey, other.Region.EndKey) {
 		originKey := &metapb.Region{EndKey: origin.Region.EndKey}
 		otherKey := &metapb.Region{EndKey: other.Region.EndKey}
-		ret = append(ret, fmt.Sprintf("EndKey Changed:{%s} -> {%s}, StartKey: {%s}", originKey, otherKey, origin.Region.StartKey))
+		ret = append(ret, fmt.Sprintf("EndKey Changed:{%s} -> {%s}", originKey, otherKey))
 	} else {
 		ret = append(ret, fmt.Sprintf("EndKey:{%s}", &metapb.Region{EndKey: origin.Region.EndKey}))
 	}
 
-	return strings.Join(ret, ",")
+	return strings.Join(ret, ", ")
 }

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -121,9 +121,18 @@ func (*testRegionKey) TestRegionKey(c *C) {
 		s := fmt.Sprintln(&metapb.Region{StartKey: []byte(got)})
 		c.Assert(strings.Contains(s, t.expect), IsTrue)
 
+		// start key changed
 		orgion := NewRegionInfo(&metapb.Region{EndKey: []byte(got)}, nil)
 		region := NewRegionInfo(&metapb.Region{StartKey: []byte(got), EndKey: []byte(got)}, nil)
 		s = DiffRegionKeyInfo(orgion, region)
+		c.Assert(s, Matches, ".*StartKey Changed.*")
+		c.Assert(strings.Contains(s, t.expect), IsTrue)
+
+		// end key changed
+		orgion = NewRegionInfo(&metapb.Region{StartKey: []byte(got)}, nil)
+		region = NewRegionInfo(&metapb.Region{StartKey: []byte(got), EndKey: []byte(got)}, nil)
+		s = DiffRegionKeyInfo(orgion, region)
+		c.Assert(s, Matches, ".*EndKey Changed.*")
 		c.Assert(strings.Contains(s, t.expect), IsTrue)
 	}
 }

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -15,6 +15,7 @@ package core
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -114,9 +115,8 @@ func (*testRegionKey) TestRegionKey(c *C) {
 		{"\"\\x80\\x00\\x00\\x00\\x00\\x00\\x00\\xff\\x05\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xf8\"",
 			`"\200\000\000\000\000\000\000\377\005\000\000\000\000\000\000\000\370"`},
 	}
-	got := make([]byte, 30)
 	for _, t := range testCase {
-		_, err := fmt.Sscanf(t.key, "%q", &got)
+		got, err := strconv.Unquote(t.key)
 		c.Assert(err, IsNil)
 		s := fmt.Sprintln(&metapb.Region{StartKey: []byte(got)})
 		c.Assert(strings.Contains(s, t.expect), IsTrue)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (required)

<!--
Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- Summarize your change (required)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

Please **NOTE** that:
- Do not assume the code is self-evident
- Do not assume reviewers understand the original issue
-->
No use of escape characters will print strange logs. this PR fix it.
## What are the type of the changes (required)?

<!--
The currently defined types are listed below, please pick one of the types for this PR by removing the others:
-->

- Improvement (non-breaking change which is an improvement to an existing feature)


## How has this PR been tested (required)?
<!--
Please describe the tests that you ran to verify your changes. Have you finished unit tests, integration tests, or manual tests?
-->
unit test.


