### PR TITLE
server: support tinyLFU cache

### DIFF
--- a/server/cache/cache.go
+++ b/server/cache/cache.go
@@ -41,6 +41,8 @@ const (
 	LRUCache Type = 1
 	// TwoQueueCache is for 2Q cache
 	TwoQueueCache Type = 2
+	// TinyLFUCache is for TinyLFU cache
+	TinyLFUCache Type = 3
 )
 
 var (
@@ -110,6 +112,8 @@ func NewCache(size int, cacheType Type) Cache {
 		return newThreadSafeCache(newLRU(size))
 	case TwoQueueCache:
 		return newThreadSafeCache(newTwoQueue(size))
+	case TinyLFUCache:
+		return newThreadSafeCache(newTinyLFU(size))
 	default:
 		panic("Unknown cache type")
 	}

--- a/server/cache/cache_test.go
+++ b/server/cache/cache_test.go
@@ -253,3 +253,78 @@ func (s *testRegionCacheSuite) TestTwoQueueCache(c *C) {
 	c.Assert(ok, IsFalse)
 	c.Assert(val, IsNil)
 }
+
+func (s *testRegionCacheSuite) TestTinyLFUCache(c *C) {
+	cache := newTinyLFU(3)
+	cache.Put(1, "1")
+	cache.Put(2, "2")
+	cache.Put(3, "3")
+
+	val, ok := cache.Get(3)
+	c.Assert(ok, IsTrue)
+	c.Assert(val, DeepEquals, "3")
+
+	val, ok = cache.Get(2)
+	c.Assert(ok, IsTrue)
+	c.Assert(val, DeepEquals, "2")
+
+	val, ok = cache.Get(1)
+	c.Assert(ok, IsTrue)
+	c.Assert(val, DeepEquals, "1")
+
+	c.Assert(cache.Len(), Equals, 3)
+
+	cache.Put(4, "4")
+
+	c.Assert(cache.Len(), Equals, 3)
+
+	val, ok = cache.Get(3)
+	c.Assert(ok, IsFalse)
+	c.Assert(val, IsNil)
+
+	val, ok = cache.Get(1)
+	c.Assert(ok, IsTrue)
+	c.Assert(val, DeepEquals, "1")
+
+	val, ok = cache.Get(2)
+	c.Assert(ok, IsTrue)
+	c.Assert(val, DeepEquals, "2")
+
+	val, ok = cache.Get(4)
+	c.Assert(ok, IsTrue)
+	c.Assert(val, DeepEquals, "4")
+
+	c.Assert(cache.Len(), Equals, 3)
+
+	val, ok = cache.Peek(1)
+	c.Assert(ok, IsTrue)
+	c.Assert(val, DeepEquals, "1")
+
+	elems := cache.Elems()
+	c.Assert(elems, HasLen, 3)
+	c.Assert(elems[0].Value, DeepEquals, "4")
+	c.Assert(elems[1].Value, DeepEquals, "2")
+	c.Assert(elems[2].Value, DeepEquals, "1")
+
+	cache.Remove(1)
+	cache.Remove(2)
+	cache.Remove(4)
+
+	c.Assert(cache.Len(), Equals, 0)
+
+	val, ok = cache.Get(1)
+	c.Assert(ok, IsFalse)
+	c.Assert(val, IsNil)
+
+	val, ok = cache.Get(2)
+	c.Assert(ok, IsFalse)
+	c.Assert(val, IsNil)
+
+	val, ok = cache.Get(3)
+	c.Assert(ok, IsFalse)
+	c.Assert(val, IsNil)
+
+	val, ok = cache.Get(4)
+	c.Assert(ok, IsFalse)
+	c.Assert(val, IsNil)
+}

--- a/server/cache/lru.go
+++ b/server/cache/lru.go
@@ -45,18 +45,25 @@ func newLRU(maxCount int) *LRU {
 
 // Put puts an item into cache.
 func (c *LRU) Put(key uint64, value interface{}) {
+	c.put(key, value)
+}
+
+func (c *LRU) put(key uint64, value interface{}) *Item {
 	if ele, ok := c.cache[key]; ok {
 		c.ll.MoveToFront(ele)
 		ele.Value.(*Item).Value = value
-		return
+		return nil
 	}
 
 	kv := &Item{Key: key, Value: value}
 	ele := c.ll.PushFront(kv)
 	c.cache[key] = ele
 	if c.maxCount != 0 && c.ll.Len() > c.maxCount {
+		back := c.ll.Back()
 		c.removeOldest()
+		return back.Value.(*Item)
 	}
+	return nil
 }
 
 // Get retrives an item from cache.

--- a/server/cache/slru.go
+++ b/server/cache/slru.go
@@ -1,0 +1,213 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"container/list"
+)
+
+const (
+	probationSegment int = iota
+	protectedSegment
+)
+
+const (
+	protectedRatio = 0.8
+)
+
+// SLRUItem is the cache entry.
+type SLRUItem struct {
+	Key    uint64
+	Value  interface{}
+	status int
+}
+
+// SLRU is a segmented LRU.
+type SLRU struct {
+	probationCap int
+	protectedCap int
+
+	probation *list.List
+	protected *list.List
+	cache     map[uint64]*list.Element
+}
+
+func newSLRU(cap int) *SLRU {
+	probationCap := int(float64(cap) * (1 - protectedRatio))
+	if probationCap < 1 {
+		probationCap = 1
+	}
+	return &SLRU{
+		protectedCap: cap - probationCap,
+		probationCap: probationCap,
+		protected:    list.New(),
+		probation:    list.New(),
+		cache:        make(map[uint64]*list.Element),
+	}
+}
+
+// Put puts an item into cache.
+func (c *SLRU) Put(key uint64, value interface{}) {
+	elem, ok := c.cache[key]
+	if ok {
+		item := elem.Value.(*SLRUItem)
+		item.Value = value
+		c.update(elem)
+		return
+	}
+
+	newItem := &SLRUItem{Key: key, Value: value, status: probationSegment}
+	if c.probation.Len() < c.probationCap || c.Len() < c.probationCap+c.protectedCap {
+		c.cache[key] = c.probation.PushFront(newItem)
+		return
+	}
+
+	back := c.probation.Back()
+	if back == nil {
+		return
+	}
+
+	item := back.Value.(*SLRUItem)
+	delete(c.cache, item.Key)
+	item = newItem
+	c.cache[item.Key] = back
+	c.probation.MoveToFront(back)
+}
+
+// Get retrives an item from cache.
+func (c *SLRU) Get(key uint64) (interface{}, bool) {
+	elem := c.cache[key]
+	if elem == nil {
+		return nil, false
+	}
+
+	item := elem.Value.(*SLRUItem)
+	if item.status == protectedSegment {
+		c.protected.MoveToFront(elem)
+		return elem.Value.(*SLRUItem).Value, true
+	}
+
+	if c.protected.Len() < c.protectedCap {
+		c.probation.Remove(elem)
+		item.status = protectedSegment
+		c.cache[key] = c.protected.PushFront(item)
+		return elem.Value.(*SLRUItem).Value, true
+	}
+
+	back := c.protected.Back()
+	backItem := back.Value.(*SLRUItem)
+	*backItem, *item = *item, *backItem
+
+	item.status = probationSegment
+	backItem.status = protectedSegment
+
+	c.cache[key] = back
+	c.cache[item.Key] = elem
+	c.protected.MoveToFront(back)
+	c.probation.MoveToFront(elem)
+	return back.Value.(*SLRUItem).Value, true
+}
+
+func (c *SLRU) update(elem *list.Element) {
+	item := elem.Value.(*SLRUItem)
+	if item.status == protectedSegment {
+		c.protected.MoveToFront(elem)
+	}
+
+	if c.protected.Len() < c.protectedCap {
+		c.probation.Remove(elem)
+		item.status = protectedSegment
+		c.cache[item.Key] = c.protected.PushFront(item)
+	}
+
+	back := c.protected.Back()
+	backItem := back.Value.(*SLRUItem)
+	*backItem, *item = *item, *backItem
+
+	item.status = probationSegment
+	backItem.status = protectedSegment
+
+	c.cache[backItem.Key] = back
+	c.cache[item.Key] = elem
+	c.protected.MoveToFront(back)
+	c.probation.MoveToFront(elem)
+}
+
+// Peek reads an item from cache. The action is no considered 'Use'.
+func (c *SLRU) Peek(key uint64) (interface{}, bool) {
+	if elem, ok := c.cache[key]; ok {
+		return elem.Value.(*SLRUItem).Value, true
+	}
+	return nil, false
+}
+
+// Remove eliminates an item from cache.
+func (c *SLRU) Remove(key uint64) {
+	c.remove(key)
+}
+
+func (c *SLRU) remove(key uint64) bool {
+	if elem, ok := c.cache[key]; ok {
+		c.removeElement(elem)
+		return ok
+	}
+	return false
+}
+
+func (c *SLRU) removeElement(elem *list.Element) {
+	item := elem.Value.(*SLRUItem)
+	if item.status == protectedSegment {
+		c.protected.Remove(elem)
+	} else {
+		c.probation.Remove(elem)
+	}
+	delete(c.cache, item.Key)
+}
+
+// Len returns current cache size.
+func (c *SLRU) Len() int {
+	return c.protected.Len() + c.probation.Len()
+}
+
+// Elems return all items in cache.
+func (c *SLRU) Elems() []*Item {
+	elems := make([]*Item, 0, c.Len())
+	for elem := c.protected.Front(); elem != nil; elem = elem.Next() {
+		item := elem.Value.(*SLRUItem)
+		elems = append(elems, &Item{
+			Key:   item.Key,
+			Value: item.Value,
+		})
+	}
+	for elem := c.probation.Front(); elem != nil; elem = elem.Next() {
+		item := elem.Value.(*SLRUItem)
+		elems = append(elems, &Item{
+			Key:   item.Key,
+			Value: item.Value,
+		})
+	}
+	return elems
+}
+
+func (c *SLRU) victim() *SLRUItem {
+	if c.Len() < c.probationCap+c.protectedCap {
+		return nil
+	}
+
+	v := c.probation.Back()
+	if v == nil {
+		return nil
+	}
+	return v.Value.(*SLRUItem)
+}

--- a/server/cache/tinylfu.go
+++ b/server/cache/tinylfu.go
@@ -1,0 +1,304 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"math"
+)
+
+const (
+	falsePositiveProbability = 0.1
+	percentEden              = 0.01
+	sampleMultiplier         = 10
+	sketchDepth              = 4
+)
+
+// TinyLFU is
+type TinyLFU struct {
+	doorkeeper *Doorkeeper
+	cms        *CountMinSketch
+
+	additions int
+	samples   int
+
+	eden *LRU
+	main *SLRU
+}
+
+func newTinyLFU(size int) *TinyLFU {
+	samples := size * sampleMultiplier
+	doorkeeper := newDoorkeeper(size, falsePositiveProbability)
+	cms := newCountMinSketch(size)
+	edenCapacity := int(float64(size) * percentEden)
+	if edenCapacity < 1 {
+		edenCapacity = 1
+	}
+	return &TinyLFU{
+		doorkeeper: doorkeeper,
+		cms:        cms,
+		samples:    samples,
+		eden:       newLRU(edenCapacity),
+		main:       newSLRU(size - edenCapacity),
+	}
+}
+
+// Put puts an item into cache.
+func (c *TinyLFU) Put(key uint64, value interface{}) {
+	c.increase(fnvU64(key))
+	candidate := c.eden.put(key, value)
+	if candidate == nil {
+		return
+	}
+	victim := c.main.victim()
+	if victim == nil {
+		c.main.Put(candidate.Key, candidate.Value)
+		return
+	}
+	candidateFeq := c.estimate(fnvU64(candidate.Key))
+	victimFeq := c.estimate(fnvU64(victim.Key))
+	if candidateFeq > victimFeq {
+		c.main.Put(candidate.Key, candidate.Value)
+	}
+}
+
+// Get retrives an item from cache.
+func (c *TinyLFU) Get(key uint64) (interface{}, bool) {
+	c.increase(fnvU64(key))
+	if val, ok := c.eden.Get(key); ok {
+		return val, ok
+	}
+	if val, ok := c.main.Get(key); ok {
+		return val, ok
+	}
+	return nil, false
+}
+
+// Peek reads an item from cache. The action is no considered 'Use'.
+func (c *TinyLFU) Peek(key uint64) (interface{}, bool) {
+	if val, ok := c.eden.Peek(key); ok {
+		return val, ok
+	}
+	if val, ok := c.main.Peek(key); ok {
+		return val, ok
+	}
+	return nil, false
+}
+
+// Remove removes an item from cache.
+func (c *TinyLFU) Remove(key uint64) {
+	if c.eden.remove(key) {
+		return
+	}
+	if c.main.remove(key) {
+		return
+	}
+}
+
+// Elems return all items in cache.
+func (c *TinyLFU) Elems() []*Item {
+	size := c.Len()
+	elems := make([]*Item, 0, size)
+	elems = append(elems, c.eden.Elems()...)
+	elems = append(elems, c.main.Elems()...)
+	return elems
+}
+
+// Len returns current cache size.
+func (c *TinyLFU) Len() int {
+	return c.eden.Len() + c.main.Len()
+}
+
+func (c *TinyLFU) increase(h uint64) {
+	c.additions++
+	if c.additions >= c.samples {
+		c.doorkeeper.reset()
+		c.cms.reset()
+		c.additions = 0
+	}
+	if c.doorkeeper.put(h) {
+		c.cms.add(h)
+	}
+}
+
+func (c *TinyLFU) estimate(h uint64) uint8 {
+	freq := c.cms.estimate(h)
+	if c.doorkeeper.contains(h) {
+		freq++
+	}
+	return freq
+}
+
+// Doorkeeper is an implementation of the bloom filter.
+type Doorkeeper struct {
+	numHashes uint32
+	bitsMask  uint32
+	bits      []uint64
+}
+
+func newDoorkeeper(capacity int, fpp float64) *Doorkeeper {
+	ln2 := math.Log(2.0)
+	factor := -math.Log(fpp) / math.Pow(ln2, 2)
+
+	numBits := ceilingNextPowerOfTwo(uint32(float64(capacity) * factor))
+	if numBits < 1024 {
+		numBits = 1024
+	}
+	bitsMask := numBits - 1
+
+	numHashes := uint32(0.7 * float64(numBits) / float64(capacity))
+	if numHashes < 2 {
+		numHashes = 2
+	}
+
+	size := int(numBits+63) / 64
+	bits := make([]uint64, size)
+	return &Doorkeeper{
+		numHashes: numHashes,
+		bitsMask:  bitsMask,
+		bits:      bits,
+	}
+}
+
+func (d *Doorkeeper) put(h uint64) bool {
+	h1, h2 := uint32(h), uint32(h>>32)
+	var o uint = 1
+	for i := uint32(0); i < d.numHashes; i++ {
+		o &= d.set((h1 + (i * h2)) & d.bitsMask)
+	}
+	return o == 1
+}
+
+func (d *Doorkeeper) contains(h uint64) bool {
+	h1, h2 := uint32(h), uint32(h>>32)
+	var o uint = 1
+	for i := uint32(0); i < d.numHashes; i++ {
+		o &= d.get((h1 + (i * h2)) & d.bitsMask)
+	}
+	return o == 1
+}
+
+func (d *Doorkeeper) set(i uint32) uint {
+	idx, shift := i/64, i%64
+	val := d.bits[idx]
+	mask := uint64(1) << shift
+	d.bits[idx] |= mask
+	return uint((val & mask) >> shift)
+}
+
+func (d *Doorkeeper) get(i uint32) uint {
+	idx, shift := i/64, i%64
+	val := d.bits[idx]
+	mask := uint64(1) << shift
+	return uint((val & mask) >> shift)
+}
+
+func (d *Doorkeeper) reset() {
+	for i := range d.bits {
+		d.bits[i] = 0
+	}
+}
+
+type counter []byte
+
+func newCounter(width int) counter {
+	return make(counter, width/2)
+}
+
+func (c counter) get(i uint32) byte {
+	return byte(c[i/2]>>((i&1)*4)) & 0x0f
+}
+
+func (c counter) inc(i uint32) {
+	idx := i / 2
+	shift := (i & 1) * 4
+	v := (c[idx] >> shift) & 0x0f
+	if v < 15 {
+		c[idx] += 1 << shift
+	}
+}
+
+func (c counter) reset() {
+	for i := range c {
+		c[i] = (c[i] >> 1) & 0x77
+	}
+}
+
+// CountMinSketch is an implementation of count-min sketch algorithm.
+type CountMinSketch struct {
+	counters [sketchDepth]counter
+	mask     uint32
+}
+
+func newCountMinSketch(width int) *CountMinSketch {
+	size := ceilingNextPowerOfTwo(uint32(width))
+	c := CountMinSketch{mask: size - 1}
+	for i := 0; i < sketchDepth; i++ {
+		c.counters[i] = newCounter(int(size))
+	}
+	return &c
+}
+
+func (c *CountMinSketch) add(h uint64) {
+	h1, h2 := uint32(h), uint32(h>>32)
+
+	for i := range c.counters {
+		pos := (h1 + uint32(i)*h2) & c.mask
+		c.counters[i].inc(pos)
+	}
+}
+
+func (c *CountMinSketch) estimate(h uint64) uint8 {
+	h1, h2 := uint32(h), uint32(h>>32)
+
+	var min byte = 0xFF
+	for i := 0; i < sketchDepth; i++ {
+		pos := (h1 + uint32(i)*h2) & c.mask
+		v := c.counters[i].get(pos)
+		if v < min {
+			min = v
+		}
+	}
+	return min
+}
+
+func (c *CountMinSketch) reset() {
+	for _, c := range c.counters {
+		c.reset()
+	}
+}
+
+func ceilingNextPowerOfTwo(i uint32) uint32 {
+	n := i - 1
+	n |= n >> 1
+	n |= n >> 2
+	n |= n >> 4
+	n |= n >> 8
+	n |= n >> 16
+	n++
+	return n
+}
+
+const (
+	fnvOffset uint64 = 14695981039346656037
+	fnvPrime  uint64 = 1099511628211
+)
+
+func fnvU64(v uint64) uint64 {
+	h := fnvOffset
+	for i := uint(0); i < 64; i += 8 {
+		h ^= (v >> i) & 0xFF
+		h *= fnvPrime
+	}
+	return h
+}


### PR DESCRIPTION
## What have you changed? (required)
This PR is just an experiment and feel free to close it. It tries to support another kind of the cache policy named TinyLFU, which "uses a small admission LRU that evicts to a large Segmented LRU if accepted by the TinyLFU admission policy".  The paper of this algorithm can be found [here](https://arxiv.org/pdf/1512.00727.pdf). The implementation of this PR is mainly based on [dgryski/go-tinylfu](https://github.com/dgryski/go-tinylfu) and [goburrow/cache](https://github.com/goburrow/cache).
In some cases, TinyLFU is more stable than LRU or 2Q cache policies. Here is an [exmaple](https://play.golang.org/p/Sm0JhhwPoVu). But I'm not sure it is useful and reasonable.
```
LRU Hit:0, 2Q Hit:0, TinyLFU Hit:0
LRU Hit:0, 2Q Hit:0, TinyLFU Hit:0
LRU Hit:0, 2Q Hit:0, TinyLFU Hit:0
LRU Hit:11, 2Q Hit:11, TinyLFU Hit:11
LRU Hit:9, 2Q Hit:9, TinyLFU Hit:9
LRU Hit:11, 2Q Hit:11, TinyLFU Hit:11
LRU Hit:13, 2Q Hit:13, TinyLFU Hit:13
LRU Hit:13, 2Q Hit:13, TinyLFU Hit:13
LRU Hit:11, 2Q Hit:11, TinyLFU Hit:11
LRU Hit:11, 2Q Hit:11, TinyLFU Hit:11
LRU Hit:10, 2Q Hit:10, TinyLFU Hit:10
LRU Hit:10, 2Q Hit:10, TinyLFU Hit:10
LRU Hit:11, 2Q Hit:11, TinyLFU Hit:11
LRU Hit:38, 2Q Hit:41, TinyLFU Hit:22
LRU Hit:39, 2Q Hit:37, TinyLFU Hit:17
LRU Hit:40, 2Q Hit:40, TinyLFU Hit:19
LRU Hit:41, 2Q Hit:41, TinyLFU Hit:19
LRU Hit:39, 2Q Hit:39, TinyLFU Hit:20
LRU Hit:39, 2Q Hit:39, TinyLFU Hit:18
LRU Hit:38, 2Q Hit:38, TinyLFU Hit:17
LRU Hit:0, 2Q Hit:12, TinyLFU Hit:20
LRU Hit:0, 2Q Hit:11, TinyLFU Hit:18
LRU Hit:0, 2Q Hit:11, TinyLFU Hit:17
LRU Hit:12, 2Q Hit:12, TinyLFU Hit:20
LRU Hit:13, 2Q Hit:13, TinyLFU Hit:22
LRU Hit:39, 2Q Hit:39, TinyLFU Hit:29
LRU Hit:40, 2Q Hit:38, TinyLFU Hit:29
LRU Hit:41, 2Q Hit:40, TinyLFU Hit:30
LRU Hit:41, 2Q Hit:41, TinyLFU Hit:31
LRU Hit:40, 2Q Hit:40, TinyLFU Hit:29
LRU Hit:40, 2Q Hit:40, TinyLFU Hit:32
LRU Hit:41, 2Q Hit:41, TinyLFU Hit:31
LRU Hit:41, 2Q Hit:41, TinyLFU Hit:30
LRU Hit:39, 2Q Hit:39, TinyLFU Hit:28
LRU Hit:39, 2Q Hit:39, TinyLFU Hit:28
LRU Hit:39, 2Q Hit:39, TinyLFU Hit:29
LRU Hit:42, 2Q Hit:42, TinyLFU Hit:28
LRU Hit:39, 2Q Hit:39, TinyLFU Hit:30
LRU Hit:42, 2Q Hit:40, TinyLFU Hit:39
LRU Hit:41, 2Q Hit:41, TinyLFU Hit:40
LRU Hit:0, 2Q Hit:12, TinyLFU Hit:40
LRU Hit:0, 2Q Hit:11, TinyLFU Hit:39
LRU Hit:0, 2Q Hit:12, TinyLFU Hit:37
LRU Hit:13, 2Q Hit:13, TinyLFU Hit:41
LRU Hit:12, 2Q Hit:12, TinyLFU Hit:41
LRU Hit:11, 2Q Hit:11, TinyLFU Hit:40
LRU Hit:12, 2Q Hit:12, TinyLFU Hit:39
LRU Hit:11, 2Q Hit:11, TinyLFU Hit:39
LRU Hit:11, 2Q Hit:11, TinyLFU Hit:41
LRU Hit:12, 2Q Hit:12, TinyLFU Hit:41
LRU Hit:41, 2Q Hit:39, TinyLFU Hit:39
LRU Hit:38, 2Q Hit:39, TinyLFU Hit:40
LRU Hit:39, 2Q Hit:37, TinyLFU Hit:40
LRU Hit:40, 2Q Hit:40, TinyLFU Hit:38
LRU Hit:40, 2Q Hit:40, TinyLFU Hit:37
LRU Hit:38, 2Q Hit:38, TinyLFU Hit:43
LRU Hit:41, 2Q Hit:41, TinyLFU Hit:41
LRU Hit:41, 2Q Hit:41, TinyLFU Hit:41
LRU Hit:40, 2Q Hit:40, TinyLFU Hit:39
LRU Hit:41, 2Q Hit:41, TinyLFU Hit:40
LRU Hit:0, 2Q Hit:12, TinyLFU Hit:41
LRU Hit:0, 2Q Hit:12, TinyLFU Hit:43
```

## What are the type of the changes (required)?
- New feature (non-breaking change which adds functionality)

## How has this PR been tested (required)?
- Unit tests
- Manual tests

