### PR TITLE
revive linter: exit 1 on failure

### DIFF
--- a/revive.toml
+++ b/revive.toml
@@ -1,7 +1,7 @@
 ignoreGeneratedHeader = false
 severity = "error"
 confidence = 0.8
-errorCode = 0
+errorCode = 1
 warningCode = 0
 
 [rule.blank-imports]


### PR DESCRIPTION
## What have you changed? (required)

revive linter: exit 1 on failure.
I didn't realize it was defaulting to exit with code 0.
Warning still exits with code 0.