### PR TITLE
server: try to replace the down replicas instead of removing directly

### DIFF
--- a/pkg/faketikv/cases/cases.go
+++ b/pkg/faketikv/cases/cases.go
@@ -74,15 +74,15 @@ func (a *idAllocator) nextID() uint64 {
 
 // ConfMap is a mapping of the cases to the their corresponding initialize functions.
 var ConfMap = map[string]func() *Conf{
-	"balance-leader":      newBalanceLeader,
-	"add-nodes":           newAddNodes,
-	"add-nodes-dynamic":   newAddNodesDynamic,
-	"delete-nodes":        newDeleteNodes,
-	"region-split":        newRegionSplit,
-	"region-merge":        newRegionMerge,
-	"hot-read":            newHotRead,
-	"hot-write":           newHotWrite,
-	"makeup-down-replica": newMakeupDownReplica,
+	"balance-leader":       newBalanceLeader,
+	"add-nodes":            newAddNodes,
+	"add-nodes-dynamic":    newAddNodesDynamic,
+	"delete-nodes":         newDeleteNodes,
+	"region-split":         newRegionSplit,
+	"region-merge":         newRegionMerge,
+	"hot-read":             newHotRead,
+	"hot-write":            newHotWrite,
+	"makeup-down-replicas": newMakeupDownReplicas,
 }
 
 // NewConf creates a config to initialize simulator cluster.

--- a/pkg/faketikv/cases/cases.go
+++ b/pkg/faketikv/cases/cases.go
@@ -74,14 +74,15 @@ func (a *idAllocator) nextID() uint64 {
 
 // ConfMap is a mapping of the cases to the their corresponding initialize functions.
 var ConfMap = map[string]func() *Conf{
-	"balance-leader":    newBalanceLeader,
-	"add-nodes":         newAddNodes,
-	"add-nodes-dynamic": newAddNodesDynamic,
-	"delete-nodes":      newDeleteNodes,
-	"region-split":      newRegionSplit,
-	"region-merge":      newRegionMerge,
-	"hot-read":          newHotRead,
-	"hot-write":         newHotWrite,
+	"balance-leader":      newBalanceLeader,
+	"add-nodes":           newAddNodes,
+	"add-nodes-dynamic":   newAddNodesDynamic,
+	"delete-nodes":        newDeleteNodes,
+	"region-split":        newRegionSplit,
+	"region-merge":        newRegionMerge,
+	"hot-read":            newHotRead,
+	"hot-write":           newHotWrite,
+	"makeup-down-replica": newMakeupDownReplica,
 }
 
 // NewConf creates a config to initialize simulator cluster.

--- a/pkg/faketikv/cases/makeup_down_replica.go
+++ b/pkg/faketikv/cases/makeup_down_replica.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pingcap/pd/server/core"
 )
 
-func newMakeupDownReplica() *Conf {
+func newMakeupDownReplicas() *Conf {
 	var conf Conf
 	var id idAllocator
 
@@ -48,19 +48,13 @@ func newMakeupDownReplica() *Conf {
 	}
 	conf.MaxID = id.maxID
 
-	var ids []uint64
-	for _, store := range conf.Stores {
-		ids = append(ids, store.ID)
-	}
-
 	numNodes := 4
-	e := &DeleteNodesInner{}
 	down := false
+	e := &DeleteNodesInner{}
 	e.Step = func(tick int64) uint64 {
 		if numNodes > 3 && tick%100 == 0 {
 			numNodes--
-			nodeID := uint64(1)
-			return nodeID
+			return uint64(1)
 		}
 		if tick == 300 {
 			down = true
@@ -79,21 +73,21 @@ func newMakeupDownReplica() *Conf {
 			}
 			sum += regionCount
 		}
-
 		simutil.Logger.Infof("region counts: %v", regionCounts)
+
 		if down && sum < 1200 {
-			simutil.Logger.Error("making up replica doesn't start immediately")
+			// only need to print once
 			down = false
+			simutil.Logger.Error("making up replicas don't start immediately")
 			return false
 		}
+
 		for _, regionCount := range regionCounts {
 			if regionCount != 400 {
 				return false
 			}
 		}
-
 		return true
-
 	}
 	return &conf
 }

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -364,12 +364,10 @@ func (s *testCoordinatorSuite) TestReplica(c *C) {
 		core.WithDownPeers(append(region.GetDownPeers(), downPeer)),
 	)
 	dispatchHeartbeat(c, co, region, stream)
-	waitRemovePeer(c, stream, region, 3)
-	region = region.Clone(core.WithDownPeers(nil))
-	dispatchHeartbeat(c, co, region, stream)
 	waitAddLearner(c, stream, region, 4)
 	dispatchHeartbeat(c, co, region, stream)
 	waitPromoteLearner(c, stream, region, 4)
+	region = region.Clone(core.WithDownPeers(nil))
 	dispatchHeartbeat(c, co, region, stream)
 	waitNoResponse(c, stream)
 

--- a/server/schedule/replica_checker.go
+++ b/server/schedule/replica_checker.go
@@ -250,7 +250,7 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, peer *metapb.Peer, sta
 
 	storeID, _ := r.SelectBestReplacementStore(region, peer, NewStorageThresholdFilter())
 	if storeID == 0 {
-		log.Debugf("[region %d] no best store to add replica", region.GetId())
+		log.Debugf("[region %d] no best store to add replica", region.GetID())
 		return nil
 	}
 	newPeer, err := r.cluster.AllocPeer(storeID)

--- a/server/schedule/replica_checker.go
+++ b/server/schedule/replica_checker.go
@@ -14,6 +14,8 @@
 package schedule
 
 import (
+	"fmt"
+
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/server/namespace"
@@ -169,7 +171,8 @@ func (r *ReplicaChecker) checkDownPeer(region *core.RegionInfo) *Operator {
 		if stats.GetDownSeconds() < uint64(r.cluster.GetMaxStoreDownTime().Seconds()) {
 			continue
 		}
-		return CreateRemovePeerOperator("removeDownReplica", r.cluster, OpReplica, region, peer.GetStoreId())
+
+		return r.handleReplica(region, peer, "Down")
 	}
 	return nil
 }
@@ -194,29 +197,7 @@ func (r *ReplicaChecker) checkOfflinePeer(region *core.RegionInfo) *Operator {
 			continue
 		}
 
-		// Check the number of replicas first.
-		if len(region.GetPeers()) > r.cluster.GetMaxReplicas() {
-			return CreateRemovePeerOperator("removeExtraOfflineReplica", r.cluster, OpReplica, region, peer.GetStoreId())
-		}
-
-		// Consider we have 3 peers (A, B, C), we set the store that contains C to
-		// offline while C is pending. If we generate an operator that adds a replica
-		// D then removes C, D will not be successfully added util C is normal again.
-		// So it's better to remove C directly.
-		if region.GetPendingPeer(peer.GetId()) != nil {
-			return CreateRemovePeerOperator("removePendingOfflineReplica", r.cluster, OpReplica, region, peer.GetStoreId())
-		}
-
-		storeID, _ := r.SelectBestReplacementStore(region, peer, NewStorageThresholdFilter())
-		if storeID == 0 {
-			log.Debugf("[region %d] no best store to add replica", region.GetID())
-			return nil
-		}
-		newPeer, err := r.cluster.AllocPeer(storeID)
-		if err != nil {
-			return nil
-		}
-		return CreateMovePeerOperator("replaceOfflineReplica", r.cluster, region, OpReplica, peer.GetStoreId(), newPeer.GetStoreId(), newPeer.GetId())
+		return r.handleReplica(region, peer, "Offline")
 	}
 
 	return nil
@@ -249,4 +230,34 @@ func (r *ReplicaChecker) checkBestReplacement(region *core.RegionInfo) *Operator
 	}
 	checkerCounter.WithLabelValues("replica_checker", "new_operator").Inc()
 	return CreateMovePeerOperator("moveToBetterLocation", r.cluster, region, OpReplica, oldPeer.GetStoreId(), newPeer.GetStoreId(), newPeer.GetId())
+}
+
+func (r *ReplicaChecker) handleReplica(region *core.RegionInfo, peer *metapb.Peer, status string) *Operator {
+	removeExtra := fmt.Sprintf("%s%s%s", "removeExtra", status, "Replica")
+	// Check the number of replicas first.
+	if len(region.GetPeers()) > r.cluster.GetMaxReplicas() {
+		return CreateRemovePeerOperator(removeExtra, r.cluster, OpReplica, region, peer.GetStoreId())
+	}
+
+	removePending := fmt.Sprintf("%s%s%s", "removePending", status, "Replica")
+	// Consider we have 3 peers (A, B, C), we set the store that contains C to
+	// offline/down while C is pending. If we generate an operator that adds a replica
+	// D then removes C, D will not be successfully added util C is normal again.
+	// So it's better to remove C directly.
+	if region.GetPendingPeer(peer.GetId()) != nil {
+		return CreateRemovePeerOperator(removePending, r.cluster, OpReplica, region, peer.GetStoreId())
+	}
+
+	storeID, _ := r.SelectBestReplacementStore(region, peer, NewStorageThresholdFilter())
+	if storeID == 0 {
+		log.Debugf("[region %d] no best store to add replica", region.GetId())
+		return nil
+	}
+	newPeer, err := r.cluster.AllocPeer(storeID)
+	if err != nil {
+		return nil
+	}
+
+	replace := fmt.Sprintf("%s%s%s", "replace", status, "Replica")
+	return CreateMovePeerOperator(replace, r.cluster, region, OpReplica, peer.GetStoreId(), newPeer.GetStoreId(), newPeer.GetId())
 }

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -544,11 +544,9 @@ func (s *testReplicaCheckerSuite) TestBasic(c *C) {
 		Peer:        region.GetStorePeer(2),
 		DownSeconds: 24 * 60 * 60,
 	}
-	region = region.Clone(
-		core.WithRemoveStorePeer(1),
-		core.WithDownPeers(append(region.GetDownPeers(), downPeer)),
-	)
-	testutil.CheckRemovePeer(c, rc.Check(region), 2)
+
+	region = region.Clone(core.WithDownPeers(append(region.GetDownPeers(), downPeer)))
+	testutil.CheckTransferPeer(c, rc.Check(region), schedule.OpReplica, 2, 1)
 	region = region.Clone(core.WithDownPeers(nil))
 	c.Assert(rc.Check(region), IsNil)
 
@@ -796,7 +794,7 @@ func (s *testReplicaCheckerSuite) TestOpts(c *C) {
 	}))
 	tc.SetStoreOffline(2)
 	// RemoveDownReplica has higher priority than replaceOfflineReplica.
-	testutil.CheckRemovePeer(c, rc.Check(region), 1)
+	testutil.CheckTransferPeer(c, rc.Check(region), schedule.OpReplica, 1, 4)
 	opt.DisableRemoveDownReplica = true
 	testutil.CheckTransferPeer(c, rc.Check(region), schedule.OpReplica, 2, 4)
 	opt.DisableReplaceOfflineReplica = true


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
At present, if a store is down, it will remove peers in the store directly, and then make up replicas. It usually needs some time because it will traverse all the regions. 

### What is changed and how it works?
This PR tries to move the peers to another store if the original store is down.
Besides, this PR adds a case in the simulator to simulate this kind of situation. It will print an error log without these changes: `making up replicas don't start immediately`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test 

