### PR TITLE
server: make debug log look better

### DIFF
--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -153,8 +153,8 @@ func (l *balanceLeaderScheduler) createOperator(region *core.RegionInfo, source,
 	}
 
 	if !shouldBalance(cluster, source, target, region, core.LeaderKind, opInfluence) {
-		log.Debugf(`[%s] skip balance region %d, source %d to target %d, source size: %v, source score: %v, source influence: %v,
-			target size: %v, target score: %v, target influence: %v, average region size: %v`, l.GetName(), region.GetId(), source.GetId(), target.GetId(),
+		log.Debugf("[%s] skip balance region %d, source %d to target %d, source size: %v, source score: %v, source influence: %v, target size: %v, target score: %v, target influence: %v, average region size: %v",
+			l.GetName(), region.GetId(), source.GetId(), target.GetId(),
 			source.LeaderSize, source.LeaderScore(0), opInfluence.GetStoreInfluence(source.GetId()).ResourceSize(core.LeaderKind),
 			target.LeaderSize, target.LeaderScore(0), opInfluence.GetStoreInfluence(target.GetId()).ResourceSize(core.LeaderKind),
 			cluster.GetAverageRegionSize())

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -151,8 +151,8 @@ func (s *balanceRegionScheduler) transferPeer(cluster schedule.Cluster, region *
 	log.Debugf("[region %d] source store id is %v, target store id is %v", region.GetId(), source.GetId(), target.GetId())
 
 	if !shouldBalance(cluster, source, target, region, core.RegionKind, opInfluence) {
-		log.Debugf(`[%s] skip balance region %d, source %d to target %d ,source size: %v, source score: %v, source influence: %v, 
-			target size: %v, target score: %v, target influence: %v, average region size: %v`, s.GetName(), region.GetId(), source.GetId(), target.GetId(),
+		log.Debugf("[%s] skip balance region %d, source %d to target %d ,source size: %v, source score: %v, source influence: %v, target size: %v, target score: %v, target influence: %v, average region size: %v",
+			s.GetName(), region.GetId(), source.GetId(), target.GetId(),
 			source.RegionSize, source.RegionScore(cluster.GetHighSpaceRatio(), cluster.GetLowSpaceRatio(), 0),
 			opInfluence.GetStoreInfluence(source.GetId()).ResourceSize(core.RegionKind),
 			target.RegionSize, target.RegionScore(cluster.GetHighSpaceRatio(), cluster.GetLowSpaceRatio(), 0),


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
This PR is going to make the debug log look better.

### What is changed and how it works?
before:
```
2018/08/30 10:11:03.437 balance_leader.go:156: [debug] [balance-leader-scheduler] skip balance region 2968, source 4 to target 2, source size: 19296, source score: 19296, so
urce influence: 0,
			target size: 18912, target score: 18912, target influence: 0, average region size: 96
```
after:
```
2018/08/30 10:12:43.080 balance_leader.go:156: [debug] [balance-leader-scheduler] skip balance region 1896, source 6 to target 1, source size: 11808, source score: 11808, so
urce influence: 0, target size: 11712, target score: 11712, target influence: 0, average region size: 96
```