### PR TITLE
server: store cannot turn into tombstone due to limited resources

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -448,18 +448,40 @@ func (c *RaftCluster) SetStoreWeight(storeID uint64, leader, region float64) err
 }
 
 func (c *RaftCluster) checkStores() {
+	var offlineStore *metapb.Store
+	var upStoreCount uint64
+
 	cluster := c.cachedCluster
-	for _, store := range cluster.getMetaStores() {
+	allStoresFull := true
+
+	for _, store := range cluster.GetStores() {
 		if store.GetState() != metapb.StoreState_Offline {
+			if !store.IsLowSpace(cluster.GetLowSpaceRatio()) {
+				allStoresFull = false
+			}
+			upStoreCount++
 			continue
 		}
-		if c.storeIsEmpty(store.GetId()) {
-			err := c.BuryStore(store.GetId(), false)
-			if err != nil {
-				log.Errorf("bury store %v failed: %v", store, err)
-			} else {
-				log.Infof("buried store %v", store)
-			}
+		offlineStore = store.Store
+	}
+
+	if upStoreCount < c.s.GetConfig().Replication.MaxReplicas {
+		log.Warnf("store %v cannot turn into Tombstone, there are no extra nodes to accommodate the extra replicas", offlineStore)
+		return
+	}
+
+	offlineStoreID := offlineStore.GetId()
+	if allStoresFull && !c.storeIsEmpty(offlineStoreID) {
+		log.Warnf("store %v cannot turn into Tombstone, there are no extra space to accommodate the extra replicas", offlineStore)
+		return
+	}
+
+	if c.storeIsEmpty(offlineStoreID) {
+		err := c.BuryStore(offlineStoreID, false)
+		if err != nil {
+			log.Errorf("bury store %v failed: %v", offlineStore, err)
+		} else {
+			log.Infof("buried store %v", offlineStore)
 		}
 	}
 }

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -461,7 +461,7 @@ func (c *RaftCluster) checkStores() {
 		}
 		offlineStore := store.Store
 		// If the store is empty, it can be buried.
-		if cluster.isPrepared() && cluster.getStoreRegionCount(offlineStore.GetId()) == 0 {
+		if cluster.getStoreRegionCount(offlineStore.GetId()) == 0 {
 			err := c.BuryStore(offlineStore.GetId(), false)
 			if err != nil {
 				log.Errorf("bury store %v failed: %v", offlineStore, err)

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -479,7 +479,7 @@ func (c *RaftCluster) checkStores() {
 		}
 	}
 
-	if offlineStores == nil {
+	if len(offlineStores) == 0 {
 		return
 	}
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
This PR closes #1221.

### What is changed and how it works?
When setting a store to `Offline`, it won't turn into `Tombstone`, if there are no extra space or nodes to accommodate the extra replicas. This PR will show warning message to let user know about it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 
