### PR TITLE
client: Add GetAllStores function to PdClient interface

### DIFF
--- a/pd-client/client_test.go
+++ b/pd-client/client_test.go
@@ -281,6 +281,15 @@ func (s *testClientSuite) TestGetStore(c *C) {
 	c.Assert(n, IsNil)
 }
 
+func (s *testClientSuite) TestGetAllStores(c *C) {
+	cluster := s.srv.GetRaftCluster()
+	c.Assert(cluster, NotNil)
+
+	stores, err := s.client.GetAllStores(context.Background())
+	c.Assert(err, IsNil)
+	c.Assert(stores, DeepEquals, []*metapb.Store{store})
+}
+
 func (s *testClientSuite) checkGCSafePoint(c *C, expectedSafePoint uint64) {
 	req := &pdpb.GetGCSafePointRequest{
 		Header: newHeader(s.srv),


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

Now we want invoke RPC calls to each TiKV in TiDB, so TiDB should know all TiKVs before doing this. PD already has this functionality but it didn't show up in the PDClient interface. Add it so that TiDB can call it conveniently.

### What is changed and how it works?

This PR added GetAllStores function to PdClient interface so that TiDB can use it conveniently to get all TiKVs.

### Check List <!--REMOVE the items that are not applicable-->

Tests

 - Unit test

Related changes

 - Need to cherry-pick to the release branch (Maybe)