### PR TITLE
pd-ctl: list all regions in a specified store 

### DIFF
--- a/pdctl/command/region_command.go
+++ b/pdctl/command/region_command.go
@@ -26,6 +26,7 @@ import (
 
 var (
 	regionsPrefix          = "pd/api/v1/regions"
+	regionsStorePrefix     = "pd/api/v1/regions/store"
 	regionsCheckPrefix     = "pd/api/v1/regions/check"
 	regionsWriteflowPrefix = "pd/api/v1/regions/writeflow"
 	regionsReadflowPrefix  = "pd/api/v1/regions/readflow"
@@ -34,7 +35,7 @@ var (
 	regionKeyPrefix        = "pd/api/v1/region/key"
 )
 
-// NewRegionCommand return a region subcommand of rootCmd
+// NewRegionCommand returns a region subcommand of rootCmd
 func NewRegionCommand() *cobra.Command {
 	r := &cobra.Command{
 		Use:   `region <region_id> [-jq="<query string>"]`,
@@ -44,6 +45,7 @@ func NewRegionCommand() *cobra.Command {
 	r.AddCommand(NewRegionWithKeyCommand())
 	r.AddCommand(NewRegionWithCheckCommand())
 	r.AddCommand(NewRegionWithSiblingCommand())
+	r.AddCommand(NewRegionWithStoreCommand())
 
 	topRead := &cobra.Command{
 		Use:   "topread <limit>",
@@ -119,7 +121,7 @@ func showRegionTopReadCommandFunc(cmd *cobra.Command, args []string) {
 	fmt.Println(r)
 }
 
-// NewRegionWithKeyCommand return a region with key subcommand of regionCmd
+// NewRegionWithKeyCommand returns a region with key subcommand of regionCmd
 func NewRegionWithKeyCommand() *cobra.Command {
 	r := &cobra.Command{
 		Use:   "key [--format=raw|pb|proto|protobuf] <key>",
@@ -188,7 +190,7 @@ func decodeProtobufText(text string) (string, error) {
 	return string(buf), nil
 }
 
-// NewRegionWithCheckCommand return a region with check subcommand of regionCmd
+// NewRegionWithCheckCommand returns a region with check subcommand of regionCmd
 func NewRegionWithCheckCommand() *cobra.Command {
 	r := &cobra.Command{
 		Use:   "check [miss-peer|extra-peer|down-peer|pending-peer|incorrect-ns]",
@@ -213,7 +215,7 @@ func showRegionWithCheckCommandFunc(cmd *cobra.Command, args []string) {
 	fmt.Println(r)
 }
 
-// NewRegionWithSiblingCommand return a region with check subcommand of regionCmd
+// NewRegionWithSiblingCommand returns a region with sibling subcommand of regionCmd
 func NewRegionWithSiblingCommand() *cobra.Command {
 	r := &cobra.Command{
 		Use:   "sibling <region_id>",
@@ -233,6 +235,31 @@ func showRegionWithSiblingCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
 		fmt.Printf("Failed to get region sibling: %s\n", err)
+		return
+	}
+	fmt.Println(r)
+}
+
+// NewRegionWithStoreCommand returns regions with store subcommand of regionCmd
+func NewRegionWithStoreCommand() *cobra.Command {
+	r := &cobra.Command{
+		Use:   "store <store_id>",
+		Short: "show the regions of a specific store",
+		Run:   showRegionWithStoreCommandFunc,
+	}
+	return r
+}
+
+func showRegionWithStoreCommandFunc(cmd *cobra.Command, args []string) {
+	if len(args) != 1 {
+		fmt.Println(cmd.UsageString())
+		return
+	}
+	storeID := args[0]
+	prefix := regionsStorePrefix + "/" + storeID
+	r, err := doRequest(cmd, prefix, http.MethodGet)
+	if err != nil {
+		fmt.Printf("Failed to get regions with the given storeID: %s\n", err)
 		return
 	}
 	fmt.Println(r)

--- a/server/api/api.raml
+++ b/server/api/api.raml
@@ -861,6 +861,20 @@ types:
           description: The region does not exist.
         500:
           description: PD server failed to proceed the request.
+  /store/{id}:
+    uriParameters:
+      id: integer
+    get:
+      description: List all regions of a specific store.
+      responses:
+        200:
+          body:
+            application/json:
+              type: Regions
+        400:
+          description: The input is invalid.
+        500:
+          description: PD server failed to proceed the request.
 
 /schedulers:
   description: Running schedulers.

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -143,6 +143,31 @@ func (h *regionsHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 	h.rd.JSON(w, http.StatusOK, regionsInfo)
 }
 
+func (h *regionsHandler) GetStoreRegions(w http.ResponseWriter, r *http.Request) {
+	cluster := h.svr.GetRaftCluster()
+	if cluster == nil {
+		h.rd.JSON(w, http.StatusInternalServerError, server.ErrNotBootstrapped.Error())
+		return
+	}
+
+	vars := mux.Vars(r)
+	id, err := strconv.Atoi(vars["id"])
+	if err != nil {
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	regions := cluster.GetStoreRegions(uint64(id))
+	regionInfos := make([]*regionInfo, len(regions))
+	for i, r := range regions {
+		regionInfos[i] = newRegionInfo(r)
+	}
+	regionsInfo := &regionsInfo{
+		Count:   len(regions),
+		Regions: regionInfos,
+	}
+	h.rd.JSON(w, http.StatusOK, regionsInfo)
+}
+
 func (h *regionsHandler) GetMissPeerRegions(w http.ResponseWriter, r *http.Request) {
 	handler := h.svr.GetHandler()
 	res, err := handler.GetMissPeerRegions()

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -84,6 +84,7 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 
 	regionsHandler := newRegionsHandler(svr, rd)
 	router.HandleFunc("/api/v1/regions", regionsHandler.GetAll).Methods("GET")
+	router.HandleFunc("/api/v1/regions/store/{id}", regionsHandler.GetStoreRegions).Methods("GET")
 	router.HandleFunc("/api/v1/regions/writeflow", regionsHandler.GetTopWriteFlow).Methods("GET")
 	router.HandleFunc("/api/v1/regions/readflow", regionsHandler.GetTopReadFlow).Methods("GET")
 	router.HandleFunc("/api/v1/regions/check/miss-peer", regionsHandler.GetMissPeerRegions).Methods("GET")

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -252,6 +252,11 @@ func (c *RaftCluster) GetRegions() []*core.RegionInfo {
 	return c.cachedCluster.getRegions()
 }
 
+// GetStoreRegions returns all regions info with a given storeID.
+func (c *RaftCluster) GetStoreRegions(storeID uint64) []*core.RegionInfo {
+	return c.cachedCluster.getStoreRegions(storeID)
+}
+
 // GetRegionStats returns region statistics from cluster.
 func (c *RaftCluster) GetRegionStats(startKey, endKey []byte) *core.RegionStats {
 	return c.cachedCluster.getRegionStats(startKey, endKey)

--- a/server/cluster_info.go
+++ b/server/cluster_info.go
@@ -312,6 +312,12 @@ func (c *clusterInfo) getRegions() []*core.RegionInfo {
 	return c.core.Regions.GetRegions()
 }
 
+func (c *clusterInfo) getStoreRegions(storeID uint64) []*core.RegionInfo {
+	c.RLock()
+	defer c.RUnlock()
+	return c.core.Regions.GetStoreRegions(storeID)
+}
+
 func (c *clusterInfo) getMetaRegions() []*metapb.Region {
 	c.RLock()
 	defer c.RUnlock()

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -630,6 +630,18 @@ func (r *RegionsInfo) GetRegions() []*RegionInfo {
 	return regions
 }
 
+// GetStoreRegions gets all RegionInfo with a given storeID
+func (r *RegionsInfo) GetStoreRegions(storeID uint64) []*RegionInfo {
+	var regions []*RegionInfo
+	for _, region := range r.regions.m {
+		storeIDs := region.GetStoreIds()
+		if _, ok := storeIDs[storeID]; ok {
+			regions = append(regions, region.Clone())
+		}
+	}
+	return regions
+}
+
 // GetStoreLeaderRegionSize get total size of store's leader regions
 func (r *RegionsInfo) GetStoreLeaderRegionSize(storeID uint64) int64 {
 	return r.leaders[storeID].TotalSize()

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -632,15 +632,15 @@ func (r *RegionsInfo) GetRegions() []*RegionInfo {
 
 // GetStoreRegions gets all RegionInfo with a given storeID
 func (r *RegionsInfo) GetStoreRegions(storeID uint64) []*RegionInfo {
-	var regions []*RegionInfo
+	regions := make([]*RegionInfo, 0, r.GetStoreLeaderCount(storeID)+r.GetStoreFollowerCount(storeID))
 	if leaders, ok := r.leaders[storeID]; ok {
 		for _, region := range leaders.m {
-			regions = append(regions, region.Clone())
+			regions = append(regions, region.RegionInfo)
 		}
 	}
 	if followers, ok := r.followers[storeID]; ok {
 		for _, region := range followers.m {
-			regions = append(regions, region.Clone())
+			regions = append(regions, region.RegionInfo)
 		}
 	}
 	return regions

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -633,9 +633,13 @@ func (r *RegionsInfo) GetRegions() []*RegionInfo {
 // GetStoreRegions gets all RegionInfo with a given storeID
 func (r *RegionsInfo) GetStoreRegions(storeID uint64) []*RegionInfo {
 	var regions []*RegionInfo
-	for _, region := range r.regions.m {
-		storeIDs := region.GetStoreIds()
-		if _, ok := storeIDs[storeID]; ok {
+	if r.leaders[storeID] != nil {
+		for _, region := range r.leaders[storeID].m {
+			regions = append(regions, region.Clone())
+		}
+	}
+	if r.followers[storeID] != nil {
+		for _, region := range r.followers[storeID].m {
 			regions = append(regions, region.Clone())
 		}
 	}

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -633,13 +633,13 @@ func (r *RegionsInfo) GetRegions() []*RegionInfo {
 // GetStoreRegions gets all RegionInfo with a given storeID
 func (r *RegionsInfo) GetStoreRegions(storeID uint64) []*RegionInfo {
 	var regions []*RegionInfo
-	if r.leaders[storeID] != nil {
-		for _, region := range r.leaders[storeID].m {
+	if leaders, ok := r.leaders[storeID]; ok {
+		for _, region := range leaders.m {
 			regions = append(regions, region.Clone())
 		}
 	}
-	if r.followers[storeID] != nil {
-		for _, region := range r.followers[storeID].m {
+	if followers, ok := r.followers[storeID]; ok {
+		for _, region := range followers.m {
 			regions = append(regions, region.Clone())
 		}
 	}


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Closes #511.

### What is changed and how it works?
This PR adds API to list all regions in a specified store. After this PR is merged, we can use `region store <id>` to print all regions in a specified store by using `pd-ctl`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
