### PR TITLE
pd-ctl: support topconfver and topversion

### DIFF
--- a/pdctl/command/region_command.go
+++ b/pdctl/command/region_command.go
@@ -30,6 +30,8 @@ var (
 	regionsCheckPrefix     = "pd/api/v1/regions/check"
 	regionsWriteflowPrefix = "pd/api/v1/regions/writeflow"
 	regionsReadflowPrefix  = "pd/api/v1/regions/readflow"
+	regionsConfVerPrefix   = "pd/api/v1/regions/confver"
+	regionsVersionPrefix   = "pd/api/v1/regions/version"
 	regionsSiblingPrefix   = "pd/api/v1/regions/sibling"
 	regionIDPrefix         = "pd/api/v1/region/id"
 	regionKeyPrefix        = "pd/api/v1/region/key"
@@ -60,6 +62,20 @@ func NewRegionCommand() *cobra.Command {
 		Run:   showRegionTopWriteCommandFunc,
 	}
 	r.AddCommand(topWrite)
+
+	topConfVer := &cobra.Command{
+		Use:   "topconfver <limit>",
+		Short: "show regions with top conf verion",
+		Run:   showRegionTopConfVerCommandFunc,
+	}
+	r.AddCommand(topConfVer)
+
+	topVersion := &cobra.Command{
+		Use:   "topversion <limit>",
+		Short: "show regions with top version",
+		Run:   showRegionTopVersionCommandFunc,
+	}
+	r.AddCommand(topVersion)
 	r.Flags().String("jq", "", "jq query")
 
 	return r
@@ -121,7 +137,41 @@ func showRegionTopReadCommandFunc(cmd *cobra.Command, args []string) {
 	fmt.Println(r)
 }
 
-// NewRegionWithKeyCommand returns a region with key subcommand of regionCmd
+func showRegionTopConfVerCommandFunc(cmd *cobra.Command, args []string) {
+	prefix := regionsConfVerPrefix
+	if len(args) == 1 {
+		if _, err := strconv.Atoi(args[0]); err != nil {
+			fmt.Println("limit should be a number")
+			return
+		}
+		prefix += "?limit=" + args[0]
+	}
+	r, err := doRequest(cmd, prefix, http.MethodGet)
+	if err != nil {
+		fmt.Printf("Failed to get regions: %s\n", err)
+		return
+	}
+	fmt.Println(r)
+}
+
+func showRegionTopVersionCommandFunc(cmd *cobra.Command, args []string) {
+	prefix := regionsVersionPrefix
+	if len(args) == 1 {
+		if _, err := strconv.Atoi(args[0]); err != nil {
+			fmt.Println("limit should be a number")
+			return
+		}
+		prefix += "?limit=" + args[0]
+	}
+	r, err := doRequest(cmd, prefix, http.MethodGet)
+	if err != nil {
+		fmt.Printf("Failed to get regions: %s\n", err)
+		return
+	}
+	fmt.Println(r)
+}
+
+// NewRegionWithKeyCommand return a region with key subcommand of regionCmd
 func NewRegionWithKeyCommand() *cobra.Command {
 	r := &cobra.Command{
 		Use:   "key [--format=raw|pb|proto|protobuf] <key>",

--- a/pdctl/command/region_command.go
+++ b/pdctl/command/region_command.go
@@ -65,7 +65,7 @@ func NewRegionCommand() *cobra.Command {
 
 	topConfVer := &cobra.Command{
 		Use:   "topconfver <limit>",
-		Short: "show regions with top conf verion",
+		Short: "show regions with top conf version",
 		Run:   showRegionTopConfVerCommandFunc,
 	}
 	r.AddCommand(topConfVer)

--- a/server/api/api.raml
+++ b/server/api/api.raml
@@ -831,6 +831,38 @@ types:
           description: The input is invalid.
         500:
           description: PD server failed to proceed the request.
+  /confver:
+    get:
+      description: List regions with the largest conf version.
+      queryParameters:
+        limit?:
+          type: integer
+          default: 16
+      responses:
+        200:
+          body:
+            application/json:
+              type: Regions
+        400:
+          description: The input is invalid.
+        500:
+          description: PD server failed to proceed the request.
+  /version:
+    get:
+      description: List regions with the largest version.
+      queryParameters:
+        limit?:
+          type: integer
+          default: 16
+      responses:
+        200:
+          body:
+            application/json:
+              type: Regions
+        400:
+          description: The input is invalid.
+        500:
+          description: PD server failed to proceed the request.
   /check/{filter}:
     uriParameters:
       filter:

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -255,6 +255,18 @@ func (h *regionsHandler) GetTopReadFlow(w http.ResponseWriter, r *http.Request) 
 	h.GetTopNRegions(w, r, func(a, b *core.RegionInfo) bool { return a.GetBytesRead() < b.GetBytesRead() })
 }
 
+func (h *regionsHandler) GetTopConfVer(w http.ResponseWriter, r *http.Request) {
+	h.GetTopNRegions(w, r, func(a, b *core.RegionInfo) bool {
+		return a.GetMeta().GetRegionEpoch().GetConfVer() < b.GetMeta().GetRegionEpoch().GetConfVer()
+	})
+}
+
+func (h *regionsHandler) GetTopVersion(w http.ResponseWriter, r *http.Request) {
+	h.GetTopNRegions(w, r, func(a, b *core.RegionInfo) bool {
+		return a.GetMeta().GetRegionEpoch().GetVersion() < b.GetMeta().GetRegionEpoch().GetVersion()
+	})
+}
+
 func (h *regionsHandler) GetTopNRegions(w http.ResponseWriter, r *http.Request, less func(a, b *core.RegionInfo) bool) {
 	cluster := h.svr.GetRaftCluster()
 	if cluster == nil {

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -52,10 +52,11 @@ func newTestRegionInfo(regionID, storeID uint64, start, end []byte, opts ...core
 		StoreId: storeID,
 	}
 	metaRegion := &metapb.Region{
-		Id:       regionID,
-		StartKey: start,
-		EndKey:   end,
-		Peers:    []*metapb.Peer{leader},
+		Id:          regionID,
+		StartKey:    start,
+		EndKey:      end,
+		Peers:       []*metapb.Peer{leader},
+		RegionEpoch: &metapb.RegionEpoch{ConfVer: 1, Version: 1},
 	}
 	newOpts := []core.RegionCreateOption{
 		core.SetApproximateKeys(10),
@@ -120,15 +121,19 @@ func (s *testRegionSuite) TestStoreRegions(c *C) {
 }
 
 func (s *testRegionSuite) TestTopFlow(c *C) {
-	r1 := newTestRegionInfo(1, 1, []byte("a"), []byte("b"), core.SetWrittenBytes(1000), core.SetReadBytes(1000))
+	r1 := newTestRegionInfo(1, 1, []byte("a"), []byte("b"), core.SetWrittenBytes(1000), core.SetReadBytes(1000), core.SetRegionConfVer(1), core.SetRegionVersion(1))
 	mustRegionHeartbeat(c, s.svr, r1)
-	r2 := newTestRegionInfo(2, 1, []byte("b"), []byte("c"), core.SetWrittenBytes(2000), core.SetReadBytes(0))
+	r2 := newTestRegionInfo(2, 1, []byte("b"), []byte("c"), core.SetWrittenBytes(2000), core.SetReadBytes(0), core.SetRegionConfVer(2), core.SetRegionVersion(3))
 	mustRegionHeartbeat(c, s.svr, r2)
-	r3 := newTestRegionInfo(3, 1, []byte("c"), []byte("d"), core.SetWrittenBytes(500), core.SetReadBytes(800))
+	r3 := newTestRegionInfo(3, 1, []byte("c"), []byte("d"), core.SetWrittenBytes(500), core.SetReadBytes(800), core.SetRegionConfVer(3), core.SetRegionVersion(2))
 	mustRegionHeartbeat(c, s.svr, r3)
 	s.checkTopFlow(c, fmt.Sprintf("%s/regions/writeflow", s.urlPrefix), []uint64{2, 1, 3})
 	s.checkTopFlow(c, fmt.Sprintf("%s/regions/readflow", s.urlPrefix), []uint64{1, 3, 2})
 	s.checkTopFlow(c, fmt.Sprintf("%s/regions/writeflow?limit=2", s.urlPrefix), []uint64{2, 1})
+	s.checkTopFlow(c, fmt.Sprintf("%s/regions/confver", s.urlPrefix), []uint64{3, 2, 1})
+	s.checkTopFlow(c, fmt.Sprintf("%s/regions/confver?limit=2", s.urlPrefix), []uint64{3, 2})
+	s.checkTopFlow(c, fmt.Sprintf("%s/regions/version", s.urlPrefix), []uint64{2, 3, 1})
+	s.checkTopFlow(c, fmt.Sprintf("%s/regions/version?limit=2", s.urlPrefix), []uint64{2, 3})
 }
 
 func (s *testRegionSuite) checkTopFlow(c *C, url string, regionIDs []uint64) {

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -127,16 +127,16 @@ func (s *testRegionSuite) TestTopFlow(c *C) {
 	mustRegionHeartbeat(c, s.svr, r2)
 	r3 := newTestRegionInfo(3, 1, []byte("c"), []byte("d"), core.SetWrittenBytes(500), core.SetReadBytes(800), core.SetRegionConfVer(3), core.SetRegionVersion(2))
 	mustRegionHeartbeat(c, s.svr, r3)
-	s.checkTopFlow(c, fmt.Sprintf("%s/regions/writeflow", s.urlPrefix), []uint64{2, 1, 3})
-	s.checkTopFlow(c, fmt.Sprintf("%s/regions/readflow", s.urlPrefix), []uint64{1, 3, 2})
-	s.checkTopFlow(c, fmt.Sprintf("%s/regions/writeflow?limit=2", s.urlPrefix), []uint64{2, 1})
-	s.checkTopFlow(c, fmt.Sprintf("%s/regions/confver", s.urlPrefix), []uint64{3, 2, 1})
-	s.checkTopFlow(c, fmt.Sprintf("%s/regions/confver?limit=2", s.urlPrefix), []uint64{3, 2})
-	s.checkTopFlow(c, fmt.Sprintf("%s/regions/version", s.urlPrefix), []uint64{2, 3, 1})
-	s.checkTopFlow(c, fmt.Sprintf("%s/regions/version?limit=2", s.urlPrefix), []uint64{2, 3})
+	s.checkTopRegions(c, fmt.Sprintf("%s/regions/writeflow", s.urlPrefix), []uint64{2, 1, 3})
+	s.checkTopRegions(c, fmt.Sprintf("%s/regions/readflow", s.urlPrefix), []uint64{1, 3, 2})
+	s.checkTopRegions(c, fmt.Sprintf("%s/regions/writeflow?limit=2", s.urlPrefix), []uint64{2, 1})
+	s.checkTopRegions(c, fmt.Sprintf("%s/regions/confver", s.urlPrefix), []uint64{3, 2, 1})
+	s.checkTopRegions(c, fmt.Sprintf("%s/regions/confver?limit=2", s.urlPrefix), []uint64{3, 2})
+	s.checkTopRegions(c, fmt.Sprintf("%s/regions/version", s.urlPrefix), []uint64{2, 3, 1})
+	s.checkTopRegions(c, fmt.Sprintf("%s/regions/version?limit=2", s.urlPrefix), []uint64{2, 3})
 }
 
-func (s *testRegionSuite) checkTopFlow(c *C, url string, regionIDs []uint64) {
+func (s *testRegionSuite) checkTopRegions(c *C, url string, regionIDs []uint64) {
 	regions := &regionsInfo{}
 	err := readJSONWithURL(url, regions)
 	c.Assert(err, IsNil)

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -87,6 +87,8 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	router.HandleFunc("/api/v1/regions/store/{id}", regionsHandler.GetStoreRegions).Methods("GET")
 	router.HandleFunc("/api/v1/regions/writeflow", regionsHandler.GetTopWriteFlow).Methods("GET")
 	router.HandleFunc("/api/v1/regions/readflow", regionsHandler.GetTopReadFlow).Methods("GET")
+	router.HandleFunc("/api/v1/regions/confver", regionsHandler.GetTopConfVer).Methods("GET")
+	router.HandleFunc("/api/v1/regions/version", regionsHandler.GetTopVersion).Methods("GET")
 	router.HandleFunc("/api/v1/regions/check/miss-peer", regionsHandler.GetMissPeerRegions).Methods("GET")
 	router.HandleFunc("/api/v1/regions/check/extra-peer", regionsHandler.GetExtraPeerRegions).Methods("GET")
 	router.HandleFunc("/api/v1/regions/check/pending-peer", regionsHandler.GetPendingPeerRegions).Methods("GET")

--- a/server/core/region_option.go
+++ b/server/core/region_option.go
@@ -156,14 +156,22 @@ func SetApproximateKeys(v int64) RegionCreateOption {
 // SetRegionConfVer sets the config version for the reigon.
 func SetRegionConfVer(confVer uint64) RegionCreateOption {
 	return func(region *RegionInfo) {
-		region.meta.RegionEpoch.ConfVer = confVer
+		if region.meta.RegionEpoch == nil {
+			region.meta.RegionEpoch = &metapb.RegionEpoch{ConfVer: confVer, Version: 1}
+		} else {
+			region.meta.RegionEpoch.ConfVer = confVer
+		}
 	}
 }
 
 // SetRegionVersion sets the version for the reigon.
 func SetRegionVersion(version uint64) RegionCreateOption {
 	return func(region *RegionInfo) {
-		region.meta.RegionEpoch.Version = version
+		if region.meta.RegionEpoch == nil {
+			region.meta.RegionEpoch = &metapb.RegionEpoch{ConfVer: 1, Version: version}
+		} else {
+			region.meta.RegionEpoch.Version = version
+		}
 	}
 }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Related to #1092.

### What is changed and how it works?
This PR provides a way to list top regions whose conf version or version is the largest. After this PR, we can use `region topconfver <limit>` or  `region topversion <limit>` in `pd-ctl` to find what we want.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test