### PR TITLE
server: cleanup residual region clone

### DIFF
--- a/server/cluster_info.go
+++ b/server/cluster_info.go
@@ -295,7 +295,7 @@ func (c *clusterInfo) searchPrevRegion(regionKey []byte) *core.RegionInfo {
 func (c *clusterInfo) putRegion(region *core.RegionInfo) error {
 	c.Lock()
 	defer c.Unlock()
-	return c.putRegionLocked(region.Clone())
+	return c.putRegionLocked(region)
 }
 
 func (c *clusterInfo) putRegionLocked(region *core.RegionInfo) error {

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -242,7 +242,7 @@ func (s *testCoordinatorSuite) TestDispatch(c *C) {
 
 func dispatchHeartbeat(c *C, co *coordinator, region *core.RegionInfo, stream *mockHeartbeatStream) {
 	co.hbStreams.bindStream(region.GetLeader().GetStoreId(), stream)
-	co.cluster.putRegion(region)
+	co.cluster.putRegion(region.Clone())
 	co.dispatch(region)
 }
 

--- a/server/region_statistics.go
+++ b/server/region_statistics.go
@@ -59,7 +59,7 @@ func newRegionStatistics(opt *scheduleOption, classifier namespace.Classifier) *
 func (r *regionStatistics) getRegionStatsByType(typ regionStatisticType) []*core.RegionInfo {
 	res := make([]*core.RegionInfo, 0, len(r.stats[typ]))
 	for _, r := range r.stats[typ] {
-		res = append(res, r.Clone())
+		res = append(res, r)
 	}
 	return res
 }


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
After the RegionInfo refactor PR https://github.com/pingcap/pd/pull/1207, we are able to avoid region clone in non-test files.

### What is changed and how it works?
Search and cleanup region clone from non-test files. There is still a place that is currently inconvenient to remove. 
https://github.com/pingcap/pd/blob/21d425857acf52e8ddf9c913d1f7a70c4ec79654/server/schedule/replica_checker.go#L101 
It does have a good reason to clone here. But we may consider handle it later.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
