### PR TITLE
pkg/errors: use a lower bound

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,7 +38,7 @@
 
 [[constraint]]
   name = "github.com/pkg/errors"
-  version = "0.8.0"
+  version = ">= 0.8.0"
 
 [[override]]
   name = "github.com/BurntSushi/toml"


### PR DESCRIPTION
Other projects are now depending directly on PD.

In the long term we need to separate out client/library functionality
from the server. But that will still require this change.

This came up in https://github.com/pingcap/tidb/pull/7151