### PR TITLE
pdctl: more precise tso time decoding

### DIFF
--- a/pdctl/command/tso_command.go
+++ b/pdctl/command/tso_command.go
@@ -48,7 +48,7 @@ func showTSOCommandFunc(cmd *cobra.Command, args []string) {
 	}
 	logical := ts & logicalBits
 	physical := ts >> physicalShiftBits
-	physicalTime := time.Unix(int64(physical/1000), 0)
+	physicalTime := time.Unix(int64(physical/1000), int64(physical%1000)*time.Millisecond.Nanoseconds())
 	fmt.Println("system: ", physicalTime)
 	fmt.Println("logic: ", logical)
 }


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
More precise tso time decoding

### What is changed and how it works?
Calculate the millisecond portion

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test
```
>> tso 402826222697185283
system:  2018-09-11 18:01:30.245 +0800 CST
logic:  3
```