### PR TITLE
Errors add stack

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -326,12 +326,13 @@
   revision = "279515615485b0f2d12f1421cc412fe2784e0190"
 
 [[projects]]
-  digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
+  digest = "1:1ddea2d64730f05a189090d765b5108370acf83208d5074b2024a113096f4792"
   name = "github.com/pkg/errors"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
-  version = "v0.8.0"
+  revision = "0c849bcccef2ad68bca21ce43782f28e68996375"
+  source = "https://github.com/pingcap/errors"
+  version = "v0.10.0"
 
 [[projects]]
   digest = "1:8d8f554bbb62fb7aecf661b85b25e227f6ab6cfe2b4395ea65ef478bfc174940"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,7 +38,8 @@
 
 [[constraint]]
   name = "github.com/pkg/errors"
-  version = ">= 0.8.0"
+  version = ">= 0.9.0"
+  source = "https://github.com/pingcap/errors"
 
 [[override]]
   name = "github.com/BurntSushi/toml"

--- a/pd-client/client.go
+++ b/pd-client/client.go
@@ -175,7 +175,7 @@ func (c *client) initClusterID() error {
 		time.Sleep(time.Second)
 	}
 
-	return errors.WithStack(errFailInitClusterID)
+	return errors.AddStack(errFailInitClusterID)
 }
 
 func (c *client) updateLeader() error {
@@ -186,7 +186,7 @@ func (c *client) updateLeader() error {
 		if err != nil || members.GetLeader() == nil || len(members.GetLeader().GetClientUrls()) == 0 {
 			select {
 			case <-c.ctx.Done():
-				return errors.WithStack(err)
+				return errors.AddStack(err)
 			default:
 				continue
 			}
@@ -204,7 +204,7 @@ func (c *client) getMembers(ctx context.Context, url string) (*pdpb.GetMembersRe
 	}
 	members, err := pdpb.NewPDClient(cc).GetMembers(ctx, &pdpb.GetMembersRequest{})
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.AddStack(err)
 	}
 	return members, nil
 }
@@ -274,11 +274,11 @@ func (c *client) getOrCreateGRPCConn(addr string) (*grpc.ClientConn, error) {
 	}
 	u, err := url.Parse(addr)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.AddStack(err)
 	}
 	cc, err := grpc.Dial(u.Host, opt)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.AddStack(err)
 	}
 	c.connMu.Lock()
 	defer c.connMu.Unlock()
@@ -367,7 +367,7 @@ func (c *client) tsLoop() {
 				log.Errorf("[pd] create tso stream error: %v", err)
 				c.ScheduleCheckLeader()
 				cancel()
-				c.revokeTSORequest(errors.WithStack(err))
+				c.revokeTSORequest(errors.AddStack(err))
 				select {
 				case <-time.After(time.Second):
 				case <-loopCtx.Done():
@@ -440,19 +440,19 @@ func (c *client) processTSORequests(stream pdpb.PD_TsoClient, requests []*tsoReq
 	}
 
 	if err := stream.Send(req); err != nil {
-		err = errors.WithStack(err)
+		err = errors.AddStack(err)
 		c.finishTSORequest(requests, 0, 0, err)
 		return err
 	}
 	resp, err := stream.Recv()
 	if err != nil {
-		err = errors.WithStack(err)
+		err = errors.AddStack(err)
 		c.finishTSORequest(requests, 0, 0, err)
 		return err
 	}
 	requestDuration.WithLabelValues("tso").Observe(time.Since(start).Seconds())
 	if resp.GetCount() != uint32(len(requests)) {
-		err = errors.WithStack(errTSOLength)
+		err = errors.AddStack(errTSOLength)
 		c.finishTSORequest(requests, 0, 0, err)
 		return err
 	}
@@ -486,7 +486,7 @@ func (c *client) Close() {
 	c.cancel()
 	c.wg.Wait()
 
-	c.revokeTSORequest(errors.WithStack(errClosing))
+	c.revokeTSORequest(errors.AddStack(errClosing))
 
 	c.connMu.Lock()
 	defer c.connMu.Unlock()
@@ -562,7 +562,7 @@ func (req *tsoRequest) Wait() (physical int64, logical int64, err error) {
 	cmdDuration.WithLabelValues("tso_async_wait").Observe(time.Since(req.start).Seconds())
 	select {
 	case err = <-req.done:
-		err = errors.WithStack(err)
+		err = errors.AddStack(err)
 		defer tsoReqPool.Put(req)
 		if err != nil {
 			cmdFailedDuration.WithLabelValues("tso").Observe(time.Since(req.start).Seconds())
@@ -572,7 +572,7 @@ func (req *tsoRequest) Wait() (physical int64, logical int64, err error) {
 		cmdDuration.WithLabelValues("tso").Observe(time.Since(req.start).Seconds())
 		return
 	case <-req.ctx.Done():
-		return 0, 0, errors.WithStack(req.ctx.Err())
+		return 0, 0, errors.AddStack(req.ctx.Err())
 	}
 }
 
@@ -599,7 +599,7 @@ func (c *client) GetRegion(ctx context.Context, key []byte) (*metapb.Region, *me
 	if err != nil {
 		cmdFailedDuration.WithLabelValues("get_region").Observe(time.Since(start).Seconds())
 		c.ScheduleCheckLeader()
-		return nil, nil, errors.WithStack(err)
+		return nil, nil, errors.AddStack(err)
 	}
 	return resp.GetRegion(), resp.GetLeader(), nil
 }
@@ -622,7 +622,7 @@ func (c *client) GetPrevRegion(ctx context.Context, key []byte) (*metapb.Region,
 	if err != nil {
 		cmdFailedDuration.WithLabelValues("get_prev_region").Observe(time.Since(start).Seconds())
 		c.ScheduleCheckLeader()
-		return nil, nil, errors.WithStack(err)
+		return nil, nil, errors.AddStack(err)
 	}
 	return resp.GetRegion(), resp.GetLeader(), nil
 }
@@ -645,7 +645,7 @@ func (c *client) GetRegionByID(ctx context.Context, regionID uint64) (*metapb.Re
 	if err != nil {
 		cmdFailedDuration.WithLabelValues("get_region_byid").Observe(time.Since(start).Seconds())
 		c.ScheduleCheckLeader()
-		return nil, nil, errors.WithStack(err)
+		return nil, nil, errors.AddStack(err)
 	}
 	return resp.GetRegion(), resp.GetLeader(), nil
 }
@@ -668,7 +668,7 @@ func (c *client) GetStore(ctx context.Context, storeID uint64) (*metapb.Store, e
 	if err != nil {
 		cmdFailedDuration.WithLabelValues("get_store").Observe(time.Since(start).Seconds())
 		c.ScheduleCheckLeader()
-		return nil, errors.WithStack(err)
+		return nil, errors.AddStack(err)
 	}
 	store := resp.GetStore()
 	if store == nil {
@@ -697,7 +697,7 @@ func (c *client) GetAllStores(ctx context.Context) ([]*metapb.Store, error) {
 	if err != nil {
 		cmdFailedDuration.WithLabelValues("get_all_stores").Observe(time.Since(start).Seconds())
 		c.ScheduleCheckLeader()
-		return nil, errors.WithStack(err)
+		return nil, errors.AddStack(err)
 	}
 	stores := resp.GetStores()
 	return stores, nil
@@ -721,7 +721,7 @@ func (c *client) UpdateGCSafePoint(ctx context.Context, safePoint uint64) (uint6
 	if err != nil {
 		cmdFailedDuration.WithLabelValues("update_gc_safe_point").Observe(time.Since(start).Seconds())
 		c.ScheduleCheckLeader()
-		return 0, errors.WithStack(err)
+		return 0, errors.AddStack(err)
 	}
 	return resp.GetNewSafePoint(), nil
 }

--- a/pdctl/command/global.go
+++ b/pdctl/command/global.go
@@ -43,7 +43,7 @@ func InitHTTPSClient(CAPath, CertPath, KeyPath string) error {
 	}
 	tlsConfig, err := tlsInfo.ClientConfig()
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 
 	dialClient = &http.Client{Transport: &http.Transport{

--- a/pdctl/command/operator.go
+++ b/pdctl/command/operator.go
@@ -355,7 +355,7 @@ func parseUint64s(args []string) ([]uint64, error) {
 	for _, arg := range args {
 		v, err := strconv.ParseUint(arg, 10, 64)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errors.AddStack(err)
 		}
 		results = append(results, v)
 	}

--- a/pkg/apiutil/apiutil.go
+++ b/pkg/apiutil/apiutil.go
@@ -27,7 +27,7 @@ import (
 // This is designed to be used in a defer statement.
 func DeferClose(c io.Closer, err *error) {
 	if cerr := c.Close(); cerr != nil && *err == nil {
-		*err = errors.WithStack(cerr)
+		*err = errors.AddStack(cerr)
 	}
 }
 
@@ -55,7 +55,7 @@ func ReadJSON(r io.ReadCloser, data interface{}) error {
 	defer DeferClose(r, &err)
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 
 	err = json.Unmarshal(b, data)

--- a/pkg/etcdutil/etcdutil.go
+++ b/pkg/etcdutil/etcdutil.go
@@ -76,7 +76,7 @@ func AddEtcdMember(client *clientv3.Client, urls []string) (*clientv3.MemberAddR
 	ctx, cancel := context.WithTimeout(client.Ctx(), DefaultRequestTimeout)
 	addResp, err := client.MemberAdd(ctx, urls)
 	cancel()
-	return addResp, errors.WithStack(err)
+	return addResp, errors.AddStack(err)
 }
 
 // ListEtcdMembers returns a list of internal etcd members.
@@ -84,7 +84,7 @@ func ListEtcdMembers(client *clientv3.Client) (*clientv3.MemberListResponse, err
 	ctx, cancel := context.WithTimeout(client.Ctx(), DefaultRequestTimeout)
 	listResp, err := client.MemberList(ctx)
 	cancel()
-	return listResp, errors.WithStack(err)
+	return listResp, errors.AddStack(err)
 }
 
 // RemoveEtcdMember removes a member by the given id.
@@ -92,5 +92,5 @@ func RemoveEtcdMember(client *clientv3.Client, id uint64) (*clientv3.MemberRemov
 	ctx, cancel := context.WithTimeout(client.Ctx(), DefaultRequestTimeout)
 	rmResp, err := client.MemberRemove(ctx, id)
 	cancel()
-	return rmResp, errors.WithStack(err)
+	return rmResp, errors.AddStack(err)
 }

--- a/pkg/faketikv/client.go
+++ b/pkg/faketikv/client.go
@@ -107,13 +107,13 @@ func (c *client) initClusterID() error {
 		return nil
 	}
 
-	return errors.WithStack(errFailInitClusterID)
+	return errors.AddStack(errFailInitClusterID)
 }
 
 func (c *client) getMembers(ctx context.Context) (*pdpb.GetMembersResponse, error) {
 	members, err := c.pdClient().GetMembers(ctx, &pdpb.GetMembersRequest{})
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.AddStack(err)
 	}
 	return members, nil
 }
@@ -121,7 +121,7 @@ func (c *client) getMembers(ctx context.Context) (*pdpb.GetMembersResponse, erro
 func (c *client) createConn() (*grpc.ClientConn, error) {
 	cc, err := grpc.Dial(strings.TrimPrefix(c.url, "http://"), grpc.WithInsecure())
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.AddStack(err)
 	}
 	return cc, nil
 }

--- a/pkg/faketikv/drive.go
+++ b/pkg/faketikv/drive.go
@@ -78,7 +78,7 @@ func (d *Driver) Prepare() error {
 		var id uint64
 		id, err = d.client.AllocID(context.Background())
 		if err != nil {
-			return errors.WithStack(err)
+			return errors.AddStack(err)
 		}
 		if id > d.conf.MaxID {
 			break

--- a/pkg/faketikv/raft.go
+++ b/pkg/faketikv/raft.go
@@ -253,7 +253,7 @@ func (r *RaftEngine) allocID(storeID uint64) (uint64, error) {
 		return 0, errors.Errorf("node %d not found", storeID)
 	}
 	id, err := node.client.AllocID(context.Background())
-	return id, errors.WithStack(err)
+	return id, errors.AddStack(err)
 }
 
 const (

--- a/pkg/integration_test/cluster.go
+++ b/pkg/integration_test/cluster.go
@@ -141,7 +141,7 @@ func (s *testServer) GetEtcdLeader() (string, error) {
 	req := &pdpb.GetMembersRequest{Header: &pdpb.RequestHeader{ClusterId: s.server.ClusterID()}}
 	members, err := s.server.GetMembers(context.TODO(), req)
 	if err != nil {
-		return "", errors.WithStack(err)
+		return "", errors.AddStack(err)
 	}
 	return members.GetEtcdLeader().GetName(), nil
 }
@@ -190,7 +190,7 @@ func (c *testCluster) RunServers(ctx context.Context, servers []*testServer) err
 	}
 	for _, c := range res {
 		if err := <-c; err != nil {
-			return errors.WithStack(err)
+			return errors.AddStack(err)
 		}
 	}
 	return nil

--- a/pkg/typeutil/duration.go
+++ b/pkg/typeutil/duration.go
@@ -40,11 +40,11 @@ func (d *Duration) MarshalJSON() ([]byte, error) {
 func (d *Duration) UnmarshalJSON(text []byte) error {
 	s, err := strconv.Unquote(string(text))
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	duration, err := time.ParseDuration(s)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	d.Duration = duration
 	return nil
@@ -54,5 +54,5 @@ func (d *Duration) UnmarshalJSON(text []byte) error {
 func (d *Duration) UnmarshalText(text []byte) error {
 	var err error
 	d.Duration, err = time.ParseDuration(string(text))
-	return errors.WithStack(err)
+	return errors.AddStack(err)
 }

--- a/pkg/typeutil/size.go
+++ b/pkg/typeutil/size.go
@@ -32,11 +32,11 @@ func (b ByteSize) MarshalJSON() ([]byte, error) {
 func (b *ByteSize) UnmarshalJSON(text []byte) error {
 	s, err := strconv.Unquote(string(text))
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	v, err := gh.ParseBytes(s)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	*b = ByteSize(v)
 	return nil
@@ -46,7 +46,7 @@ func (b *ByteSize) UnmarshalJSON(text []byte) error {
 func (b *ByteSize) UnmarshalText(text []byte) error {
 	v, err := gh.ParseBytes(string(text))
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	*b = ByteSize(v)
 	return nil

--- a/pkg/typeutil/string_slice.go
+++ b/pkg/typeutil/string_slice.go
@@ -32,7 +32,7 @@ func (s StringSlice) MarshalJSON() ([]byte, error) {
 func (s *StringSlice) UnmarshalJSON(text []byte) error {
 	data, err := strconv.Unquote(string(text))
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	if len(data) == 0 {
 		*s = nil

--- a/server/api/diagnose.go
+++ b/server/api/diagnose.go
@@ -115,7 +115,7 @@ func (d *diagnoseHandler) membersDiagnose(rdd *[]*Recommendation) error {
 	req := &pdpb.GetMembersRequest{Header: &pdpb.RequestHeader{ClusterId: d.svr.ClusterID()}}
 	members, err := d.svr.GetMembers(context.Background(), req)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	lenMembers := len(members.Members)
 	if lenMembers > 0 {

--- a/server/api/label.go
+++ b/server/api/label.go
@@ -102,11 +102,11 @@ func newStoresLabelFilter(name, value string) (*storesLabelFilter, error) {
 	// add (?i) to set a case-insensitive flag
 	keyPattern, err := regexp.Compile("(?i)" + name)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.AddStack(err)
 	}
 	valuePattern, err := regexp.Compile("(?i)" + value)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.AddStack(err)
 	}
 	return &storesLabelFilter{
 		keyPattern:   keyPattern,

--- a/server/api/member.go
+++ b/server/api/member.go
@@ -53,7 +53,7 @@ func (h *memberHandler) getMembers() (*pdpb.GetMembersResponse, error) {
 	req := &pdpb.GetMembersRequest{Header: &pdpb.RequestHeader{ClusterId: h.svr.ClusterID()}}
 	members, err := h.svr.GetMembers(context.Background(), req)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.AddStack(err)
 	}
 	// Fill leader priorities.
 	for _, m := range members.GetMembers() {

--- a/server/api/store.go
+++ b/server/api/store.go
@@ -360,7 +360,7 @@ func newStoreStateFilter(u *url.URL) (*storeStateFilter, error) {
 		for _, s := range v {
 			state, err := strconv.Atoi(s)
 			if err != nil {
-				return nil, errors.WithStack(err)
+				return nil, errors.AddStack(err)
 			}
 
 			storeState := metapb.StoreState(state)

--- a/server/api/util.go
+++ b/server/api/util.go
@@ -70,11 +70,11 @@ func readJSON(r io.ReadCloser, data interface{}) error {
 
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	err = json.Unmarshal(b, data)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 
 	return nil
@@ -83,7 +83,7 @@ func readJSON(r io.ReadCloser, data interface{}) error {
 func postJSON(url string, data []byte) error {
 	resp, err := server.DialClient.Post(url, "application/json", bytes.NewBuffer(data))
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	res, err := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
@@ -112,7 +112,7 @@ func doDelete(url string) error {
 func doGet(url string) (*http.Response, error) {
 	resp, err := server.DialClient.Get(url)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.AddStack(err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.Errorf("http get url %s return code %d", url, resp.StatusCode)

--- a/server/config.go
+++ b/server/config.go
@@ -224,7 +224,7 @@ func (c *Config) Parse(arguments []string) error {
 	// Parse first to get config file.
 	err := c.FlagSet.Parse(arguments)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 
 	// Load config file if specified.
@@ -251,7 +251,7 @@ func (c *Config) Parse(arguments []string) error {
 	// Parse again to replace with command line options.
 	err = c.FlagSet.Parse(arguments)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 
 	if len(c.FlagSet.Args()) != 0 {
@@ -268,15 +268,15 @@ func (c *Config) validate() error {
 	}
 	dataDir, err := filepath.Abs(c.DataDir)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	logFile, err := filepath.Abs(c.Log.File.Filename)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	rel, err := filepath.Rel(dataDir, filepath.Dir(logFile))
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	if !strings.HasPrefix(rel, "..") {
 		return errors.New("log directory shouldn't be the subdirectory of data directory")
@@ -370,7 +370,7 @@ func (c *Config) String() string {
 // configFromFile loads config from file.
 func (c *Config) configFromFile(path string) (*toml.MetaData, error) {
 	meta, err := toml.DecodeFile(path, c)
-	return &meta, errors.WithStack(err)
+	return &meta, errors.AddStack(err)
 }
 
 // ScheduleConfig is the schedule configuration.
@@ -628,7 +628,7 @@ func (s SecurityConfig) ToTLSConfig() (*tls.Config, error) {
 	}
 	tlsConfig, err := tlsInfo.ClientConfig()
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.AddStack(err)
 	}
 	return tlsConfig, nil
 }
@@ -660,7 +660,7 @@ func ParseUrls(s string) ([]url.URL, error) {
 	for _, item := range items {
 		u, err := url.Parse(item)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errors.AddStack(err)
 		}
 
 		urls = append(urls, *u)

--- a/server/core/kv.go
+++ b/server/core/kv.go
@@ -109,7 +109,7 @@ func (kv *KV) DeleteRegion(region *metapb.Region) error {
 func (kv *KV) SaveConfig(cfg interface{}) error {
 	value, err := json.Marshal(cfg)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	return kv.Save(configPath, string(value))
 }
@@ -125,7 +125,7 @@ func (kv *KV) LoadConfig(cfg interface{}) (bool, error) {
 	}
 	err = json.Unmarshal([]byte(value), cfg)
 	if err != nil {
-		return false, errors.WithStack(err)
+		return false, errors.AddStack(err)
 	}
 	return true, nil
 }
@@ -143,7 +143,7 @@ func (kv *KV) LoadStores(stores *StoresInfo) error {
 		for _, s := range res {
 			store := &metapb.Store{}
 			if err := store.Unmarshal([]byte(s)); err != nil {
-				return errors.WithStack(err)
+				return errors.AddStack(err)
 			}
 			storeInfo := NewStoreInfo(store)
 			leaderWeight, err := kv.loadFloatWithDefaultValue(kv.storeLeaderWeightPath(storeInfo.GetId()), 1.0)
@@ -186,7 +186,7 @@ func (kv *KV) loadFloatWithDefaultValue(path string, def float64) (float64, erro
 	}
 	val, err := strconv.ParseFloat(res, 64)
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return 0, errors.AddStack(err)
 	}
 	return val, nil
 }
@@ -214,7 +214,7 @@ func (kv *KV) LoadRegions(regions *RegionsInfo) error {
 		for _, s := range res {
 			region := &metapb.Region{}
 			if err := region.Unmarshal([]byte(s)); err != nil {
-				return errors.WithStack(err)
+				return errors.AddStack(err)
 			}
 
 			nextID = region.GetId() + 1
@@ -265,13 +265,13 @@ func (kv *KV) loadProto(key string, msg proto.Message) (bool, error) {
 		return false, nil
 	}
 	err = proto.Unmarshal([]byte(value), msg)
-	return true, errors.WithStack(err)
+	return true, errors.AddStack(err)
 }
 
 func (kv *KV) saveProto(key string, msg proto.Message) error {
 	value, err := proto.Marshal(msg)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	return kv.Save(key, string(value))
 }

--- a/server/etcd_kv.go
+++ b/server/etcd_kv.go
@@ -84,10 +84,10 @@ func (kv *etcdKVBase) Save(key, value string) error {
 	resp, err := kv.server.leaderTxn().Then(clientv3.OpPut(key, value)).Commit()
 	if err != nil {
 		log.Errorf("save to etcd error: %v", err)
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	if !resp.Succeeded {
-		return errors.WithStack(errTxnFailed)
+		return errors.AddStack(errTxnFailed)
 	}
 	return nil
 }
@@ -98,10 +98,10 @@ func (kv *etcdKVBase) Delete(key string) error {
 	resp, err := kv.server.leaderTxn().Then(clientv3.OpDelete(key)).Commit()
 	if err != nil {
 		log.Errorf("delete from etcd error: %v", err)
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	if !resp.Succeeded {
-		return errors.WithStack(errTxnFailed)
+		return errors.AddStack(errTxnFailed)
 	}
 	return nil
 }
@@ -119,5 +119,5 @@ func kvGet(c *clientv3.Client, key string, opts ...clientv3.OpOption) (*clientv3
 		log.Warnf("kv gets too slow: key %v cost %v err %v", key, cost, err)
 	}
 
-	return resp, errors.WithStack(err)
+	return resp, errors.AddStack(err)
 }

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -71,7 +71,7 @@ func (s *Server) Tso(stream pdpb.PD_TsoServer) error {
 			return nil
 		}
 		if err != nil {
-			return errors.WithStack(err)
+			return errors.AddStack(err)
 		}
 		if err = s.validateRequest(request.GetHeader()); err != nil {
 			return err
@@ -87,7 +87,7 @@ func (s *Server) Tso(stream pdpb.PD_TsoServer) error {
 			Count:     count,
 		}
 		if err := stream.Send(response); err != nil {
-			return errors.WithStack(err)
+			return errors.AddStack(err)
 		}
 	}
 }
@@ -284,10 +284,10 @@ func (s *heartbeatServer) Send(m *pdpb.RegionHeartbeatResponse) error {
 		if err != nil {
 			atomic.StoreInt32(&s.closed, 1)
 		}
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	case <-time.After(regionHeartbeatSendTimeout):
 		atomic.StoreInt32(&s.closed, 1)
-		return errors.WithStack(errSendRegionHeartbeatTimeout)
+		return errors.AddStack(errSendRegionHeartbeatTimeout)
 	}
 }
 
@@ -298,7 +298,7 @@ func (s *heartbeatServer) Recv() (*pdpb.RegionHeartbeatRequest, error) {
 	req, err := s.stream.Recv()
 	if err != nil {
 		atomic.StoreInt32(&s.closed, 1)
-		return nil, errors.WithStack(err)
+		return nil, errors.AddStack(err)
 	}
 	return req, nil
 }
@@ -312,7 +312,7 @@ func (s *Server) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error {
 			Header: s.notBootstrappedHeader(),
 		}
 		err := server.Send(resp)
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 
 	var lastBind time.Time
@@ -322,7 +322,7 @@ func (s *Server) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error {
 			return nil
 		}
 		if err != nil {
-			return errors.WithStack(err)
+			return errors.AddStack(err)
 		}
 
 		if err = s.validateRequest(request.GetHeader()); err != nil {
@@ -649,7 +649,7 @@ func (s *Server) UpdateGCSafePoint(ctx context.Context, request *pdpb.UpdateGCSa
 // TODO: Call it in gRPC intercepter.
 func (s *Server) validateRequest(header *pdpb.RequestHeader) error {
 	if !s.IsLeader() {
-		return errors.WithStack(notLeaderError)
+		return errors.AddStack(notLeaderError)
 	}
 	if header.GetClusterId() != s.clusterID {
 		return status.Errorf(codes.FailedPrecondition, "mismatch cluster id, need %d but got %d", s.clusterID, header.GetClusterId())

--- a/server/handler.go
+++ b/server/handler.go
@@ -63,7 +63,7 @@ func newHandler(s *Server) *Handler {
 func (h *Handler) getCoordinator() (*coordinator, error) {
 	cluster := h.s.GetRaftCluster()
 	if cluster == nil {
-		return nil, errors.WithStack(ErrNotBootstrapped)
+		return nil, errors.AddStack(ErrNotBootstrapped)
 	}
 	return cluster.coordinator, nil
 }
@@ -81,7 +81,7 @@ func (h *Handler) GetSchedulers() ([]string, error) {
 func (h *Handler) GetStores() ([]*core.StoreInfo, error) {
 	cluster := h.s.GetRaftCluster()
 	if cluster == nil {
-		return nil, errors.WithStack(ErrNotBootstrapped)
+		return nil, errors.AddStack(ErrNotBootstrapped)
 	}
 	storeMetas := cluster.GetStores()
 	stores := make([]*core.StoreInfo, 0, len(storeMetas))
@@ -337,7 +337,7 @@ func (h *Handler) AddTransferLeaderOperator(regionID uint64, storeID uint64) err
 	step := schedule.TransferLeader{FromStore: region.GetLeader().GetStoreId(), ToStore: newLeader.GetStoreId()}
 	op := schedule.NewOperator("adminTransferLeader", regionID, region.GetRegionEpoch(), schedule.OpAdmin|schedule.OpLeader, step)
 	if ok := c.addOperator(op); !ok {
-		return errors.WithStack(errAddOperator)
+		return errors.AddStack(errAddOperator)
 	}
 	return nil
 }
@@ -388,7 +388,7 @@ func (h *Handler) AddTransferRegionOperator(regionID uint64, storeIDs map[uint64
 
 	op := schedule.NewOperator("adminMoveRegion", regionID, region.GetRegionEpoch(), schedule.OpAdmin|schedule.OpRegion, steps...)
 	if ok := c.addOperator(op); !ok {
-		return errors.WithStack(errAddOperator)
+		return errors.AddStack(errAddOperator)
 	}
 	return nil
 }
@@ -420,7 +420,7 @@ func (h *Handler) AddTransferPeerOperator(regionID uint64, fromStoreID, toStoreI
 
 	op := schedule.CreateMovePeerOperator("adminMovePeer", c.cluster, region, schedule.OpAdmin, fromStoreID, toStoreID, newPeer.GetId())
 	if ok := c.addOperator(op); !ok {
-		return errors.WithStack(errAddOperator)
+		return errors.AddStack(errAddOperator)
 	}
 	return nil
 }
@@ -462,7 +462,7 @@ func (h *Handler) AddAddPeerOperator(regionID uint64, toStoreID uint64) error {
 	}
 	op := schedule.NewOperator("adminAddPeer", regionID, region.GetRegionEpoch(), schedule.OpAdmin|schedule.OpRegion, steps...)
 	if ok := c.addOperator(op); !ok {
-		return errors.WithStack(errAddOperator)
+		return errors.AddStack(errAddOperator)
 	}
 	return nil
 }
@@ -485,7 +485,7 @@ func (h *Handler) AddRemovePeerOperator(regionID uint64, fromStoreID uint64) err
 
 	op := schedule.CreateRemovePeerOperator("adminRemovePeer", c.cluster, schedule.OpAdmin, region, fromStoreID)
 	if ok := c.addOperator(op); !ok {
-		return errors.WithStack(errAddOperator)
+		return errors.AddStack(errAddOperator)
 	}
 	return nil
 }
@@ -528,7 +528,7 @@ func (h *Handler) AddMergeRegionOperator(regionID uint64, targetID uint64) error
 		return err
 	}
 	if ok := c.addOperator(op1, op2); !ok {
-		return errors.WithStack(ErrAddOperator)
+		return errors.AddStack(ErrAddOperator)
 	}
 	return nil
 }
@@ -552,7 +552,7 @@ func (h *Handler) AddSplitRegionOperator(regionID uint64, policy string) error {
 	}
 	op := schedule.NewOperator("adminSplitRegion", regionID, region.GetRegionEpoch(), schedule.OpAdmin, step)
 	if ok := c.addOperator(op); !ok {
-		return errors.WithStack(errAddOperator)
+		return errors.AddStack(errAddOperator)
 	}
 	return nil
 }
@@ -574,7 +574,7 @@ func (h *Handler) AddScatterRegionOperator(regionID uint64) error {
 		return nil
 	}
 	if ok := c.addOperator(op); !ok {
-		return errors.WithStack(errAddOperator)
+		return errors.AddStack(errAddOperator)
 	}
 	return nil
 }

--- a/server/join.go
+++ b/server/join.go
@@ -92,7 +92,7 @@ func PrepareJoinCluster(cfg *Config) error {
 		TLS:         tlsConfig,
 	})
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	defer client.Close()
 

--- a/server/leader.go
+++ b/server/leader.go
@@ -212,7 +212,7 @@ func (s *Server) campaignLeader() error {
 	}
 
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 
 	leaderKey := s.getLeaderPath()
@@ -222,7 +222,7 @@ func (s *Server) campaignLeader() error {
 		Then(clientv3.OpPut(leaderKey, s.memberValue, clientv3.WithLease(leaseResp.ID))).
 		Commit()
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	if !resp.Succeeded {
 		return errors.New("campaign leader failed, other server may campaign ok")
@@ -234,7 +234,7 @@ func (s *Server) campaignLeader() error {
 
 	ch, err := lessor.KeepAlive(ctx, leaseResp.ID)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	log.Debugf("campaign leader ok %s", s.Name())
 
@@ -344,7 +344,7 @@ func (s *Server) ResignLeader(nextLeader string) error {
 	nextLeaderID := leaderIDs[rand.Intn(len(leaderIDs))]
 	log.Infof("%s ready to resign leader, next leader: %v", s.Name(), nextLeaderID)
 	err = s.etcd.Server.MoveLeader(s.serverLoopCtx, s.ID(), nextLeaderID)
-	return errors.WithStack(err)
+	return errors.AddStack(err)
 }
 
 func (s *Server) deleteLeaderKey() error {
@@ -352,7 +352,7 @@ func (s *Server) deleteLeaderKey() error {
 	leaderKey := s.getLeaderPath()
 	resp, err := s.leaderTxn().Then(clientv3.OpDelete(leaderKey)).Commit()
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	if !resp.Succeeded {
 		return errors.New("resign leader failed, we are not leader already")

--- a/server/schedulers/adjacent_region.go
+++ b/server/schedulers/adjacent_region.go
@@ -37,11 +37,11 @@ func init() {
 		if len(args) == 2 {
 			leaderLimit, err := strconv.ParseUint(args[0], 10, 64)
 			if err != nil {
-				return nil, errors.WithStack(err)
+				return nil, errors.AddStack(err)
 			}
 			peerLimit, err := strconv.ParseUint(args[1], 10, 64)
 			if err != nil {
-				return nil, errors.WithStack(err)
+				return nil, errors.AddStack(err)
 			}
 			return newBalanceAdjacentRegionScheduler(limiter, leaderLimit, peerLimit), nil
 		}

--- a/server/schedulers/evict_leader.go
+++ b/server/schedulers/evict_leader.go
@@ -29,7 +29,7 @@ func init() {
 		}
 		id, err := strconv.ParseUint(args[0], 10, 64)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errors.AddStack(err)
 		}
 		return newEvictLeaderScheduler(limiter, id), nil
 	})

--- a/server/schedulers/grant_leader.go
+++ b/server/schedulers/grant_leader.go
@@ -29,7 +29,7 @@ func init() {
 		}
 		id, err := strconv.ParseUint(args[0], 10, 64)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errors.AddStack(err)
 		}
 		return newGrantLeaderScheduler(limiter, id), nil
 	})

--- a/server/server.go
+++ b/server/server.go
@@ -135,13 +135,13 @@ func (s *Server) startEtcd(ctx context.Context) error {
 	log.Info("start embed etcd")
 	etcd, err := embed.StartEtcd(s.etcdCfg)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 
 	// Check cluster ID
 	urlmap, err := types.NewURLsMap(s.cfg.InitialCluster)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	tlsConfig, err := s.cfg.Security.ToTLSConfig()
 	if err != nil {
@@ -167,7 +167,7 @@ func (s *Server) startEtcd(ctx context.Context) error {
 		TLS:         tlsConfig,
 	})
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 
 	etcdServerID := uint64(etcd.Server.ID())
@@ -344,7 +344,7 @@ func (s *Server) bootstrapCluster(req *pdpb.BootstrapRequest) (*pdpb.BootstrapRe
 	// Set cluster meta
 	clusterValue, err := clusterMeta.Marshal()
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.AddStack(err)
 	}
 	clusterRootPath := s.getClusterRootPath()
 
@@ -363,13 +363,13 @@ func (s *Server) bootstrapCluster(req *pdpb.BootstrapRequest) (*pdpb.BootstrapRe
 	storePath := makeStoreKey(clusterRootPath, storeMeta.GetId())
 	storeValue, err := storeMeta.Marshal()
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.AddStack(err)
 	}
 	ops = append(ops, clientv3.OpPut(storePath, string(storeValue)))
 
 	regionValue, err := req.GetRegion().Marshal()
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.AddStack(err)
 	}
 
 	// Set region meta with region id.
@@ -380,7 +380,7 @@ func (s *Server) bootstrapCluster(req *pdpb.BootstrapRequest) (*pdpb.BootstrapRe
 	bootstrapCmp := clientv3.Compare(clientv3.CreateRevision(clusterRootPath), "=", 0)
 	resp, err := s.txn().If(bootstrapCmp).Then(ops...).Commit()
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.AddStack(err)
 	}
 	if !resp.Succeeded {
 		log.Warnf("cluster %d already bootstrapped", clusterID)
@@ -658,7 +658,7 @@ func (s *Server) SetMemberLeaderPriority(id uint64, priority int) error {
 	key := s.getMemberLeaderPriorityPath(id)
 	res, err := s.leaderTxn().Then(clientv3.OpPut(key, strconv.Itoa(priority))).Commit()
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	if !res.Succeeded {
 		return errors.New("save leader priority failed, maybe not leader")
@@ -671,7 +671,7 @@ func (s *Server) DeleteMemberLeaderPriority(id uint64) error {
 	key := s.getMemberLeaderPriorityPath(id)
 	res, err := s.leaderTxn().Then(clientv3.OpDelete(key)).Commit()
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	if !res.Succeeded {
 		return errors.New("delete leader priority failed, maybe not leader")
@@ -691,7 +691,7 @@ func (s *Server) GetMemberLeaderPriority(id uint64) (int, error) {
 	}
 	priority, err := strconv.ParseInt(string(res.Kvs[0].Value), 10, 32)
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return 0, errors.AddStack(err)
 	}
 	return int(priority), nil
 }

--- a/server/tso.go
+++ b/server/tso.go
@@ -63,7 +63,7 @@ func (s *Server) saveTimestamp(ts time.Time) error {
 
 	resp, err := s.leaderTxn().Then(clientv3.OpPut(key, string(data))).Commit()
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	if !resp.Succeeded {
 		return errors.New("save timestamp failed, maybe we lost leader")

--- a/server/util.go
+++ b/server/util.go
@@ -109,7 +109,7 @@ func getProtoMsg(c *clientv3.Client, key string, msg proto.Message, opts ...clie
 	}
 
 	if err = proto.Unmarshal(value, msg); err != nil {
-		return false, errors.WithStack(err)
+		return false, errors.AddStack(err)
 	}
 
 	return true, nil
@@ -133,7 +133,7 @@ func initOrGetClusterID(c *clientv3.Client, key string) (uint64, error) {
 		Else(clientv3.OpGet(key)).
 		Commit()
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return 0, errors.AddStack(err)
 	}
 
 	// Txn commits ok, return the generated cluster ID.
@@ -213,7 +213,7 @@ func (t *slowLogTxn) Commit() (*clientv3.TxnResponse, error) {
 	txnCounter.WithLabelValues(label).Inc()
 	txnDuration.WithLabelValues(label).Observe(cost.Seconds())
 
-	return resp, errors.WithStack(err)
+	return resp, errors.AddStack(err)
 }
 
 // GetMembers return a slice of Members.

--- a/server/version.go
+++ b/server/version.go
@@ -69,7 +69,7 @@ func ParseVersion(v string) (*semver.Version, error) {
 		v = v[1:]
 	}
 	ver, err := semver.NewVersion(v)
-	return ver, errors.WithStack(err)
+	return ver, errors.AddStack(err)
 }
 
 // MustParseVersion wraps ParseVersion and will panic if error is not nil.

--- a/table/namespace_classifier.go
+++ b/table/namespace_classifier.go
@@ -407,7 +407,7 @@ func (namespaceInfo *namespacesInfo) namespacePath(nsID uint64) string {
 func (namespaceInfo *namespacesInfo) saveNamespace(kv *core.KV, ns *Namespace) error {
 	value, err := json.Marshal(ns)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.AddStack(err)
 	}
 	err = kv.Save(namespaceInfo.namespacePath(ns.GetID()), string(value))
 	return err
@@ -428,7 +428,7 @@ func (namespaceInfo *namespacesInfo) loadNamespaces(kv *core.KV, rangeLimit int)
 		for _, s := range res {
 			ns := &Namespace{}
 			if err := json.Unmarshal([]byte(s), ns); err != nil {
-				return errors.WithStack(err)
+				return errors.AddStack(err)
 			}
 			nextID = ns.GetID() + 1
 			namespaceInfo.setNamespace(ns)

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -13,24 +13,24 @@
 //
 // Adding context to an error
 //
-// The errors.Wrap function returns a new error that adds context to the
-// original error by recording a stack trace at the point Wrap is called,
+// The errors.Annotate function returns a new error that adds context to the
+// original error by recording a stack trace at the point Annotate is called,
 // and the supplied message. For example
 //
 //     _, err := ioutil.ReadAll(r)
 //     if err != nil {
-//             return errors.Wrap(err, "read failed")
+//             return errors.Annotate(err, "read failed")
 //     }
 //
-// If additional control is required the errors.WithStack and errors.WithMessage
-// functions destructure errors.Wrap into its component operations of annotating
+// If additional control is required the errors.AddStack and errors.WithMessage
+// functions destructure errors.Annotate into its component operations of annotating
 // an error with a stack trace and an a message, respectively.
 //
 // Retrieving the cause of an error
 //
-// Using errors.Wrap constructs a stack of errors, adding context to the
+// Using errors.Annotate constructs a stack of errors, adding context to the
 // preceding error. Depending on the nature of the error it may be necessary
-// to reverse the operation of errors.Wrap to retrieve the original error
+// to reverse the operation of errors.Annotate to retrieve the original error
 // for inspection. Any error value which implements this interface
 //
 //     type causer interface {
@@ -50,6 +50,7 @@
 //
 // causer interface is not exported by this package, but is considered a part
 // of stable public API.
+// errors.Unwrap is also available: this will retrieve the next error in the chain.
 //
 // Formatted printing of errors
 //
@@ -64,14 +65,9 @@
 //
 // Retrieving the stack trace of an error or wrapper
 //
-// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
-// invoked. This information can be retrieved with the following interface.
-//
-//     type stackTracer interface {
-//             StackTrace() errors.StackTrace
-//     }
-//
-// Where errors.StackTrace is defined as
+// New, Errorf, Annotate, and Annotatef record a stack trace at the point they are invoked.
+// This information can be retrieved with the StackTracer interface that returns
+// a StackTrace. Where errors.StackTrace is defined as
 //
 //     type StackTrace []Frame
 //
@@ -79,16 +75,15 @@
 // the fmt.Formatter interface that can be used for printing information about
 // the stack trace of this error. For example:
 //
-//     if err, ok := err.(stackTracer); ok {
-//             for _, f := range err.StackTrace() {
+//     if stacked := errors.GetStackTracer(err); stacked != nil {
+//             for _, f := range stacked.StackTrace() {
 //                     fmt.Printf("%+s:%d", f)
 //             }
 //     }
 //
-// stackTracer interface is not exported by this package, but is considered a part
-// of stable public API.
-//
 // See the documentation for Frame.Format for more details.
+//
+// errors.Find can be used to search for an error in the error chain.
 package errors
 
 import (
@@ -113,6 +108,21 @@ func Errorf(format string, args ...interface{}) error {
 		msg:   fmt.Sprintf(format, args...),
 		stack: callers(),
 	}
+}
+
+// StackTraceAware is an optimization to avoid repetitive traversals of an error chain.
+// HasStack checks for this marker first.
+// Annotate/Wrap and Annotatef/Wrapf will produce this marker.
+type StackTraceAware interface {
+	HasStack() bool
+}
+
+// HasStack tells whether a StackTracer exists in the error chain
+func HasStack(err error) bool {
+	if errWithStack, ok := err.(StackTraceAware); ok {
+		return errWithStack.HasStack()
+	}
+	return GetStackTracer(err) != nil
 }
 
 // fundamental is an error that has a message and a stack, but no caller.
@@ -141,14 +151,26 @@ func (f *fundamental) Format(s fmt.State, verb rune) {
 
 // WithStack annotates err with a stack trace at the point WithStack was called.
 // If err is nil, WithStack returns nil.
+//
+// Deprecated: use AddStack
 func WithStack(err error) error {
 	if err == nil {
 		return nil
 	}
+
 	return &withStack{
 		err,
 		callers(),
 	}
+}
+
+// AddStack is similar to WithStack.
+// However, it will first check with HasStack to see if a stack trace already exists in the causer chain before creating another one.
+func AddStack(err error) error {
+	if HasStack(err) {
+		return err
+	}
+	return WithStack(err)
 }
 
 type withStack struct {
@@ -175,15 +197,19 @@ func (w *withStack) Format(s fmt.State, verb rune) {
 }
 
 // Wrap returns an error annotating err with a stack trace
-// at the point Wrap is called, and the supplied message.
-// If err is nil, Wrap returns nil.
+// at the point Annotate is called, and the supplied message.
+// If err is nil, Annotate returns nil.
+//
+// Deprecated: use Annotate instead
 func Wrap(err error, message string) error {
 	if err == nil {
 		return nil
 	}
+	hasStack := HasStack(err)
 	err = &withMessage{
-		cause: err,
-		msg:   message,
+		cause:         err,
+		msg:           message,
+		causeHasStack: hasStack,
 	}
 	return &withStack{
 		err,
@@ -192,15 +218,19 @@ func Wrap(err error, message string) error {
 }
 
 // Wrapf returns an error annotating err with a stack trace
-// at the point Wrapf is call, and the format specifier.
-// If err is nil, Wrapf returns nil.
+// at the point Annotatef is call, and the format specifier.
+// If err is nil, Annotatef returns nil.
+//
+// Deprecated: use Annotatef instead
 func Wrapf(err error, format string, args ...interface{}) error {
 	if err == nil {
 		return nil
 	}
+	hasStack := HasStack(err)
 	err = &withMessage{
-		cause: err,
-		msg:   fmt.Sprintf(format, args...),
+		cause:         err,
+		msg:           fmt.Sprintf(format, args...),
+		causeHasStack: hasStack,
 	}
 	return &withStack{
 		err,
@@ -215,18 +245,21 @@ func WithMessage(err error, message string) error {
 		return nil
 	}
 	return &withMessage{
-		cause: err,
-		msg:   message,
+		cause:         err,
+		msg:           message,
+		causeHasStack: HasStack(err),
 	}
 }
 
 type withMessage struct {
-	cause error
-	msg   string
+	cause         error
+	msg           string
+	causeHasStack bool
 }
 
-func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
-func (w *withMessage) Cause() error  { return w.cause }
+func (w *withMessage) Error() string  { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error   { return w.cause }
+func (w *withMessage) HasStack() bool { return w.causeHasStack }
 
 func (w *withMessage) Format(s fmt.State, verb rune) {
 	switch verb {
@@ -254,16 +287,35 @@ func (w *withMessage) Format(s fmt.State, verb rune) {
 // be returned. If the error is nil, nil will be returned without further
 // investigation.
 func Cause(err error) error {
+	cause := Unwrap(err)
+	if cause == nil {
+		return err
+	}
+	return Cause(cause)
+}
+
+// Unwrap uses causer to return the next error in the chain or nil.
+// This goes one-level deeper, whereas Cause goes as far as possible
+func Unwrap(err error) error {
 	type causer interface {
 		Cause() error
 	}
-
-	for err != nil {
-		cause, ok := err.(causer)
-		if !ok {
-			break
-		}
-		err = cause.Cause()
+	if unErr, ok := err.(causer); ok {
+		return unErr.Cause()
 	}
-	return err
+	return nil
+}
+
+// Find an error in the chain that matches a test function.
+// returns nil if no error is found.
+func Find(origErr error, test func(error) bool) error {
+	var foundErr error
+	WalkDeep(origErr, func(err error) bool {
+		if test(err) {
+			foundErr = err
+			return true
+		}
+		return false
+	})
+	return foundErr
 }

--- a/vendor/github.com/pkg/errors/group.go
+++ b/vendor/github.com/pkg/errors/group.go
@@ -1,0 +1,42 @@
+package errors
+
+// ErrorGroup is an interface for multiple errors that are not a chain.
+// This happens for example when executing multiple operations in parallel.
+type ErrorGroup interface {
+	Errors() []error
+}
+
+// Errors uses the ErrorGroup interface to return a slice of errors.
+// If the ErrorGroup interface is not implemented it returns an array containing just the given error.
+func Errors(err error) []error {
+	if eg, ok := err.(ErrorGroup); ok {
+		return eg.Errors()
+	}
+	return []error{err}
+}
+
+// WalkDeep does a depth-first traversal of all errors.
+// Any ErrorGroup is traversed (after going deep).
+// The visitor function can return true to end the traversal early
+// In that case, WalkDeep will return true, otherwise false.
+func WalkDeep(err error, visitor func(err error) bool) bool {
+	// Go deep
+	unErr := err
+	for unErr != nil {
+		if done := visitor(unErr); done {
+			return true
+		}
+		unErr = Unwrap(unErr)
+	}
+
+	// Go wide
+	if group, ok := err.(ErrorGroup); ok {
+		for _, err := range group.Errors() {
+			if early := WalkDeep(err, visitor); early {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/vendor/github.com/pkg/errors/juju_adaptor.go
+++ b/vendor/github.com/pkg/errors/juju_adaptor.go
@@ -1,0 +1,76 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// ==================== juju adaptor start ========================
+
+// Trace annotates err with a stack trace at the point WithStack was called.
+// If err is nil or already contain stack trace return directly.
+func Trace(err error) error {
+	return AddStack(err)
+}
+
+func Annotate(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	hasStack := HasStack(err)
+	err = &withMessage{
+		cause:         err,
+		msg:           message,
+		causeHasStack: hasStack,
+	}
+	if hasStack {
+		return err
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+func Annotatef(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	hasStack := HasStack(err)
+	err = &withMessage{
+		cause:         err,
+		msg:           fmt.Sprintf(format, args...),
+		causeHasStack: hasStack,
+	}
+	if hasStack {
+		return err
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// ErrorStack will format a stack trace if it is available, otherwise it will be Error()
+func ErrorStack(err error) string {
+	if err == nil {
+		return ""
+	}
+	return fmt.Sprintf("%+v", err)
+}
+
+// NotFoundf represents an error with not found message.
+func NotFoundf(format string, args ...interface{}) error {
+	return Errorf(format+" not found", args...)
+}
+
+// BadRequestf represents an error with bad request message.
+func BadRequestf(format string, args ...interface{}) error {
+	return Errorf(format+" bad request", args...)
+}
+
+// NotSupportedf represents an error with not supported message.
+func NotSupportedf(format string, args ...interface{}) error {
+	return Errorf(format+" not supported", args...)
+}
+
+// ==================== juju adaptor end ========================

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,12 +1,36 @@
 package errors
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"path"
 	"runtime"
+	"strconv"
 	"strings"
 )
+
+// StackTracer retrieves the StackTrace
+// Generally you would want to use the GetStackTracer function to do that.
+type StackTracer interface {
+	StackTrace() StackTrace
+}
+
+// GetStackTracer will return the first StackTracer in the causer chain.
+// This function is used by AddStack to avoid creating redundant stack traces.
+//
+// You can also use the StackTracer interface on the returned error to get the stack trace.
+func GetStackTracer(origErr error) StackTracer {
+	var stacked StackTracer
+	WalkDeep(origErr, func(err error) bool {
+		if stackTracer, ok := err.(StackTracer); ok {
+			stacked = stackTracer
+			return true
+		}
+		return false
+	})
+	return stacked
+}
 
 // Frame represents a program counter inside a stack frame.
 type Frame uintptr
@@ -46,9 +70,15 @@ func (f Frame) line() int {
 //
 // Format accepts flags that alter the printing of some verbs, as follows:
 //
-//    %+s   path of source file relative to the compile time GOPATH
+//    %+s   function name and path of source file relative to the compile time
+//          GOPATH separated by \n\t (<funcname>\n\t<path>)
 //    %+v   equivalent to %+s:%d
 func (f Frame) Format(s fmt.State, verb rune) {
+	f.format(s, s, verb)
+}
+
+// format allows stack trace printing calls to be made with a bytes.Buffer.
+func (f Frame) format(w io.Writer, s fmt.State, verb rune) {
 	switch verb {
 	case 's':
 		switch {
@@ -56,46 +86,83 @@ func (f Frame) Format(s fmt.State, verb rune) {
 			pc := f.pc()
 			fn := runtime.FuncForPC(pc)
 			if fn == nil {
-				io.WriteString(s, "unknown")
+				io.WriteString(w, "unknown")
 			} else {
 				file, _ := fn.FileLine(pc)
-				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+				io.WriteString(w, fn.Name())
+				io.WriteString(w, "\n\t")
+				io.WriteString(w, file)
 			}
 		default:
-			io.WriteString(s, path.Base(f.file()))
+			io.WriteString(w, path.Base(f.file()))
 		}
 	case 'd':
-		fmt.Fprintf(s, "%d", f.line())
+		io.WriteString(w, strconv.Itoa(f.line()))
 	case 'n':
 		name := runtime.FuncForPC(f.pc()).Name()
-		io.WriteString(s, funcname(name))
+		io.WriteString(w, funcname(name))
 	case 'v':
-		f.Format(s, 's')
-		io.WriteString(s, ":")
-		f.Format(s, 'd')
+		f.format(w, s, 's')
+		io.WriteString(w, ":")
+		f.format(w, s, 'd')
 	}
 }
 
 // StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
 type StackTrace []Frame
 
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
 func (st StackTrace) Format(s fmt.State, verb rune) {
+	var b bytes.Buffer
 	switch verb {
 	case 'v':
 		switch {
 		case s.Flag('+'):
-			for _, f := range st {
-				fmt.Fprintf(s, "\n%+v", f)
+			b.Grow(len(st) * stackMinLen)
+			for _, fr := range st {
+				b.WriteByte('\n')
+				fr.format(&b, s, verb)
 			}
 		case s.Flag('#'):
-			fmt.Fprintf(s, "%#v", []Frame(st))
+			fmt.Fprintf(&b, "%#v", []Frame(st))
 		default:
-			fmt.Fprintf(s, "%v", []Frame(st))
+			st.formatSlice(&b, s, verb)
 		}
 	case 's':
-		fmt.Fprintf(s, "%s", []Frame(st))
+		st.formatSlice(&b, s, verb)
 	}
+	io.Copy(s, &b)
 }
+
+// formatSlice will format this StackTrace into the given buffer as a slice of
+// Frame, only valid when called with '%s' or '%v'.
+func (st StackTrace) formatSlice(b *bytes.Buffer, s fmt.State, verb rune) {
+	b.WriteByte('[')
+	if len(st) == 0 {
+		b.WriteByte(']')
+		return
+	}
+
+	b.Grow(len(st) * (stackMinLen / 4))
+	st[0].format(b, s, verb)
+	for _, fr := range st[1:] {
+		b.WriteByte(' ')
+		fr.format(b, s, verb)
+	}
+	b.WriteByte(']')
+}
+
+// stackMinLen is a best-guess at the minimum length of a stack trace. It
+// doesn't need to be exact, just give a good enough head start for the buffer
+// to avoid the expensive early growth.
+const stackMinLen = 96
 
 // stack represents a stack of program counters.
 type stack []uintptr
@@ -105,10 +172,14 @@ func (s *stack) Format(st fmt.State, verb rune) {
 	case 'v':
 		switch {
 		case st.Flag('+'):
+			var b bytes.Buffer
+			b.Grow(len(*s) * stackMinLen)
 			for _, pc := range *s {
 				f := Frame(pc)
-				fmt.Fprintf(st, "\n%+v", f)
+				b.WriteByte('\n')
+				f.format(&b, st, 'v')
 			}
+			io.Copy(st, &b)
 		}
 	}
 }
@@ -122,9 +193,13 @@ func (s *stack) StackTrace() StackTrace {
 }
 
 func callers() *stack {
+	return callersSkip(4)
+}
+
+func callersSkip(skip int) *stack {
 	const depth = 32
 	var pcs [depth]uintptr
-	n := runtime.Callers(3, pcs[:])
+	n := runtime.Callers(skip, pcs[:])
 	var st stack = pcs[0:n]
 	return &st
 }
@@ -137,42 +212,15 @@ func funcname(name string) string {
 	return name[i+1:]
 }
 
-func trimGOPATH(name, file string) string {
-	// Here we want to get the source file path relative to the compile time
-	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
-	// GOPATH at runtime, but we can infer the number of path segments in the
-	// GOPATH. We note that fn.Name() returns the function name qualified by
-	// the import path, which does not include the GOPATH. Thus we can trim
-	// segments from the beginning of the file path until the number of path
-	// separators remaining is one more than the number of path separators in
-	// the function name. For example, given:
-	//
-	//    GOPATH     /home/user
-	//    file       /home/user/src/pkg/sub/file.go
-	//    fn.Name()  pkg/sub.Type.Method
-	//
-	// We want to produce:
-	//
-	//    pkg/sub/file.go
-	//
-	// From this we can easily see that fn.Name() has one less path separator
-	// than our desired output. We count separators from the end of the file
-	// path until it finds two more than in the function name and then move
-	// one character forward to preserve the initial path segment without a
-	// leading separator.
-	const sep = "/"
-	goal := strings.Count(name, sep) + 2
-	i := len(file)
-	for n := 0; n < goal; n++ {
-		i = strings.LastIndex(file[:i], sep)
-		if i == -1 {
-			// not enough separators found, set i so that the slice expression
-			// below leaves file unmodified
-			i = -len(sep)
-			break
-		}
-	}
-	// get back to 0 or trim the leading separator
-	file = file[i+len(sep):]
-	return file
+// NewStack is for library implementers that want to generate a stack trace.
+// Normally you should insted use AddStack to get an error with a stack trace.
+//
+// The result of this function can be turned into a stack trace by calling .StackTrace()
+//
+// This function takes an argument for the number of stack frames to skip.
+// This avoids putting stack generation function calls like this one in the stack trace.
+// A value of 0 will give you the line that called NewStack(0)
+// A library author wrapping this in their own function will want to use a value of at least 1.
+func NewStack(skip int) StackTracer {
+	return callersSkip(skip + 3)
 }


### PR DESCRIPTION
### What problem does this PR solve?

This ensures that duplicate stack traces will not be created.



### What is changed and how it works?

use errors.AddStack for stack trace de-duping
errors.AddStack is now available on our fork.
upgrade to pingcap/errors 0.9.0

### Check List 

No change to functionality or API. Tests and checks should pass the same.
Performance should be the same, but is now guaranteed to not get worse.