### PR TITLE
Fix panic of adjacent-region-scheduler after pd transfer leader

### DIFF
--- a/server/schedulers/adjacent_region.go
+++ b/server/schedulers/adjacent_region.go
@@ -199,7 +199,9 @@ func (l *balanceAdjacentRegionScheduler) process(cluster schedule.Cluster) []*sc
 		l.cacheRegions.head = head + 1
 		l.lastKey = r2.GetStartKey()
 	}()
-	if l.unsafeToBalance(cluster, r1) {
+	// after the cluster is prepared, there is a gap that some regions heartbeats are not received.
+	// Leader of those region is nil, and we should skip them.
+	if r1.GetLeader() == nil || r2.GetLeader() == nil || l.unsafeToBalance(cluster, r1) {
 		schedulerCounter.WithLabelValues(l.GetName(), "skip").Inc()
 		return nil
 	}
@@ -221,6 +223,9 @@ func (l *balanceAdjacentRegionScheduler) unsafeToBalance(cluster schedule.Cluste
 		return true
 	}
 	store := cluster.GetStore(region.GetLeader().GetStoreId())
+	if store == nil {
+		return true
+	}
 	s := l.selector.SelectSource(cluster, []*core.StoreInfo{store})
 	if s == nil {
 		return true

--- a/server/schedulers/adjacent_region.go
+++ b/server/schedulers/adjacent_region.go
@@ -144,8 +144,8 @@ func (l *balanceAdjacentRegionScheduler) Schedule(cluster schedule.Cluster, opIn
 	regions := cluster.ScanRegions(l.lastKey, scanLimit)
 	// scan to the end
 	if len(regions) <= 1 {
-		l.adjacentRegionsCount = 0
 		schedulerStatus.WithLabelValues(l.GetName(), "adjacent_count").Set(float64(l.adjacentRegionsCount))
+		l.adjacentRegionsCount = 0
 		l.lastKey = []byte("")
 		return nil
 	}


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

If `adjacent-region` scheduler is enabled, after pd transfers leader and the new leader is prepared, 
there is a gap that heartbeats of some regions are not received, and leaders are not updated.

store id of a nil peer  is `0`, see https://github.com/pingcap/pd/blob/fa5f08c252a4c5025cdef5bf0f2bdab78d7c0a36/vendor/github.com/pingcap/kvproto/pkg/metapb/metapb.pb.go#L256, so this line https://github.com/pingcap/pd/blob/fa5f08c252a4c5025cdef5bf0f2bdab78d7c0a36/server/schedulers/adjacent_region.go#L223 return a `nil` store, which causes panic.

### What is changed and how it works?

This change makes sure that region's leader is not nil, and leader's store is not nil, and also fix metric value of adjacent-count.

Another solution is  skip holes of not heartbeat-ed regions when calculating adjacent-regions, which prevents the issue at front.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

`make test`

No side effects
