### PR TITLE
config: fix DisableNamespaceRelocation option clone behaviour

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -463,6 +463,7 @@ func (c *ScheduleConfig) clone() *ScheduleConfig {
 		DisableMakeUpReplica:         c.DisableMakeUpReplica,
 		DisableRemoveExtraReplica:    c.DisableRemoveExtraReplica,
 		DisableLocationReplacement:   c.DisableLocationReplacement,
+		DisableNamespaceRelocation:   c.DisableNamespaceRelocation,
 		Schedulers:                   schedulers,
 	}
 }


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

Fix `DisableNamespaceRelocation` option when cloning SchedulerConfig.

### What is changed and how it works?
As it is.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
make test

