### PR TITLE
pd-ctl: return full region information for /region api

### DIFF
--- a/server/api/region.go
+++ b/server/api/region.go
@@ -130,11 +130,10 @@ func (h *regionsHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 		h.rd.JSON(w, http.StatusInternalServerError, server.ErrNotBootstrapped.Error())
 		return
 	}
-
-	regions := cluster.GetMetaRegions()
+	regions := cluster.GetRegions()
 	regionInfos := make([]*regionInfo, len(regions))
 	for i, r := range regions {
-		regionInfos[i] = newRegionInfo(core.NewRegionInfo(r, nil))
+		regionInfos[i] = newRegionInfo(r)
 	}
 	regionsInfo := &regionsInfo{
 		Count:   len(regions),

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -83,6 +83,26 @@ func (s *testRegionSuite) TestRegion(c *C) {
 	c.Assert(r2, DeepEquals, newRegionInfo(r))
 }
 
+func (s *testRegionSuite) TestRegions(c *C) {
+	regions := []*core.RegionInfo{
+		newTestRegionInfo(2, 1, []byte("a"), []byte("b")),
+		newTestRegionInfo(3, 1, []byte("b"), []byte("c")),
+		newTestRegionInfo(4, 1, []byte("c"), []byte("d")),
+		newTestRegionInfo(5, 1, []byte("d"), []byte("e")),
+	}
+	regionsInfo := make([]*regionInfo, 0, len(regions))
+	for i, region := range regions {
+		regionsInfo[i] = newRegionInfo(region)
+		mustRegionHeartbeat(c, s.svr, region)
+	}
+
+	url := fmt.Sprintf("%s/regions", s.urlPrefix)
+	rs := &regionsInfo{}
+	err := readJSONWithURL(url, rs)
+	c.Assert(err, IsNil)
+	c.Assert(rs, DeepEquals, regionsInfo)
+}
+
 func (s *testRegionSuite) TestStoreRegions(c *C) {
 	r1 := newTestRegionInfo(2, 1, []byte("a"), []byte("b"))
 	r2 := newTestRegionInfo(3, 1, []byte("b"), []byte("c"))

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -100,7 +100,12 @@ func (s *testRegionSuite) TestRegions(c *C) {
 	err := readJSONWithURL(url, regionsInfo)
 	c.Assert(err, IsNil)
 	c.Assert(regionsInfo.Count, Equals, len(regions))
-	c.Assert(regionsInfo.Regions, DeepEquals, regions)
+	sort.Slice(regionsInfo.Regions, func(i, j int) bool {
+		return regionsInfo.Regions[i].ID < regionsInfo.Regions[j].ID
+	})
+	for i, r := range regionsInfo.Regions {
+		c.Assert(r.ID, Equals, regions[i].ID)
+	}
 }
 
 func (s *testRegionSuite) TestStoreRegions(c *C) {

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -89,7 +89,7 @@ func (s *testRegionSuite) TestRegions(c *C) {
 		newTestRegionInfo(3, 1, []byte("b"), []byte("c")),
 		newTestRegionInfo(4, 2, []byte("c"), []byte("d")),
 	}
-	regions := make([]*regionInfo, 0)
+	regions := make([]*regionInfo, 0, len(rs))
 	for _, r := range rs {
 		regions = append(regions, newRegionInfo(r))
 		mustRegionHeartbeat(c, s.svr, r)

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -87,8 +87,7 @@ func (s *testRegionSuite) TestRegions(c *C) {
 	rs := []*core.RegionInfo{
 		newTestRegionInfo(2, 1, []byte("a"), []byte("b")),
 		newTestRegionInfo(3, 1, []byte("b"), []byte("c")),
-		newTestRegionInfo(4, 1, []byte("c"), []byte("d")),
-		newTestRegionInfo(5, 1, []byte("d"), []byte("e")),
+		newTestRegionInfo(4, 2, []byte("c"), []byte("d")),
 	}
 	regions := make([]*regionInfo, 0)
 	for _, r := range rs {
@@ -105,6 +104,8 @@ func (s *testRegionSuite) TestRegions(c *C) {
 	})
 	for i, r := range regionsInfo.Regions {
 		c.Assert(r.ID, Equals, regions[i].ID)
+		c.Assert(r.ApproximateSize, Equals, regions[i].ApproximateSize)
+		c.Assert(r.ApproximateKeys, Equals, regions[i].ApproximateKeys)
 	}
 }
 

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -84,23 +84,23 @@ func (s *testRegionSuite) TestRegion(c *C) {
 }
 
 func (s *testRegionSuite) TestRegions(c *C) {
-	regions := []*core.RegionInfo{
+	rs := []*core.RegionInfo{
 		newTestRegionInfo(2, 1, []byte("a"), []byte("b")),
 		newTestRegionInfo(3, 1, []byte("b"), []byte("c")),
 		newTestRegionInfo(4, 1, []byte("c"), []byte("d")),
 		newTestRegionInfo(5, 1, []byte("d"), []byte("e")),
 	}
-	regionsInfo := make([]*regionInfo, 0, len(regions))
-	for i, region := range regions {
-		regionsInfo[i] = newRegionInfo(region)
-		mustRegionHeartbeat(c, s.svr, region)
+	regions := make([]*regionInfo, 0)
+	for _, r := range rs {
+		regions = append(regions, newRegionInfo(r))
+		mustRegionHeartbeat(c, s.svr, r)
 	}
-
 	url := fmt.Sprintf("%s/regions", s.urlPrefix)
-	rs := &regionsInfo{}
-	err := readJSONWithURL(url, rs)
+	regionsInfo := &regionsInfo{}
+	err := readJSONWithURL(url, regionsInfo)
 	c.Assert(err, IsNil)
-	c.Assert(rs, DeepEquals, regionsInfo)
+	c.Assert(regionsInfo.Count, Equals, len(regions))
+	c.Assert(regionsInfo.Regions, DeepEquals, regions)
 }
 
 func (s *testRegionSuite) TestStoreRegions(c *C) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->

- return full region information not only the region meta.

close #1223 

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test

Side effects

no

Related changes

 - Need to update the documentation
