### PR TITLE
pd-api: get regions with top size

### DIFF
--- a/server/api/region.go
+++ b/server/api/region.go
@@ -267,6 +267,12 @@ func (h *regionsHandler) GetTopVersion(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (h *regionsHandler) GetTopSize(w http.ResponseWriter, r *http.Request) {
+	h.GetTopNRegions(w, r, func(a, b *core.RegionInfo) bool {
+		return a.GetApproximateSize() < b.GetApproximateSize()
+	})
+}
+
 func (h *regionsHandler) GetTopNRegions(w http.ResponseWriter, r *http.Request, less func(a, b *core.RegionInfo) bool) {
 	cluster := h.svr.GetRaftCluster()
 	if cluster == nil {

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -136,6 +136,20 @@ func (s *testRegionSuite) TestTopFlow(c *C) {
 	s.checkTopRegions(c, fmt.Sprintf("%s/regions/version?limit=2", s.urlPrefix), []uint64{2, 3})
 }
 
+func (s *testRegionSuite) TestTopSize(c *C) {
+	opt := core.SetApproximateSize(1000)
+	r1 := newTestRegionInfo(7, 1, []byte("a"), []byte("b"), opt)
+	mustRegionHeartbeat(c, s.svr, r1)
+	opt = core.SetApproximateSize(900)
+	r2 := newTestRegionInfo(8, 1, []byte("b"), []byte("c"), opt)
+	mustRegionHeartbeat(c, s.svr, r2)
+	opt = core.SetApproximateSize(800)
+	r3 := newTestRegionInfo(9, 1, []byte("c"), []byte("d"))
+	mustRegionHeartbeat(c, s.svr, r3)
+	// query with limit
+	s.checkTopRegions(c, fmt.Sprintf("%s/regions/size?limit=%d", s.urlPrefix, 2), []uint64{7, 8})
+}
+
 func (s *testRegionSuite) checkTopRegions(c *C, url string, regionIDs []uint64) {
 	regions := &regionsInfo{}
 	err := readJSONWithURL(url, regions)

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -89,6 +89,7 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	router.HandleFunc("/api/v1/regions/readflow", regionsHandler.GetTopReadFlow).Methods("GET")
 	router.HandleFunc("/api/v1/regions/confver", regionsHandler.GetTopConfVer).Methods("GET")
 	router.HandleFunc("/api/v1/regions/version", regionsHandler.GetTopVersion).Methods("GET")
+	router.HandleFunc("/api/v1/regions/size", regionsHandler.GetTopSize).Methods("GET")
 	router.HandleFunc("/api/v1/regions/check/miss-peer", regionsHandler.GetMissPeerRegions).Methods("GET")
 	router.HandleFunc("/api/v1/regions/check/extra-peer", regionsHandler.GetExtraPeerRegions).Methods("GET")
 	router.HandleFunc("/api/v1/regions/check/pending-peer", regionsHandler.GetPendingPeerRegions).Methods("GET")

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -32,6 +32,7 @@ var (
 	regionsReadflowPrefix  = "pd/api/v1/regions/readflow"
 	regionsConfVerPrefix   = "pd/api/v1/regions/confver"
 	regionsVersionPrefix   = "pd/api/v1/regions/version"
+	regionsSizePrefix      = "pd/api/v1/regions/size"
 	regionsSiblingPrefix   = "pd/api/v1/regions/sibling"
 	regionIDPrefix         = "pd/api/v1/region/id"
 	regionKeyPrefix        = "pd/api/v1/region/key"
@@ -76,6 +77,13 @@ func NewRegionCommand() *cobra.Command {
 		Run:   showRegionTopVersionCommandFunc,
 	}
 	r.AddCommand(topVersion)
+
+	topSize := &cobra.Command{
+		Use:   "topsize <limit>",
+		Short: "show regions with top size",
+		Run:   showRegionTopSizeCommandFunc,
+	}
+	r.AddCommand(topSize)
 	r.Flags().String("jq", "", "jq query")
 
 	return r
@@ -156,6 +164,23 @@ func showRegionTopConfVerCommandFunc(cmd *cobra.Command, args []string) {
 
 func showRegionTopVersionCommandFunc(cmd *cobra.Command, args []string) {
 	prefix := regionsVersionPrefix
+	if len(args) == 1 {
+		if _, err := strconv.Atoi(args[0]); err != nil {
+			fmt.Println("limit should be a number")
+			return
+		}
+		prefix += "?limit=" + args[0]
+	}
+	r, err := doRequest(cmd, prefix, http.MethodGet)
+	if err != nil {
+		fmt.Printf("Failed to get regions: %s\n", err)
+		return
+	}
+	fmt.Println(r)
+}
+
+func showRegionTopSizeCommandFunc(cmd *cobra.Command, args []string) {
+	prefix := regionsSizePrefix
 	if len(args) == 1 {
 		if _, err := strconv.Atoi(args[0]); err != nil {
 			fmt.Println("limit should be a number")


### PR DESCRIPTION

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

- add HTTP API and pd-ctl to get the regions with the top size.

### What is changed and how it works?

- add HTTP API for getting regions with the top size.
- add pd-ctl command.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has HTTP API interfaces change

Side effects

no

Related changes

 - Need to update the documentation
