### PR TITLE
server: fix scheduler metrics

### DIFF
--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -408,6 +408,7 @@ func (c *coordinator) removeScheduler(name string) error {
 	}
 
 	s.Stop()
+	schedulerStatusGauge.WithLabelValues(name, "allow").Set(0)
 	delete(c.schedulers, name)
 
 	return c.cluster.opt.RemoveSchedulerCfg(name)


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Currently, after removing scheduler by using `pd-ctl`, the scheduler which is deleted still remains in the Grafana.

### What is changed and how it works?
This PR sets the metrics of the scheduler which is deleted to 0 after removing it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test