### PR TITLE
server, client: fix hanging problem when etcd failed to start

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -163,7 +163,9 @@ func (c *client) initClusterID() error {
 	defer cancel()
 	for i := 0; i < maxInitClusterRetries; i++ {
 		for _, u := range c.urls {
-			members, err := c.getMembers(ctx, u)
+			timeoutCtx, timeoutCancel := context.WithTimeout(ctx, pdTimeout)
+			members, err := c.getMembers(timeoutCtx, u)
+			timeoutCancel()
 			if err != nil || members.GetHeader() == nil {
 				log.Errorf("[pd] failed to get cluster id: %v", err)
 				continue

--- a/server/server.go
+++ b/server/server.go
@@ -43,6 +43,7 @@ import (
 
 const (
 	etcdTimeout           = time.Second * 3
+	etcdStartTimeout      = time.Minute * 5
 	serverMetricsInterval = time.Minute
 	// pdRootPath for all pd servers.
 	pdRootPath      = "/pd"
@@ -134,6 +135,9 @@ func CreateServer(cfg *Config, apiRegister func(*Server) http.Handler) (*Server,
 
 func (s *Server) startEtcd(ctx context.Context) error {
 	log.Info("start embed etcd")
+	ctx, cancel := context.WithTimeout(ctx, etcdStartTimeout)
+	defer cancel()
+
 	etcd, err := embed.StartEtcd(s.etcdCfg)
 	if err != nil {
 		return errors.WithStack(err)


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Sometimes etcd may get stuck inside when it starts up. At this point, the port of the PD is in listened, but it cannot serve any requests. At the same time, the client (tidb) will also get stuck because the pd-server does not return a message.

### What is changed and how it works?
Add context timeout in 2 places:
1. pd server `startEtcd`. If etcd is not able to start in time, pd-server will report an error and exit.
2. pd client `initClusterID`. If pd server not responds, the client will query next pd server instance.

TODO: update tidb vendor.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integration test

Related changes
 - Need to cherry-pick to the release branch
 - Need to update the documentation
