### PR TITLE
server: fix data race in RaftCluster

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -14,6 +14,7 @@
 package pd
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
@@ -27,7 +28,6 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )

--- a/server/cluster_worker.go
+++ b/server/cluster_worker.go
@@ -27,6 +27,8 @@ import (
 
 // HandleRegionHeartbeat processes RegionInfo reports from client.
 func (c *RaftCluster) HandleRegionHeartbeat(region *core.RegionInfo) error {
+	c.RLock()
+	defer c.RUnlock()
 	if err := c.cachedCluster.handleRegionHeartbeat(region); err != nil {
 		return err
 	}
@@ -60,6 +62,8 @@ func (c *RaftCluster) handleAskSplit(request *pdpb.AskSplitRequest) (*pdpb.AskSp
 		}
 	}
 
+	c.RLock()
+	defer c.RUnlock()
 	// Disable merge for the 2 regions in a period of time.
 	c.coordinator.mergeChecker.RecordRegionSplit(reqRegion.GetId())
 	c.coordinator.mergeChecker.RecordRegionSplit(newRegionID)
@@ -97,6 +101,8 @@ func (c *RaftCluster) handleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*
 	}
 	splitIDs := make([]*pdpb.SplitID, 0, splitCount)
 
+	c.RLock()
+	defer c.RUnlock()
 	// Disable merge the regions in a period of time.
 	c.coordinator.mergeChecker.RecordRegionSplit(reqRegion.GetId())
 	for i := 0; i < int(splitCount); i++ {

--- a/server/handler.go
+++ b/server/handler.go
@@ -65,6 +65,8 @@ func (h *Handler) getCoordinator() (*coordinator, error) {
 	if cluster == nil {
 		return nil, errors.WithStack(ErrNotBootstrapped)
 	}
+	cluster.RLock()
+	defer cluster.RUnlock()
 	return cluster.coordinator, nil
 }
 
@@ -119,6 +121,8 @@ func (h *Handler) GetHotBytesWriteStores() map[uint64]uint64 {
 	if cluster == nil {
 		return nil
 	}
+	cluster.RLock()
+	defer cluster.RUnlock()
 	return cluster.cachedCluster.getStoresBytesWriteStat()
 }
 
@@ -128,6 +132,8 @@ func (h *Handler) GetHotBytesReadStores() map[uint64]uint64 {
 	if cluster == nil {
 		return nil
 	}
+	cluster.RLock()
+	defer cluster.RUnlock()
 	return cluster.cachedCluster.getStoresBytesReadStat()
 }
 
@@ -137,6 +143,8 @@ func (h *Handler) GetHotKeysWriteStores() map[uint64]uint64 {
 	if cluster == nil {
 		return nil
 	}
+	cluster.RLock()
+	defer cluster.RUnlock()
 	return cluster.cachedCluster.getStoresKeysWriteStat()
 }
 
@@ -146,6 +154,8 @@ func (h *Handler) GetHotKeysReadStores() map[uint64]uint64 {
 	if cluster == nil {
 		return nil
 	}
+	cluster.RLock()
+	defer cluster.RUnlock()
 	return cluster.cachedCluster.getStoresKeysReadStat()
 }
 
@@ -585,6 +595,8 @@ func (h *Handler) GetDownPeerRegions() ([]*core.RegionInfo, error) {
 	if c == nil {
 		return nil, ErrNotBootstrapped
 	}
+	c.RLock()
+	defer c.RUnlock()
 	return c.cachedCluster.GetRegionStatsByType(downPeer), nil
 }
 
@@ -594,6 +606,8 @@ func (h *Handler) GetExtraPeerRegions() ([]*core.RegionInfo, error) {
 	if c == nil {
 		return nil, ErrNotBootstrapped
 	}
+	c.RLock()
+	defer c.RUnlock()
 	return c.cachedCluster.GetRegionStatsByType(extraPeer), nil
 }
 
@@ -603,6 +617,8 @@ func (h *Handler) GetMissPeerRegions() ([]*core.RegionInfo, error) {
 	if c == nil {
 		return nil, ErrNotBootstrapped
 	}
+	c.RLock()
+	defer c.RUnlock()
 	return c.cachedCluster.GetRegionStatsByType(missPeer), nil
 }
 
@@ -612,6 +628,8 @@ func (h *Handler) GetPendingPeerRegions() ([]*core.RegionInfo, error) {
 	if c == nil {
 		return nil, ErrNotBootstrapped
 	}
+	c.RLock()
+	defer c.RUnlock()
 	return c.cachedCluster.GetRegionStatsByType(pendingPeer), nil
 }
 
@@ -621,5 +639,7 @@ func (h *Handler) GetIncorrectNamespaceRegions() ([]*core.RegionInfo, error) {
 	if c == nil {
 		return nil, ErrNotBootstrapped
 	}
+	c.RLock()
+	defer c.RUnlock()
 	return c.cachedCluster.GetRegionStatsByType(incorrectNamespace), nil
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists--> 
When the leader drops which could be caused by some reasons (e.g. cannot read from disk), it will elect a new leader which will call `createRaftCluster` to reassign `cachedCluster`, `coordinator` and `running` in `RaftCluster`. At that time, if we read `RaftCluster` without lock, the data race may happens. This PR closes #1270.

### What is changed and how it works?
This PR adds some locks when reading from `cachedCluster` and `coordinator` in order to prevent reading and writing `RaftCluster` at the same time. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to be included in the release notes
