### PR TITLE
server: fix WaitGroup data race

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -157,9 +157,11 @@ func (c *RaftCluster) runSyncRegions() {
 
 func (c *RaftCluster) runCoordinator() {
 	defer logutil.LogPanic()
-
+	defer c.wg.Done()
+	defer c.coordinator.wg.Wait()
 	c.coordinator.run()
-	c.wg.Done()
+	<-c.coordinator.ctx.Done()
+	log.Info("coordinator: Stopped coordinator")
 }
 
 func (c *RaftCluster) stop() {

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -214,7 +214,6 @@ func (c *coordinator) run() {
 		select {
 		case <-ticker.C:
 		case <-c.ctx.Done():
-			log.Info("coordinator: Stopped coordinator")
 			return
 		}
 	}
@@ -258,7 +257,6 @@ func (c *coordinator) run() {
 
 func (c *coordinator) stop() {
 	c.cancel()
-	c.wg.Wait()
 }
 
 // Hack to retrive info from scheduler.

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -194,6 +194,7 @@ func (s *testCoordinatorSuite) TestDispatch(c *C) {
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
 	co.run()
+	defer co.wg.Wait()
 	defer co.stop()
 
 	// Transfer peer from store 4 to store 1.
@@ -298,12 +299,14 @@ func (s *testCoordinatorSuite) TestCheckRegion(c *C) {
 	tc.putRegion(r)
 	c.Assert(co.checkRegion(tc.GetRegion(1)), IsFalse)
 	co.stop()
+	co.wg.Wait()
 
 	// new cluster with learner disabled
 	cfg.DisableLearner = true
 	tc = newTestClusterInfo(opt)
 	co = newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
 	co.run()
+	defer co.wg.Wait()
 	defer co.stop()
 
 	tc.addRegionStore(4, 4)
@@ -334,6 +337,7 @@ func (s *testCoordinatorSuite) TestReplica(c *C) {
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
 	co.run()
+	defer co.wg.Wait()
 	defer co.stop()
 
 	tc.addRegionStore(1, 1)
@@ -395,6 +399,7 @@ func (s *testCoordinatorSuite) TestPeerState(c *C) {
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
 	co.run()
+	defer co.wg.Wait()
 	defer co.stop()
 
 	// Transfer peer from store 4 to store 1.
@@ -493,6 +498,7 @@ func (s *testCoordinatorSuite) TestAddScheduler(c *C) {
 	defer hbStreams.Close()
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
 	co.run()
+	defer co.wg.Wait()
 	defer co.stop()
 
 	c.Assert(co.schedulers, HasLen, 4)
@@ -571,6 +577,7 @@ func (s *testCoordinatorSuite) TestPersistScheduler(c *C) {
 	c.Assert(co.schedulers, HasLen, 2)
 	c.Assert(co.cluster.opt.persist(co.cluster.kv), IsNil)
 	co.stop()
+	co.wg.Wait()
 	// make a new coordinator for testing
 	// whether the schedulers added or removed in dynamic way are recorded in opt
 	_, newOpt := newTestScheduleConfig()
@@ -587,6 +594,7 @@ func (s *testCoordinatorSuite) TestPersistScheduler(c *C) {
 	co.run()
 	c.Assert(co.schedulers, HasLen, 3)
 	co.stop()
+	co.wg.Wait()
 	// suppose restart PD again
 	_, newOpt = newTestScheduleConfig()
 	newOpt.reload(tc.kv)
@@ -610,6 +618,7 @@ func (s *testCoordinatorSuite) TestPersistScheduler(c *C) {
 	c.Assert(co.schedulers, HasLen, 4)
 	c.Assert(co.cluster.opt.persist(co.cluster.kv), IsNil)
 	co.stop()
+	co.wg.Wait()
 
 	_, newOpt = newTestScheduleConfig()
 	newOpt.reload(co.cluster.kv)
@@ -617,6 +626,7 @@ func (s *testCoordinatorSuite) TestPersistScheduler(c *C) {
 	co = newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
 
 	co.run()
+	defer co.wg.Wait()
 	defer co.stop()
 	c.Assert(co.schedulers, HasLen, 4)
 	c.Assert(co.removeScheduler("grant-leader-scheduler-2"), IsNil)
@@ -650,6 +660,7 @@ func (s *testCoordinatorSuite) TestRestart(c *C) {
 	dispatchHeartbeat(c, co, region, stream)
 	region = waitPromoteLearner(c, stream, region, 2)
 	co.stop()
+	co.wg.Wait()
 
 	// Recreate coodinator then add another replica on store 3.
 	co = newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -659,6 +670,7 @@ func (s *testCoordinatorSuite) TestRestart(c *C) {
 	dispatchHeartbeat(c, co, region, stream)
 	waitPromoteLearner(c, stream, region, 3)
 	co.stop()
+	co.wg.Wait()
 }
 
 func waitOperator(c *C, co *coordinator, regionID uint64) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
At present, `coordinator` uses `WaitGroup` to synchronize. We call `Add()` in `(c *coordinator) run()` and `Wait()` in `(c *coordinator) stop()` which are in different goroutines. So the data race could happen when the leader drops. This PRs closes #1268. 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (`make test`)

Related changes

 - Need to be included in the release notes
