### PR TITLE
schedule: schedule limiter refactor

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -502,19 +502,19 @@ func (c *RaftCluster) checkStores() {
 }
 
 func (c *RaftCluster) checkOperators() {
-	limiter := c.coordinator.schedLimiter
-	for _, op := range limiter.GetOperators() {
+	oc := c.coordinator.opController
+	for _, op := range oc.GetOperators() {
 		// after region is merged, it will not heartbeat anymore
 		// the operator of merged region will not timeout actively
 		if c.cachedCluster.GetRegion(op.RegionID()) == nil {
 			log.Debugf("remove operator %v cause region %d is merged", op, op.RegionID())
-			limiter.RemoveOperator(op)
+			oc.RemoveOperator(op)
 			continue
 		}
 
 		if op.IsTimeout() {
 			log.Infof("[region %v] operator timeout: %s", op.RegionID(), op)
-			limiter.RemoveOperator(op)
+			oc.RemoveOperator(op)
 		}
 	}
 }
@@ -564,7 +564,7 @@ func (c *RaftCluster) runBackgroundJobs(interval time.Duration) {
 			c.checkOperators()
 			c.checkStores()
 			c.collectMetrics()
-			c.coordinator.schedLimiter.PruneHistory()
+			c.coordinator.opController.PruneHistory()
 		}
 	}
 }

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -502,20 +502,19 @@ func (c *RaftCluster) checkStores() {
 }
 
 func (c *RaftCluster) checkOperators() {
-	co := c.coordinator
-	for _, op := range co.getOperators() {
+	limiter := c.coordinator.schedLimiter
+	for _, op := range limiter.GetOperators() {
 		// after region is merged, it will not heartbeat anymore
 		// the operator of merged region will not timeout actively
 		if c.cachedCluster.GetRegion(op.RegionID()) == nil {
 			log.Debugf("remove operator %v cause region %d is merged", op, op.RegionID())
-			co.removeOperator(op)
+			limiter.RemoveOperator(op)
 			continue
 		}
 
 		if op.IsTimeout() {
 			log.Infof("[region %v] operator timeout: %s", op.RegionID(), op)
-			operatorCounter.WithLabelValues(op.Desc(), "timeout").Inc()
-			co.removeOperator(op)
+			limiter.RemoveOperator(op)
 		}
 	}
 }
@@ -565,7 +564,7 @@ func (c *RaftCluster) runBackgroundJobs(interval time.Duration) {
 			c.checkOperators()
 			c.checkStores()
 			c.collectMetrics()
-			c.coordinator.pruneHistory()
+			c.coordinator.schedLimiter.PruneHistory()
 		}
 	}
 }

--- a/server/cluster_worker.go
+++ b/server/cluster_worker.go
@@ -37,7 +37,7 @@ func (c *RaftCluster) HandleRegionHeartbeat(region *core.RegionInfo) error {
 		return errors.Errorf("invalid region, zero region peer count - %v", region)
 	}
 
-	c.coordinator.dispatch(region)
+	c.coordinator.schedLimiter.Dispatch(region)
 	return nil
 }
 

--- a/server/cluster_worker.go
+++ b/server/cluster_worker.go
@@ -37,7 +37,7 @@ func (c *RaftCluster) HandleRegionHeartbeat(region *core.RegionInfo) error {
 		return errors.Errorf("invalid region, zero region peer count - %v", region)
 	}
 
-	c.coordinator.schedLimiter.Dispatch(region)
+	c.coordinator.opController.Dispatch(region)
 	return nil
 }
 

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -14,15 +14,11 @@
 package server
 
 import (
-	"container/list"
 	"context"
 	"fmt"
 	"sync"
 	"time"
 
-	"github.com/pingcap/kvproto/pkg/eraftpb"
-	"github.com/pingcap/kvproto/pkg/metapb"
-	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/pd/pkg/logutil"
 	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/server/namespace"
@@ -35,7 +31,6 @@ const (
 	runSchedulerCheckInterval = 3 * time.Second
 	collectFactor             = 0.8
 	collectTimeout            = 5 * time.Minute
-	historyKeepTime           = 5 * time.Minute
 	maxScheduleRetries        = 10
 
 	regionheartbeatSendChanCap = 1024
@@ -57,15 +52,13 @@ type coordinator struct {
 	cancel context.CancelFunc
 
 	cluster          *clusterInfo
-	limiter          *schedule.Limiter
 	replicaChecker   *schedule.ReplicaChecker
 	regionScatterer  *schedule.RegionScatterer
 	namespaceChecker *schedule.NamespaceChecker
 	mergeChecker     *schedule.MergeChecker
-	operators        map[uint64]*schedule.Operator
 	schedulers       map[string]*scheduleController
+	schedLimiter     *schedule.SchedLimiter
 	classifier       namespace.Classifier
-	histories        *list.List
 	hbStreams        *heartbeatStreams
 }
 
@@ -75,39 +68,14 @@ func newCoordinator(cluster *clusterInfo, hbStreams *heartbeatStreams, classifie
 		ctx:              ctx,
 		cancel:           cancel,
 		cluster:          cluster,
-		limiter:          schedule.NewLimiter(),
 		replicaChecker:   schedule.NewReplicaChecker(cluster, classifier),
 		regionScatterer:  schedule.NewRegionScatterer(cluster, classifier),
 		namespaceChecker: schedule.NewNamespaceChecker(cluster, classifier),
 		mergeChecker:     schedule.NewMergeChecker(cluster, classifier),
-		operators:        make(map[uint64]*schedule.Operator),
 		schedulers:       make(map[string]*scheduleController),
+		schedLimiter:     schedule.NewSchedLimiter(cluster, hbStreams),
 		classifier:       classifier,
-		histories:        list.New(),
 		hbStreams:        hbStreams,
-	}
-}
-
-func (c *coordinator) dispatch(region *core.RegionInfo) {
-	// Check existed operator.
-	if op := c.getOperator(region.GetID()); op != nil {
-		timeout := op.IsTimeout()
-		if step := op.Check(region); step != nil && !timeout {
-			operatorCounter.WithLabelValues(op.Desc(), "check").Inc()
-			c.sendScheduleCommand(region, step)
-			return
-		}
-		if op.IsFinish() {
-			log.Infof("[region %v] operator finish: %s", region.GetID(), op)
-			operatorCounter.WithLabelValues(op.Desc(), "finish").Inc()
-			operatorDuration.WithLabelValues(op.Desc()).Observe(op.ElapsedTime().Seconds())
-			c.pushHistory(op)
-			c.removeOperator(op)
-		} else if timeout {
-			log.Infof("[region %v] operator timeout: %s", region.GetID(), op)
-			operatorCounter.WithLabelValues(op.Desc(), "timeout").Inc()
-			c.removeOperator(op)
-		}
 	}
 }
 
@@ -138,7 +106,7 @@ func (c *coordinator) patrolRegions() {
 
 		for _, region := range regions {
 			// Skip the region if there is already a pending operator.
-			if c.getOperator(region.GetID()) != nil {
+			if c.schedLimiter.GetOperator(region.GetID()) != nil {
 				continue
 			}
 
@@ -169,32 +137,33 @@ func (c *coordinator) checkRegion(region *core.RegionInfo) bool {
 			PeerID:  p.GetId(),
 		}
 		op := schedule.NewOperator("promoteLearner", region.GetID(), region.GetRegionEpoch(), schedule.OpRegion, step)
-		if c.addOperator(op) {
+		if c.schedLimiter.AddOperator(op) {
 			return true
 		}
 	}
 
-	if c.limiter.OperatorCount(schedule.OpLeader) < c.cluster.GetLeaderScheduleLimit() &&
-		c.limiter.OperatorCount(schedule.OpRegion) < c.cluster.GetRegionScheduleLimit() &&
-		c.limiter.OperatorCount(schedule.OpReplica) < c.cluster.GetReplicaScheduleLimit() {
+	limiter := c.schedLimiter.Limiter
+	if limiter.OperatorCount(schedule.OpLeader) < c.cluster.GetLeaderScheduleLimit() &&
+		limiter.OperatorCount(schedule.OpRegion) < c.cluster.GetRegionScheduleLimit() &&
+		limiter.OperatorCount(schedule.OpReplica) < c.cluster.GetReplicaScheduleLimit() {
 		if op := c.namespaceChecker.Check(region); op != nil {
-			if c.addOperator(op) {
+			if c.schedLimiter.AddOperator(op) {
 				return true
 			}
 		}
 	}
 
-	if c.limiter.OperatorCount(schedule.OpReplica) < c.cluster.GetReplicaScheduleLimit() {
+	if limiter.OperatorCount(schedule.OpReplica) < c.cluster.GetReplicaScheduleLimit() {
 		if op := c.replicaChecker.Check(region); op != nil {
-			if c.addOperator(op) {
+			if c.schedLimiter.AddOperator(op) {
 				return true
 			}
 		}
 	}
-	if c.cluster.IsFeatureSupported(RegionMerge) && c.limiter.OperatorCount(schedule.OpMerge) < c.cluster.GetMergeScheduleLimit() {
-		if op1, op2 := c.mergeChecker.Check(region); op1 != nil && op2 != nil {
+	if c.cluster.IsFeatureSupported(RegionMerge) && limiter.OperatorCount(schedule.OpMerge) < c.cluster.GetMergeScheduleLimit() {
+		if ops := c.mergeChecker.Check(region); ops != nil {
 			// make sure two operators can add successfully altogether
-			if c.addOperator(op1, op2) {
+			if c.schedLimiter.AddOperator(ops...) {
 				return true
 			}
 		}
@@ -228,7 +197,7 @@ func (c *coordinator) run() {
 			log.Info("skip create ", schedulerCfg.Type)
 			continue
 		}
-		s, err := schedule.CreateScheduler(schedulerCfg.Type, c.limiter, schedulerCfg.Args...)
+		s, err := schedule.CreateScheduler(schedulerCfg.Type, c.schedLimiter.Limiter, schedulerCfg.Args...)
 		if err != nil {
 			log.Errorf("can not create scheduler %s: %v", schedulerCfg.Type, err)
 		} else {
@@ -427,226 +396,15 @@ func (c *coordinator) runScheduler(s *scheduleController) {
 			if !s.AllowSchedule() {
 				continue
 			}
-			opInfluence := schedule.NewOpInfluence(c.getOperators(), c.cluster)
+			opInfluence := schedule.NewOpInfluence(c.schedLimiter.GetOperators(), c.cluster)
 			if op := s.Schedule(c.cluster, opInfluence); op != nil {
-				c.addOperator(op...)
+				c.schedLimiter.AddOperator(op...)
 			}
 
 		case <-s.Ctx().Done():
 			log.Infof("%v stopped: %v", s.GetName(), s.Ctx().Err())
 			return
 		}
-	}
-}
-
-func (c *coordinator) addOperatorLocked(op *schedule.Operator) bool {
-	regionID := op.RegionID()
-
-	log.Infof("[region %v] add operator: %s", regionID, op)
-
-	// If there is an old operator, replace it. The priority should be checked
-	// already.
-	if old, ok := c.operators[regionID]; ok {
-		log.Infof("[region %v] replace old operator: %s", regionID, old)
-		operatorCounter.WithLabelValues(old.Desc(), "replaced").Inc()
-		c.removeOperatorLocked(old)
-	}
-
-	c.operators[regionID] = op
-	c.limiter.UpdateCounts(c.operators)
-
-	if region := c.cluster.GetRegion(op.RegionID()); region != nil {
-		if step := op.Check(region); step != nil {
-			c.sendScheduleCommand(region, step)
-		}
-	}
-
-	operatorCounter.WithLabelValues(op.Desc(), "create").Inc()
-	return true
-}
-
-func (c *coordinator) addOperator(ops ...*schedule.Operator) bool {
-	c.Lock()
-	defer c.Unlock()
-
-	for _, op := range ops {
-		if !c.checkAddOperator(op) {
-			operatorCounter.WithLabelValues(op.Desc(), "canceled").Inc()
-			return false
-		}
-	}
-	for _, op := range ops {
-		c.addOperatorLocked(op)
-	}
-
-	return true
-}
-
-func (c *coordinator) checkAddOperator(op *schedule.Operator) bool {
-	region := c.cluster.GetRegion(op.RegionID())
-	if region == nil {
-		log.Debugf("[region %v] region not found, cancel add operator", op.RegionID())
-		return false
-	}
-	if region.GetRegionEpoch().GetVersion() != op.RegionEpoch().GetVersion() || region.GetRegionEpoch().GetConfVer() != op.RegionEpoch().GetConfVer() {
-		log.Debugf("[region %v] region epoch not match, %v vs %v, cancel add operator", op.RegionID(), region.GetRegionEpoch(), op.RegionEpoch())
-		return false
-	}
-	if old := c.operators[op.RegionID()]; old != nil && !isHigherPriorityOperator(op, old) {
-		log.Debugf("[region %v] already have operator %s, cancel add operator", op.RegionID(), old)
-		return false
-	}
-	return true
-}
-
-func isHigherPriorityOperator(new, old *schedule.Operator) bool {
-	return new.GetPriorityLevel() < old.GetPriorityLevel()
-}
-
-func (c *coordinator) pushHistory(op *schedule.Operator) {
-	c.Lock()
-	defer c.Unlock()
-	for _, h := range op.History() {
-		c.histories.PushFront(h)
-	}
-}
-
-func (c *coordinator) pruneHistory() {
-	c.Lock()
-	defer c.Unlock()
-	p := c.histories.Back()
-	for p != nil && time.Since(p.Value.(schedule.OperatorHistory).FinishTime) > historyKeepTime {
-		prev := p.Prev()
-		c.histories.Remove(p)
-		p = prev
-	}
-}
-
-func (c *coordinator) removeOperator(op *schedule.Operator) {
-	c.Lock()
-	defer c.Unlock()
-	c.removeOperatorLocked(op)
-}
-
-func (c *coordinator) removeOperatorLocked(op *schedule.Operator) {
-	regionID := op.RegionID()
-	delete(c.operators, regionID)
-	c.limiter.UpdateCounts(c.operators)
-	operatorCounter.WithLabelValues(op.Desc(), "remove").Inc()
-}
-
-func (c *coordinator) getOperator(regionID uint64) *schedule.Operator {
-	c.RLock()
-	defer c.RUnlock()
-	return c.operators[regionID]
-}
-
-func (c *coordinator) getOperators() []*schedule.Operator {
-	c.RLock()
-	defer c.RUnlock()
-
-	operators := make([]*schedule.Operator, 0, len(c.operators))
-	for _, op := range c.operators {
-		operators = append(operators, op)
-	}
-
-	return operators
-}
-
-func (c *coordinator) getHistory(start time.Time) []schedule.OperatorHistory {
-	c.RLock()
-	defer c.RUnlock()
-	histories := make([]schedule.OperatorHistory, 0, c.histories.Len())
-	for p := c.histories.Front(); p != nil; p = p.Next() {
-		history := p.Value.(schedule.OperatorHistory)
-		if history.FinishTime.Before(start) {
-			break
-		}
-		histories = append(histories, history)
-	}
-	return histories
-}
-
-func (c *coordinator) sendScheduleCommand(region *core.RegionInfo, step schedule.OperatorStep) {
-	log.Infof("[region %v] send schedule command: %s", region.GetID(), step)
-	switch s := step.(type) {
-	case schedule.TransferLeader:
-		cmd := &pdpb.RegionHeartbeatResponse{
-			TransferLeader: &pdpb.TransferLeader{
-				Peer: region.GetStorePeer(s.ToStore),
-			},
-		}
-		c.hbStreams.sendMsg(region, cmd)
-	case schedule.AddPeer:
-		if region.GetStorePeer(s.ToStore) != nil {
-			// The newly added peer is pending.
-			return
-		}
-		cmd := &pdpb.RegionHeartbeatResponse{
-			ChangePeer: &pdpb.ChangePeer{
-				ChangeType: eraftpb.ConfChangeType_AddNode,
-				Peer: &metapb.Peer{
-					Id:      s.PeerID,
-					StoreId: s.ToStore,
-				},
-			},
-		}
-		c.hbStreams.sendMsg(region, cmd)
-	case schedule.AddLearner:
-		if region.GetStorePeer(s.ToStore) != nil {
-			// The newly added peer is pending.
-			return
-		}
-		cmd := &pdpb.RegionHeartbeatResponse{
-			ChangePeer: &pdpb.ChangePeer{
-				ChangeType: eraftpb.ConfChangeType_AddLearnerNode,
-				Peer: &metapb.Peer{
-					Id:        s.PeerID,
-					StoreId:   s.ToStore,
-					IsLearner: true,
-				},
-			},
-		}
-		c.hbStreams.sendMsg(region, cmd)
-	case schedule.PromoteLearner:
-		cmd := &pdpb.RegionHeartbeatResponse{
-			ChangePeer: &pdpb.ChangePeer{
-				// reuse AddNode type
-				ChangeType: eraftpb.ConfChangeType_AddNode,
-				Peer: &metapb.Peer{
-					Id:      s.PeerID,
-					StoreId: s.ToStore,
-				},
-			},
-		}
-		c.hbStreams.sendMsg(region, cmd)
-	case schedule.RemovePeer:
-		cmd := &pdpb.RegionHeartbeatResponse{
-			ChangePeer: &pdpb.ChangePeer{
-				ChangeType: eraftpb.ConfChangeType_RemoveNode,
-				Peer:       region.GetStorePeer(s.FromStore),
-			},
-		}
-		c.hbStreams.sendMsg(region, cmd)
-	case schedule.MergeRegion:
-		if s.IsPassive {
-			return
-		}
-		cmd := &pdpb.RegionHeartbeatResponse{
-			Merge: &pdpb.Merge{
-				Target: s.ToRegion,
-			},
-		}
-		c.hbStreams.sendMsg(region, cmd)
-	case schedule.SplitRegion:
-		cmd := &pdpb.RegionHeartbeatResponse{
-			SplitRegion: &pdpb.SplitRegion{
-				Policy: s.Policy,
-			},
-		}
-		c.hbStreams.sendMsg(region, cmd)
-	default:
-		log.Errorf("unknown operatorStep: %v", step)
 	}
 }
 
@@ -665,7 +423,7 @@ func newScheduleController(c *coordinator, s schedule.Scheduler) *scheduleContro
 	return &scheduleController{
 		Scheduler:    s,
 		cluster:      c.cluster,
-		limiter:      c.limiter,
+		limiter:      c.schedLimiter.Limiter,
 		nextInterval: s.GetMinInterval(),
 		classifier:   c.classifier,
 		ctx:          ctx,

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -137,25 +137,26 @@ func (s *testCoordinatorSuite) TestBasic(c *C) {
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
-	l := co.limiter
+	sl := co.schedLimiter
+	l := sl.Limiter
 
 	tc.addLeaderRegion(1, 1)
 
 	op1 := newTestOperator(1, tc.GetRegion(1).GetRegionEpoch(), schedule.OpLeader)
-	co.addOperator(op1)
+	sl.AddOperator(op1)
 	c.Assert(l.OperatorCount(op1.Kind()), Equals, uint64(1))
-	c.Assert(co.getOperator(1).RegionID(), Equals, op1.RegionID())
+	c.Assert(sl.GetOperator(1).RegionID(), Equals, op1.RegionID())
 
 	// Region 1 already has an operator, cannot add another one.
 	op2 := newTestOperator(1, tc.GetRegion(1).GetRegionEpoch(), schedule.OpRegion)
-	co.addOperator(op2)
+	sl.AddOperator(op2)
 	c.Assert(l.OperatorCount(op2.Kind()), Equals, uint64(0))
 
 	// Remove the operator manually, then we can add a new operator.
-	co.removeOperator(op1)
-	co.addOperator(op2)
+	sl.RemoveOperator(op1)
+	sl.AddOperator(op2)
 	c.Assert(l.OperatorCount(op2.Kind()), Equals, uint64(1))
-	c.Assert(co.getOperator(1).RegionID(), Equals, op2.RegionID())
+	c.Assert(sl.GetOperator(1).RegionID(), Equals, op2.RegionID())
 }
 
 type mockHeartbeatStream struct {
@@ -213,10 +214,10 @@ func (s *testCoordinatorSuite) TestDispatch(c *C) {
 
 	// Wait for schedule and turn off balance.
 	waitOperator(c, co, 1)
-	testutil.CheckTransferPeer(c, co.getOperator(1), schedule.OpBalance, 4, 1)
+	testutil.CheckTransferPeer(c, co.schedLimiter.GetOperator(1), schedule.OpBalance, 4, 1)
 	c.Assert(co.removeScheduler("balance-region-scheduler"), IsNil)
 	waitOperator(c, co, 2)
-	testutil.CheckTransferLeader(c, co.getOperator(2), schedule.OpBalance, 4, 2)
+	testutil.CheckTransferLeader(c, co.schedLimiter.GetOperator(2), schedule.OpBalance, 4, 2)
 	c.Assert(co.removeScheduler("balance-leader-scheduler"), IsNil)
 
 	stream := newMockHeartbeatStream()
@@ -244,7 +245,7 @@ func (s *testCoordinatorSuite) TestDispatch(c *C) {
 func dispatchHeartbeat(c *C, co *coordinator, region *core.RegionInfo, stream *mockHeartbeatStream) {
 	co.hbStreams.bindStream(region.GetLeader().GetStoreId(), stream)
 	co.cluster.putRegion(region.Clone())
-	co.dispatch(region)
+	co.schedLimiter.Dispatch(region)
 }
 
 func (s *testCoordinatorSuite) TestCollectMetrics(c *C) {
@@ -287,7 +288,7 @@ func (s *testCoordinatorSuite) TestCheckRegion(c *C) {
 	tc.addLeaderRegion(1, 2, 3)
 	c.Assert(co.checkRegion(tc.GetRegion(1)), IsTrue)
 	waitOperator(c, co, 1)
-	testutil.CheckAddPeer(c, co.getOperator(1), schedule.OpReplica, 1)
+	testutil.CheckAddPeer(c, co.schedLimiter.GetOperator(1), schedule.OpReplica, 1)
 	c.Assert(co.checkRegion(tc.GetRegion(1)), IsFalse)
 
 	r := tc.GetRegion(1)
@@ -319,7 +320,7 @@ func (s *testCoordinatorSuite) TestCheckRegion(c *C) {
 	tc.putRegion(r)
 	c.Assert(co.checkRegion(tc.GetRegion(1)), IsTrue)
 	waitOperator(c, co, 1)
-	op := co.getOperator(1)
+	op := co.schedLimiter.GetOperator(1)
 	c.Assert(op.Len(), Equals, 1)
 	c.Assert(op.Step(0).(schedule.PromoteLearner).ToStore, Equals, uint64(1))
 	c.Assert(co.checkRegion(tc.GetRegion(1)), IsFalse)
@@ -413,7 +414,7 @@ func (s *testCoordinatorSuite) TestPeerState(c *C) {
 
 	// Wait for schedule.
 	waitOperator(c, co, 1)
-	testutil.CheckTransferPeer(c, co.getOperator(1), schedule.OpBalance, 4, 1)
+	testutil.CheckTransferPeer(c, co.schedLimiter.GetOperator(1), schedule.OpBalance, 4, 1)
 
 	region := tc.GetRegion(1).Clone()
 
@@ -427,7 +428,7 @@ func (s *testCoordinatorSuite) TestPeerState(c *C) {
 	region = region.Clone(core.WithPendingPeers(append(region.GetPendingPeers(), region.GetStorePeer(1))))
 	dispatchHeartbeat(c, co, region, stream)
 	waitNoResponse(c, stream)
-	c.Assert(co.getOperator(region.GetID()), NotNil)
+	c.Assert(co.schedLimiter.GetOperator(region.GetID()), NotNil)
 
 	// The new peer is not pending now, the operator will finish.
 	// And we will proceed to remove peer in store 4.
@@ -521,12 +522,12 @@ func (s *testCoordinatorSuite) TestAddScheduler(c *C) {
 	// Add regions 3 with leader in store 3 and followers in stores 1,2
 	tc.addLeaderRegion(3, 3, 1, 2)
 
-	gls, err := schedule.CreateScheduler("grant-leader", co.limiter, "0")
+	gls, err := schedule.CreateScheduler("grant-leader", co.schedLimiter.Limiter, "0")
 	c.Assert(err, IsNil)
 	c.Assert(co.addScheduler(gls), NotNil)
 	c.Assert(co.removeScheduler(gls.GetName()), NotNil)
 
-	gls, err = schedule.CreateScheduler("grant-leader", co.limiter, "1")
+	gls, err = schedule.CreateScheduler("grant-leader", co.schedLimiter.Limiter, "1")
 	c.Assert(err, IsNil)
 	c.Assert(co.addScheduler(gls), IsNil)
 
@@ -562,10 +563,10 @@ func (s *testCoordinatorSuite) TestPersistScheduler(c *C) {
 	tc.addLeaderStore(2, 1)
 
 	c.Assert(co.schedulers, HasLen, 4)
-	gls1, err := schedule.CreateScheduler("grant-leader", co.limiter, "1")
+	gls1, err := schedule.CreateScheduler("grant-leader", co.schedLimiter.Limiter, "1")
 	c.Assert(err, IsNil)
 	c.Assert(co.addScheduler(gls1, "1"), IsNil)
-	gls2, err := schedule.CreateScheduler("grant-leader", co.limiter, "2")
+	gls2, err := schedule.CreateScheduler("grant-leader", co.schedLimiter.Limiter, "2")
 	c.Assert(err, IsNil)
 	c.Assert(co.addScheduler(gls2, "2"), IsNil)
 	c.Assert(co.schedulers, HasLen, 6)
@@ -581,7 +582,7 @@ func (s *testCoordinatorSuite) TestPersistScheduler(c *C) {
 	// make a new coordinator for testing
 	// whether the schedulers added or removed in dynamic way are recorded in opt
 	_, newOpt := newTestScheduleConfig()
-	_, err = schedule.CreateScheduler("adjacent-region", co.limiter)
+	_, err = schedule.CreateScheduler("adjacent-region", co.schedLimiter.Limiter)
 	c.Assert(err, IsNil)
 	// suppose we add a new default enable scheduler
 	newOpt.AddSchedulerCfg("adjacent-region", []string{})
@@ -602,10 +603,10 @@ func (s *testCoordinatorSuite) TestPersistScheduler(c *C) {
 	co = newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
 	co.run()
 	c.Assert(co.schedulers, HasLen, 3)
-	bls, err := schedule.CreateScheduler("balance-leader", co.limiter)
+	bls, err := schedule.CreateScheduler("balance-leader", co.schedLimiter.Limiter)
 	c.Assert(err, IsNil)
 	c.Assert(co.addScheduler(bls), IsNil)
-	brs, err := schedule.CreateScheduler("balance-region", co.limiter)
+	brs, err := schedule.CreateScheduler("balance-region", co.schedLimiter.Limiter)
 	c.Assert(err, IsNil)
 	c.Assert(co.addScheduler(brs), IsNil)
 	c.Assert(co.schedulers, HasLen, 5)
@@ -675,7 +676,7 @@ func (s *testCoordinatorSuite) TestRestart(c *C) {
 
 func waitOperator(c *C, co *coordinator, regionID uint64) {
 	testutil.WaitUntil(c, func(c *C) bool {
-		return co.getOperator(regionID) != nil
+		return co.schedLimiter.GetOperator(regionID) != nil
 	})
 }
 
@@ -736,11 +737,12 @@ func (s *testScheduleControllerSuite) TestController(c *C) {
 	tc.addLeaderRegion(2, 2)
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
-	scheduler, err := schedule.CreateScheduler("balance-leader", co.limiter)
+	sl := co.schedLimiter
+	scheduler, err := schedule.CreateScheduler("balance-leader", sl.Limiter)
 	c.Assert(err, IsNil)
 	lb := &mockLimitScheduler{
 		Scheduler: scheduler,
-		counter:   co.limiter,
+		counter:   sl.Limiter,
 		kind:      schedule.OpLeader,
 	}
 
@@ -755,51 +757,51 @@ func (s *testScheduleControllerSuite) TestController(c *C) {
 	// count = 0
 	c.Assert(sc.AllowSchedule(), IsTrue)
 	op1 := newTestOperator(1, tc.GetRegion(1).GetRegionEpoch(), schedule.OpLeader)
-	c.Assert(co.addOperator(op1), IsTrue)
+	c.Assert(sl.AddOperator(op1), IsTrue)
 	// count = 1
 	c.Assert(sc.AllowSchedule(), IsTrue)
 	op2 := newTestOperator(2, tc.GetRegion(2).GetRegionEpoch(), schedule.OpLeader)
-	c.Assert(co.addOperator(op2), IsTrue)
+	c.Assert(sl.AddOperator(op2), IsTrue)
 	// count = 2
 	c.Assert(sc.AllowSchedule(), IsFalse)
-	co.removeOperator(op1)
+	sl.RemoveOperator(op1)
 	// count = 1
 	c.Assert(sc.AllowSchedule(), IsTrue)
 
 	// add a PriorityKind operator will remove old operator
 	op3 := newTestOperator(2, tc.GetRegion(2).GetRegionEpoch(), schedule.OpHotRegion)
 	op3.SetPriorityLevel(core.HighPriority)
-	c.Assert(co.addOperator(op1), IsTrue)
+	c.Assert(sl.AddOperator(op1), IsTrue)
 	c.Assert(sc.AllowSchedule(), IsFalse)
-	c.Assert(co.addOperator(op3), IsTrue)
+	c.Assert(sl.AddOperator(op3), IsTrue)
 	c.Assert(sc.AllowSchedule(), IsTrue)
-	co.removeOperator(op3)
+	sl.RemoveOperator(op3)
 
 	// add a admin operator will remove old operator
-	c.Assert(co.addOperator(op2), IsTrue)
+	c.Assert(sl.AddOperator(op2), IsTrue)
 	c.Assert(sc.AllowSchedule(), IsFalse)
 	op4 := newTestOperator(2, tc.GetRegion(2).GetRegionEpoch(), schedule.OpAdmin)
 	op4.SetPriorityLevel(core.HighPriority)
-	c.Assert(co.addOperator(op4), IsTrue)
+	c.Assert(sl.AddOperator(op4), IsTrue)
 	c.Assert(sc.AllowSchedule(), IsTrue)
-	co.removeOperator(op4)
+	sl.RemoveOperator(op4)
 
 	// test wrong region id.
 	op5 := newTestOperator(3, &metapb.RegionEpoch{}, schedule.OpHotRegion)
-	c.Assert(co.addOperator(op5), IsFalse)
+	c.Assert(sl.AddOperator(op5), IsFalse)
 
 	// test wrong region epoch.
-	co.removeOperator(op1)
+	sl.RemoveOperator(op1)
 	epoch := &metapb.RegionEpoch{
 		Version: tc.GetRegion(1).GetRegionEpoch().GetVersion() + 1,
 		ConfVer: tc.GetRegion(1).GetRegionEpoch().GetConfVer(),
 	}
 	op6 := newTestOperator(1, epoch, schedule.OpLeader)
-	c.Assert(co.addOperator(op6), IsFalse)
+	c.Assert(sl.AddOperator(op6), IsFalse)
 	epoch.Version--
 	op6 = newTestOperator(1, epoch, schedule.OpLeader)
-	c.Assert(co.addOperator(op6), IsTrue)
-	co.removeOperator(op6)
+	c.Assert(sl.AddOperator(op6), IsTrue)
+	sl.RemoveOperator(op6)
 }
 
 func (s *testScheduleControllerSuite) TestInterval(c *C) {
@@ -809,7 +811,7 @@ func (s *testScheduleControllerSuite) TestInterval(c *C) {
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
-	lb, err := schedule.CreateScheduler("balance-leader", co.limiter)
+	lb, err := schedule.CreateScheduler("balance-leader", co.schedLimiter.Limiter)
 	c.Assert(err, IsNil)
 	sc := newScheduleController(co, lb)
 

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -580,7 +580,7 @@ func (s *Server) ScatterRegion(ctx context.Context, request *pdpb.ScatterRegionR
 
 	co := cluster.coordinator
 	if op := co.regionScatterer.Scatter(region); op != nil {
-		co.addOperator(op)
+		co.schedLimiter.AddOperator(op)
 	}
 
 	return &pdpb.ScatterRegionResponse{

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -580,7 +580,7 @@ func (s *Server) ScatterRegion(ctx context.Context, request *pdpb.ScatterRegionR
 
 	co := cluster.coordinator
 	if op := co.regionScatterer.Scatter(region); op != nil {
-		co.schedLimiter.AddOperator(op)
+		co.opController.AddOperator(op)
 	}
 
 	return &pdpb.ScatterRegionResponse{

--- a/server/handler.go
+++ b/server/handler.go
@@ -155,7 +155,7 @@ func (h *Handler) AddScheduler(name string, args ...string) error {
 	if err != nil {
 		return err
 	}
-	s, err := schedule.CreateScheduler(name, c.limiter, args...)
+	s, err := schedule.CreateScheduler(name, c.schedLimiter.Limiter, args...)
 	if err != nil {
 		return err
 	}
@@ -244,7 +244,7 @@ func (h *Handler) GetOperator(regionID uint64) (*schedule.Operator, error) {
 		return nil, err
 	}
 
-	op := c.getOperator(regionID)
+	op := c.schedLimiter.GetOperator(regionID)
 	if op == nil {
 		return nil, ErrOperatorNotFound
 	}
@@ -259,12 +259,12 @@ func (h *Handler) RemoveOperator(regionID uint64) error {
 		return err
 	}
 
-	op := c.getOperator(regionID)
+	op := c.schedLimiter.GetOperator(regionID)
 	if op == nil {
 		return ErrOperatorNotFound
 	}
 
-	c.removeOperator(op)
+	c.schedLimiter.RemoveOperator(op)
 	return nil
 }
 
@@ -274,7 +274,7 @@ func (h *Handler) GetOperators() ([]*schedule.Operator, error) {
 	if err != nil {
 		return nil, err
 	}
-	return c.getOperators(), nil
+	return c.schedLimiter.GetOperators(), nil
 }
 
 // GetAdminOperators returns the running admin operators.
@@ -313,7 +313,7 @@ func (h *Handler) GetHistory(start time.Time) ([]schedule.OperatorHistory, error
 	if err != nil {
 		return nil, err
 	}
-	return c.getHistory(start), nil
+	return c.schedLimiter.GetHistory(start), nil
 }
 
 var errAddOperator = errors.New("failed to add operator, maybe already have one")
@@ -336,7 +336,7 @@ func (h *Handler) AddTransferLeaderOperator(regionID uint64, storeID uint64) err
 
 	step := schedule.TransferLeader{FromStore: region.GetLeader().GetStoreId(), ToStore: newLeader.GetStoreId()}
 	op := schedule.NewOperator("adminTransferLeader", regionID, region.GetRegionEpoch(), schedule.OpAdmin|schedule.OpLeader, step)
-	if ok := c.addOperator(op); !ok {
+	if ok := c.schedLimiter.AddOperator(op); !ok {
 		return errors.WithStack(errAddOperator)
 	}
 	return nil
@@ -387,7 +387,7 @@ func (h *Handler) AddTransferRegionOperator(regionID uint64, storeIDs map[uint64
 	}
 
 	op := schedule.NewOperator("adminMoveRegion", regionID, region.GetRegionEpoch(), schedule.OpAdmin|schedule.OpRegion, steps...)
-	if ok := c.addOperator(op); !ok {
+	if ok := c.schedLimiter.AddOperator(op); !ok {
 		return errors.WithStack(errAddOperator)
 	}
 	return nil
@@ -419,7 +419,7 @@ func (h *Handler) AddTransferPeerOperator(regionID uint64, fromStoreID, toStoreI
 	}
 
 	op := schedule.CreateMovePeerOperator("adminMovePeer", c.cluster, region, schedule.OpAdmin, fromStoreID, toStoreID, newPeer.GetId())
-	if ok := c.addOperator(op); !ok {
+	if ok := c.schedLimiter.AddOperator(op); !ok {
 		return errors.WithStack(errAddOperator)
 	}
 	return nil
@@ -461,7 +461,7 @@ func (h *Handler) AddAddPeerOperator(regionID uint64, toStoreID uint64) error {
 		}
 	}
 	op := schedule.NewOperator("adminAddPeer", regionID, region.GetRegionEpoch(), schedule.OpAdmin|schedule.OpRegion, steps...)
-	if ok := c.addOperator(op); !ok {
+	if ok := c.schedLimiter.AddOperator(op); !ok {
 		return errors.WithStack(errAddOperator)
 	}
 	return nil
@@ -484,7 +484,7 @@ func (h *Handler) AddRemovePeerOperator(regionID uint64, fromStoreID uint64) err
 	}
 
 	op := schedule.CreateRemovePeerOperator("adminRemovePeer", c.cluster, schedule.OpAdmin, region, fromStoreID)
-	if ok := c.addOperator(op); !ok {
+	if ok := c.schedLimiter.AddOperator(op); !ok {
 		return errors.WithStack(errAddOperator)
 	}
 	return nil
@@ -523,11 +523,11 @@ func (h *Handler) AddMergeRegionOperator(regionID uint64, targetID uint64) error
 		return ErrRegionNotAdjacent
 	}
 
-	op1, op2, err := schedule.CreateMergeRegionOperator("adminMergeRegion", c.cluster, region, target, schedule.OpAdmin)
+	ops, err := schedule.CreateMergeRegionOperator("adminMergeRegion", c.cluster, region, target, schedule.OpAdmin)
 	if err != nil {
 		return err
 	}
-	if ok := c.addOperator(op1, op2); !ok {
+	if ok := c.schedLimiter.AddOperator(ops...); !ok {
 		return errors.WithStack(ErrAddOperator)
 	}
 	return nil
@@ -551,7 +551,7 @@ func (h *Handler) AddSplitRegionOperator(regionID uint64, policy string) error {
 		Policy:   pdpb.CheckPolicy(pdpb.CheckPolicy_value[strings.ToUpper(policy)]),
 	}
 	op := schedule.NewOperator("adminSplitRegion", regionID, region.GetRegionEpoch(), schedule.OpAdmin, step)
-	if ok := c.addOperator(op); !ok {
+	if ok := c.schedLimiter.AddOperator(op); !ok {
 		return errors.WithStack(errAddOperator)
 	}
 	return nil
@@ -573,7 +573,7 @@ func (h *Handler) AddScatterRegionOperator(regionID uint64) error {
 	if op == nil {
 		return nil
 	}
-	if ok := c.addOperator(op); !ok {
+	if ok := c.schedLimiter.AddOperator(op); !ok {
 		return errors.WithStack(errAddOperator)
 	}
 	return nil

--- a/server/handler.go
+++ b/server/handler.go
@@ -155,7 +155,7 @@ func (h *Handler) AddScheduler(name string, args ...string) error {
 	if err != nil {
 		return err
 	}
-	s, err := schedule.CreateScheduler(name, c.schedLimiter.Limiter, args...)
+	s, err := schedule.CreateScheduler(name, c.opController.Limiter, args...)
 	if err != nil {
 		return err
 	}
@@ -244,7 +244,7 @@ func (h *Handler) GetOperator(regionID uint64) (*schedule.Operator, error) {
 		return nil, err
 	}
 
-	op := c.schedLimiter.GetOperator(regionID)
+	op := c.opController.GetOperator(regionID)
 	if op == nil {
 		return nil, ErrOperatorNotFound
 	}
@@ -259,12 +259,12 @@ func (h *Handler) RemoveOperator(regionID uint64) error {
 		return err
 	}
 
-	op := c.schedLimiter.GetOperator(regionID)
+	op := c.opController.GetOperator(regionID)
 	if op == nil {
 		return ErrOperatorNotFound
 	}
 
-	c.schedLimiter.RemoveOperator(op)
+	c.opController.RemoveOperator(op)
 	return nil
 }
 
@@ -274,7 +274,7 @@ func (h *Handler) GetOperators() ([]*schedule.Operator, error) {
 	if err != nil {
 		return nil, err
 	}
-	return c.schedLimiter.GetOperators(), nil
+	return c.opController.GetOperators(), nil
 }
 
 // GetAdminOperators returns the running admin operators.
@@ -313,7 +313,7 @@ func (h *Handler) GetHistory(start time.Time) ([]schedule.OperatorHistory, error
 	if err != nil {
 		return nil, err
 	}
-	return c.schedLimiter.GetHistory(start), nil
+	return c.opController.GetHistory(start), nil
 }
 
 var errAddOperator = errors.New("failed to add operator, maybe already have one")
@@ -336,7 +336,7 @@ func (h *Handler) AddTransferLeaderOperator(regionID uint64, storeID uint64) err
 
 	step := schedule.TransferLeader{FromStore: region.GetLeader().GetStoreId(), ToStore: newLeader.GetStoreId()}
 	op := schedule.NewOperator("adminTransferLeader", regionID, region.GetRegionEpoch(), schedule.OpAdmin|schedule.OpLeader, step)
-	if ok := c.schedLimiter.AddOperator(op); !ok {
+	if ok := c.opController.AddOperator(op); !ok {
 		return errors.WithStack(errAddOperator)
 	}
 	return nil
@@ -387,7 +387,7 @@ func (h *Handler) AddTransferRegionOperator(regionID uint64, storeIDs map[uint64
 	}
 
 	op := schedule.NewOperator("adminMoveRegion", regionID, region.GetRegionEpoch(), schedule.OpAdmin|schedule.OpRegion, steps...)
-	if ok := c.schedLimiter.AddOperator(op); !ok {
+	if ok := c.opController.AddOperator(op); !ok {
 		return errors.WithStack(errAddOperator)
 	}
 	return nil
@@ -419,7 +419,7 @@ func (h *Handler) AddTransferPeerOperator(regionID uint64, fromStoreID, toStoreI
 	}
 
 	op := schedule.CreateMovePeerOperator("adminMovePeer", c.cluster, region, schedule.OpAdmin, fromStoreID, toStoreID, newPeer.GetId())
-	if ok := c.schedLimiter.AddOperator(op); !ok {
+	if ok := c.opController.AddOperator(op); !ok {
 		return errors.WithStack(errAddOperator)
 	}
 	return nil
@@ -461,7 +461,7 @@ func (h *Handler) AddAddPeerOperator(regionID uint64, toStoreID uint64) error {
 		}
 	}
 	op := schedule.NewOperator("adminAddPeer", regionID, region.GetRegionEpoch(), schedule.OpAdmin|schedule.OpRegion, steps...)
-	if ok := c.schedLimiter.AddOperator(op); !ok {
+	if ok := c.opController.AddOperator(op); !ok {
 		return errors.WithStack(errAddOperator)
 	}
 	return nil
@@ -484,7 +484,7 @@ func (h *Handler) AddRemovePeerOperator(regionID uint64, fromStoreID uint64) err
 	}
 
 	op := schedule.CreateRemovePeerOperator("adminRemovePeer", c.cluster, schedule.OpAdmin, region, fromStoreID)
-	if ok := c.schedLimiter.AddOperator(op); !ok {
+	if ok := c.opController.AddOperator(op); !ok {
 		return errors.WithStack(errAddOperator)
 	}
 	return nil
@@ -527,7 +527,7 @@ func (h *Handler) AddMergeRegionOperator(regionID uint64, targetID uint64) error
 	if err != nil {
 		return err
 	}
-	if ok := c.schedLimiter.AddOperator(ops...); !ok {
+	if ok := c.opController.AddOperator(ops...); !ok {
 		return errors.WithStack(ErrAddOperator)
 	}
 	return nil
@@ -551,7 +551,7 @@ func (h *Handler) AddSplitRegionOperator(regionID uint64, policy string) error {
 		Policy:   pdpb.CheckPolicy(pdpb.CheckPolicy_value[strings.ToUpper(policy)]),
 	}
 	op := schedule.NewOperator("adminSplitRegion", regionID, region.GetRegionEpoch(), schedule.OpAdmin, step)
-	if ok := c.schedLimiter.AddOperator(op); !ok {
+	if ok := c.opController.AddOperator(op); !ok {
 		return errors.WithStack(errAddOperator)
 	}
 	return nil
@@ -573,7 +573,7 @@ func (h *Handler) AddScatterRegionOperator(regionID uint64) error {
 	if op == nil {
 		return nil
 	}
-	if ok := c.schedLimiter.AddOperator(op); !ok {
+	if ok := c.opController.AddOperator(op); !ok {
 		return errors.WithStack(errAddOperator)
 	}
 	return nil

--- a/server/heartbeat_streams.go
+++ b/server/heartbeat_streams.go
@@ -123,7 +123,7 @@ func (s *heartbeatStreams) bindStream(storeID uint64, stream heartbeatStream) {
 	}
 }
 
-func (s *heartbeatStreams) sendMsg(region *core.RegionInfo, msg *pdpb.RegionHeartbeatResponse) {
+func (s *heartbeatStreams) SendMsg(region *core.RegionInfo, msg *pdpb.RegionHeartbeatResponse) {
 	if region.GetLeader() == nil {
 		return
 	}

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -33,23 +33,6 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 13),
 		}, []string{"result"})
 
-	operatorCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "pd",
-			Subsystem: "schedule",
-			Name:      "operators_count",
-			Help:      "Counter of schedule operators.",
-		}, []string{"type", "event"})
-
-	operatorDuration = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: "pd",
-			Subsystem: "schedule",
-			Name:      "finish_operators_duration_seconds",
-			Help:      "Bucketed histogram of processing time (s) of finished operator.",
-			Buckets:   prometheus.ExponentialBuckets(0.01, 2, 16),
-		}, []string{"type"})
-
 	clusterStatusGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "pd",
@@ -168,8 +151,6 @@ var (
 func init() {
 	prometheus.MustRegister(txnCounter)
 	prometheus.MustRegister(txnDuration)
-	prometheus.MustRegister(operatorCounter)
-	prometheus.MustRegister(operatorDuration)
 	prometheus.MustRegister(clusterStatusGauge)
 	prometheus.MustRegister(timeJumpBackCounter)
 	prometheus.MustRegister(schedulerStatusGauge)

--- a/server/schedule/merge_checker.go
+++ b/server/schedule/merge_checker.go
@@ -51,15 +51,15 @@ func (m *MergeChecker) RecordRegionSplit(regionID uint64) {
 }
 
 // Check verifies a region's replicas, creating an Operator if need.
-func (m *MergeChecker) Check(region *core.RegionInfo) (*Operator, *Operator) {
+func (m *MergeChecker) Check(region *core.RegionInfo) []*Operator {
 	if m.splitCache.Exists(mergeBlockMarker) {
 		checkerCounter.WithLabelValues("merge_checker", "recently_start").Inc()
-		return nil, nil
+		return nil
 	}
 
 	if m.splitCache.Exists(region.GetID()) {
 		checkerCounter.WithLabelValues("merge_checker", "recently_split").Inc()
-		return nil, nil
+		return nil
 	}
 
 	checkerCounter.WithLabelValues("merge_checker", "check").Inc()
@@ -70,31 +70,31 @@ func (m *MergeChecker) Check(region *core.RegionInfo) (*Operator, *Operator) {
 	// thus here when size is 0, just skip.
 	if region.GetApproximateSize() == 0 {
 		checkerCounter.WithLabelValues("merge_checker", "skip").Inc()
-		return nil, nil
+		return nil
 	}
 
 	// region is not small enough
 	if region.GetApproximateSize() > int64(m.cluster.GetMaxMergeRegionSize()) ||
 		region.GetApproximateKeys() > int64(m.cluster.GetMaxMergeRegionKeys()) {
 		checkerCounter.WithLabelValues("merge_checker", "no_need").Inc()
-		return nil, nil
+		return nil
 	}
 
 	// skip region has down peers or pending peers or learner peers
 	if len(region.GetDownPeers()) > 0 || len(region.GetPendingPeers()) > 0 || len(region.GetLearners()) > 0 {
 		checkerCounter.WithLabelValues("merge_checker", "special_peer").Inc()
-		return nil, nil
+		return nil
 	}
 
 	if len(region.GetPeers()) != m.cluster.GetMaxReplicas() {
 		checkerCounter.WithLabelValues("merge_checker", "abnormal_replica").Inc()
-		return nil, nil
+		return nil
 	}
 
 	// skip hot region
 	if m.cluster.IsRegionHot(region.GetID()) {
 		checkerCounter.WithLabelValues("merge_checker", "hot_region").Inc()
-		return nil, nil
+		return nil
 	}
 
 	var target *core.RegionInfo
@@ -105,16 +105,16 @@ func (m *MergeChecker) Check(region *core.RegionInfo) (*Operator, *Operator) {
 
 	if target == nil {
 		checkerCounter.WithLabelValues("merge_checker", "no_target").Inc()
-		return nil, nil
+		return nil
 	}
 
 	checkerCounter.WithLabelValues("merge_checker", "new_operator").Inc()
 	log.Debugf("try to merge region {%v} into region {%v}", region, target)
-	op1, op2, err := CreateMergeRegionOperator("merge-region", m.cluster, region, target, OpMerge)
+	ops, err := CreateMergeRegionOperator("merge-region", m.cluster, region, target, OpMerge)
 	if err != nil {
-		return nil, nil
+		return nil
 	}
-	return op1, op2
+	return ops
 }
 
 func (m *MergeChecker) checkTarget(region, adjacent, target *core.RegionInfo) *core.RegionInfo {

--- a/server/schedule/metrics.go
+++ b/server/schedule/metrics.go
@@ -48,6 +48,23 @@ var (
 			Name:      "filter",
 			Help:      "Counter of the filter",
 		}, []string{"action", "store", "type"})
+
+	operatorCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "pd",
+			Subsystem: "schedule",
+			Name:      "operators_count",
+			Help:      "Counter of schedule operators.",
+		}, []string{"type", "event"})
+
+	operatorDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "pd",
+			Subsystem: "schedule",
+			Name:      "finish_operators_duration_seconds",
+			Help:      "Bucketed histogram of processing time (s) of finished operator.",
+			Buckets:   prometheus.ExponentialBuckets(0.01, 2, 16),
+		}, []string{"type"})
 )
 
 func init() {
@@ -55,4 +72,6 @@ func init() {
 	prometheus.MustRegister(operatorStepDuration)
 	prometheus.MustRegister(hotCacheStatusGauge)
 	prometheus.MustRegister(filterCounter)
+	prometheus.MustRegister(operatorCounter)
+	prometheus.MustRegister(operatorDuration)
 }

--- a/server/schedule/sched_limiter.go
+++ b/server/schedule/sched_limiter.go
@@ -1,0 +1,333 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schedule
+
+import (
+	"container/list"
+	"sync"
+	"time"
+
+	"github.com/pingcap/kvproto/pkg/eraftpb"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/pd/server/core"
+	log "github.com/sirupsen/logrus"
+)
+
+var historyKeepTime = 5 * time.Minute
+
+// HeartbeatStreams is an interface of async region heartbeat.
+type HeartbeatStreams interface {
+	SendMsg(region *core.RegionInfo, msg *pdpb.RegionHeartbeatResponse)
+}
+
+// SchedLimiter is used to limit the speed of scheduling.
+type SchedLimiter struct {
+	sync.RWMutex
+	cluster   Cluster
+	operators map[uint64]*Operator
+	Limiter   *Limiter
+	hbStreams HeartbeatStreams
+	histories *list.List
+}
+
+// NewSchedLimiter creates a SchedLimiter.
+func NewSchedLimiter(cluster Cluster, hbStreams HeartbeatStreams) *SchedLimiter {
+	return &SchedLimiter{
+		cluster:   cluster,
+		operators: make(map[uint64]*Operator),
+		Limiter:   NewLimiter(),
+		hbStreams: hbStreams,
+		histories: list.New(),
+	}
+}
+
+// Dispatch is used to dispatch the operator of a region.
+func (s *SchedLimiter) Dispatch(region *core.RegionInfo) {
+	// Check existed operator.
+	if op := s.GetOperator(region.GetID()); op != nil {
+		timeout := op.IsTimeout()
+		if step := op.Check(region); step != nil && !timeout {
+			operatorCounter.WithLabelValues(op.Desc(), "check").Inc()
+			s.SendScheduleCommand(region, step)
+			return
+		}
+		if op.IsFinish() {
+			log.Infof("[region %v] operator finish: %s", region.GetID(), op)
+			operatorCounter.WithLabelValues(op.Desc(), "finish").Inc()
+			operatorDuration.WithLabelValues(op.Desc()).Observe(op.ElapsedTime().Seconds())
+			s.pushHistory(op)
+			s.RemoveOperator(op)
+		} else if timeout {
+			log.Infof("[region %v] operator timeout: %s", region.GetID(), op)
+			s.RemoveOperator(op)
+		}
+	}
+}
+
+// AddOperator adds operators to the running operators.
+func (s *SchedLimiter) AddOperator(ops ...*Operator) bool {
+	s.Lock()
+	defer s.Unlock()
+
+	for _, op := range ops {
+		if !s.checkAddOperator(op) {
+			operatorCounter.WithLabelValues(op.Desc(), "canceled").Inc()
+			return false
+		}
+	}
+	for _, op := range ops {
+		s.addOperatorLocked(op)
+	}
+
+	return true
+}
+
+func (s *SchedLimiter) checkAddOperator(op *Operator) bool {
+	region := s.cluster.GetRegion(op.RegionID())
+	if region == nil {
+		log.Debugf("[region %v] region not found, cancel add operator", op.RegionID())
+		return false
+	}
+	if region.GetRegionEpoch().GetVersion() != op.RegionEpoch().GetVersion() || region.GetRegionEpoch().GetConfVer() != op.RegionEpoch().GetConfVer() {
+		log.Debugf("[region %v] region epoch not match, %v vs %v, cancel add operator", op.RegionID(), region.GetRegionEpoch(), op.RegionEpoch())
+		return false
+	}
+	if old := s.operators[op.RegionID()]; old != nil && !isHigherPriorityOperator(op, old) {
+		log.Debugf("[region %v] already have operator %s, cancel add operator", op.RegionID(), old)
+		return false
+	}
+	return true
+}
+
+func isHigherPriorityOperator(new, old *Operator) bool {
+	return new.GetPriorityLevel() < old.GetPriorityLevel()
+}
+
+func (s *SchedLimiter) addOperatorLocked(op *Operator) bool {
+	regionID := op.RegionID()
+
+	log.Infof("[region %v] add operator: %s", regionID, op)
+
+	// If there is an old operator, replace it. The priority should be checked
+	// already.
+	if old, ok := s.operators[regionID]; ok {
+		log.Infof("[region %v] replace old operator: %s", regionID, old)
+		operatorCounter.WithLabelValues(old.Desc(), "replaced").Inc()
+		s.removeOperatorLocked(old)
+	}
+
+	s.operators[regionID] = op
+	s.Limiter.UpdateCounts(s.operators)
+
+	if region := s.cluster.GetRegion(op.RegionID()); region != nil {
+		if step := op.Check(region); step != nil {
+			s.SendScheduleCommand(region, step)
+		}
+	}
+
+	operatorCounter.WithLabelValues(op.Desc(), "create").Inc()
+	return true
+}
+
+// RemoveOperator removes a operator from the running operators.
+func (s *SchedLimiter) RemoveOperator(op *Operator) {
+	s.Lock()
+	defer s.Unlock()
+	s.removeOperatorLocked(op)
+}
+
+func (s *SchedLimiter) removeOperatorLocked(op *Operator) {
+	regionID := op.RegionID()
+	delete(s.operators, regionID)
+	s.Limiter.UpdateCounts(s.operators)
+	operatorCounter.WithLabelValues(op.Desc(), "remove").Inc()
+}
+
+// GetOperator gets a operator from the given region.
+func (s *SchedLimiter) GetOperator(regionID uint64) *Operator {
+	s.RLock()
+	defer s.RUnlock()
+	return s.operators[regionID]
+}
+
+// GetOperators gets operators from the running operators.
+func (s *SchedLimiter) GetOperators() []*Operator {
+	s.RLock()
+	defer s.RUnlock()
+
+	operators := make([]*Operator, 0, len(s.operators))
+	for _, op := range s.operators {
+		operators = append(operators, op)
+	}
+
+	return operators
+}
+
+// SendScheduleCommand sends a command to the region.
+func (s *SchedLimiter) SendScheduleCommand(region *core.RegionInfo, step OperatorStep) {
+	log.Infof("[region %v] send schedule command: %s", region.GetID(), step)
+	switch st := step.(type) {
+	case TransferLeader:
+		cmd := &pdpb.RegionHeartbeatResponse{
+			TransferLeader: &pdpb.TransferLeader{
+				Peer: region.GetStorePeer(st.ToStore),
+			},
+		}
+		s.hbStreams.SendMsg(region, cmd)
+	case AddPeer:
+		if region.GetStorePeer(st.ToStore) != nil {
+			// The newly added peer is pending.
+			return
+		}
+		cmd := &pdpb.RegionHeartbeatResponse{
+			ChangePeer: &pdpb.ChangePeer{
+				ChangeType: eraftpb.ConfChangeType_AddNode,
+				Peer: &metapb.Peer{
+					Id:      st.PeerID,
+					StoreId: st.ToStore,
+				},
+			},
+		}
+		s.hbStreams.SendMsg(region, cmd)
+	case AddLearner:
+		if region.GetStorePeer(st.ToStore) != nil {
+			// The newly added peer is pending.
+			return
+		}
+		cmd := &pdpb.RegionHeartbeatResponse{
+			ChangePeer: &pdpb.ChangePeer{
+				ChangeType: eraftpb.ConfChangeType_AddLearnerNode,
+				Peer: &metapb.Peer{
+					Id:        st.PeerID,
+					StoreId:   st.ToStore,
+					IsLearner: true,
+				},
+			},
+		}
+		s.hbStreams.SendMsg(region, cmd)
+	case PromoteLearner:
+		cmd := &pdpb.RegionHeartbeatResponse{
+			ChangePeer: &pdpb.ChangePeer{
+				// reuse AddNode type
+				ChangeType: eraftpb.ConfChangeType_AddNode,
+				Peer: &metapb.Peer{
+					Id:      st.PeerID,
+					StoreId: st.ToStore,
+				},
+			},
+		}
+		s.hbStreams.SendMsg(region, cmd)
+	case RemovePeer:
+		cmd := &pdpb.RegionHeartbeatResponse{
+			ChangePeer: &pdpb.ChangePeer{
+				ChangeType: eraftpb.ConfChangeType_RemoveNode,
+				Peer:       region.GetStorePeer(st.FromStore),
+			},
+		}
+		s.hbStreams.SendMsg(region, cmd)
+	case MergeRegion:
+		if st.IsPassive {
+			return
+		}
+		cmd := &pdpb.RegionHeartbeatResponse{
+			Merge: &pdpb.Merge{
+				Target: st.ToRegion,
+			},
+		}
+		s.hbStreams.SendMsg(region, cmd)
+	case SplitRegion:
+		cmd := &pdpb.RegionHeartbeatResponse{
+			SplitRegion: &pdpb.SplitRegion{
+				Policy: st.Policy,
+			},
+		}
+		s.hbStreams.SendMsg(region, cmd)
+	default:
+		log.Errorf("unknown operatorStep: %v", step)
+	}
+}
+
+func (s *SchedLimiter) pushHistory(op *Operator) {
+	s.Lock()
+	defer s.Unlock()
+	for _, h := range op.History() {
+		s.histories.PushFront(h)
+	}
+}
+
+// PruneHistory prunes a part of operators' history.
+func (s *SchedLimiter) PruneHistory() {
+	s.Lock()
+	defer s.Unlock()
+	p := s.histories.Back()
+	for p != nil && time.Since(p.Value.(OperatorHistory).FinishTime) > historyKeepTime {
+		prev := p.Prev()
+		s.histories.Remove(p)
+		p = prev
+	}
+}
+
+// GetHistory gets operators' history.
+func (s *SchedLimiter) GetHistory(start time.Time) []OperatorHistory {
+	s.RLock()
+	defer s.RUnlock()
+	histories := make([]OperatorHistory, 0, s.histories.Len())
+	for p := s.histories.Front(); p != nil; p = p.Next() {
+		history := p.Value.(OperatorHistory)
+		if history.FinishTime.Before(start) {
+			break
+		}
+		histories = append(histories, history)
+	}
+	return histories
+}
+
+// Limiter is a counter that limits the number of operators.
+type Limiter struct {
+	sync.RWMutex
+	counts map[OperatorKind]uint64
+}
+
+// NewLimiter creates a schedule limiter.
+func NewLimiter() *Limiter {
+	return &Limiter{
+		counts: make(map[OperatorKind]uint64),
+	}
+}
+
+// UpdateCounts updates resource counts using current pending operators.
+func (l *Limiter) UpdateCounts(operators map[uint64]*Operator) {
+	l.Lock()
+	defer l.Unlock()
+	for k := range l.counts {
+		delete(l.counts, k)
+	}
+	for _, op := range operators {
+		l.counts[op.Kind()]++
+	}
+}
+
+// OperatorCount gets the count of operators filtered by mask.
+func (l *Limiter) OperatorCount(mask OperatorKind) uint64 {
+	l.RLock()
+	defer l.RUnlock()
+	var total uint64
+	for k, count := range l.counts {
+		if k&mask != 0 {
+			total += count
+		}
+	}
+	return total
+}

--- a/server/schedulers/random_merge.go
+++ b/server/schedulers/random_merge.go
@@ -78,9 +78,9 @@ func (s *randomMergeScheduler) Schedule(cluster schedule.Cluster, opInfluence sc
 	}
 
 	schedulerCounter.WithLabelValues(s.GetName(), "new_operator").Inc()
-	op1, op2, err := schedule.CreateMergeRegionOperator("random-merge", cluster, region, target, schedule.OpAdmin)
+	ops, err := schedule.CreateMergeRegionOperator("random-merge", cluster, region, target, schedule.OpAdmin)
 	if err != nil {
 		return nil
 	}
-	return []*schedule.Operator{op1, op2}
+	return ops
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Currently, the logic of schedule limit is mainly in `coordinator.go` which is not clear enough.

### What is changed and how it works?
This PR moves the schedule limit related logic from `coordinator.go` and `scheduler.go` to `sched_limiter.go` and does some tiny cleanup.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (`make test`)
