### PR TITLE
*: fix cluster test

### DIFF
--- a/server/heartbeat_stream_test.go
+++ b/server/heartbeat_stream_test.go
@@ -27,7 +27,7 @@ import (
 var _ = Suite(&testHeartbeatStreamSuite{})
 
 type testHeartbeatStreamSuite struct {
-	testClusterBaseSuite
+	baseCluster
 	region *metapb.Region
 }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
CI fails occasionally because the tests in `cluster_test.go` uses a shared server, which might make `getRegion` failed. 

### What is changed and how it works?
This PR starts a new server to run each test and does some clean up since `testClusterBaseSuite` looks like a gocheck suite but actually it is not. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (`make test`)

Side effects

 - Need a little bit more time to run this test suite