### PR TITLE
*: fix a tiny bug in checkStore

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -495,6 +495,7 @@ func (c *RaftCluster) checkStores() {
 		if store.GetState() != metapb.StoreState_Offline {
 			if store.GetState() == metapb.StoreState_Up && !store.IsLowSpace(cluster.GetLowSpaceRatio()) {
 				upStoreCount++
+				continue
 			}
 		}
 		offlineStore := store.Store


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Currently, the store in both up and offline state will be considered as `offlineStore`, which will call `BuryStore`, but this bug doesn't affect correctness.

### What is changed and how it works?
If the store is up, the `upStoreCount` should add one and continue the next loop.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (`make test`)

Related changes

 - Need to be included in the release notes
