### PR TITLE
use a separate builder image and deploy in Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
-FROM golang:1.9.2
-
+FROM golang:1.11.1-alpine as builder
 MAINTAINER siddontang
 
-COPY . /go/src/github.com/pingcap/pd
+RUN apk add --no-cache \
+    make \
+    git
 
-RUN cd /go/src/github.com/pingcap/pd/ && \
-    make && \
-    cp -f ./bin/pd-server /go/bin/pd-server && \
-    rm -rf ../pd
+COPY . /go/src/github.com/pingcap/pd
+WORKDIR /go/src/github.com/pingcap/pd
+
+RUN make
+
+FROM alpine:3.5
+
+COPY --from=builder /go/src/github.com/pingcap/pd/bin/pd-server /pd-server
 
 EXPOSE 2379 2380
 
-ENTRYPOINT ["pd-server"]
-
+ENTRYPOINT ["/pd-server"]


### PR DESCRIPTION
### What problem does this PR solve?

* Small, consistent executable image.
* Use the latest golang version which supports go modules.

### What is changed and how it works?

Use separate build and deploy images.


### Check List 

 - Manually tested only by verifying that pd starts up.
 - Need to be included in the release notes
