### PR TITLE
pd-ctl: support adding more schedulers

### DIFF
--- a/server/api/scheduler.go
+++ b/server/api/scheduler.go
@@ -103,9 +103,8 @@ func (h *schedulerHandler) Post(w http.ResponseWriter, r *http.Request) {
 		peerLimit, ok := input["peer_limit"].(string)
 		if ok {
 			args = append(args, peerLimit)
-		} else {
-			args = args[:0]
 		}
+
 		if err := h.AddAdjacentRegionScheduler(args...); err != nil {
 			h.r.JSON(w, http.StatusInternalServerError, err.Error())
 			return

--- a/server/schedulers/adjacent_region.go
+++ b/server/schedulers/adjacent_region.go
@@ -34,7 +34,8 @@ const (
 
 func init() {
 	schedule.RegisterScheduler("adjacent-region", func(limiter *schedule.Limiter, args []string) (schedule.Scheduler, error) {
-		if len(args) == 2 {
+		l := len(args)
+		if l == 2 {
 			leaderLimit, err := strconv.ParseUint(args[0], 10, 64)
 			if err != nil {
 				return nil, errors.WithStack(err)
@@ -44,6 +45,12 @@ func init() {
 				return nil, errors.WithStack(err)
 			}
 			return newBalanceAdjacentRegionScheduler(limiter, leaderLimit, peerLimit), nil
+		} else if l == 1 {
+			leaderLimit, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				return nil, errors.WithStack(err)
+			}
+			return newBalanceAdjacentRegionScheduler(limiter, leaderLimit), nil
 		}
 		return newBalanceAdjacentRegionScheduler(limiter), nil
 	})
@@ -92,7 +99,10 @@ func newBalanceAdjacentRegionScheduler(limiter *schedule.Limiter, args ...uint64
 		peerLimit:     defaultAdjacentPeerLimit,
 		lastKey:       []byte(""),
 	}
-	if len(args) == 2 {
+	l := len(args)
+	if l == 1 {
+		s.leaderLimit = args[0]
+	} else if l == 2 {
 		s.leaderLimit = args[0]
 		s.peerLimit = args[1]
 	}

--- a/server/schedulers/random_merge.go
+++ b/server/schedulers/random_merge.go
@@ -31,8 +31,7 @@ type randomMergeScheduler struct {
 	selector *schedule.RandomSelector
 }
 
-// newRandomMergeScheduler creates an admin scheduler that shuffles regions
-// between stores.
+// newRandomMergeScheduler creates an admin scheduler that merges regions randomly.
 func newRandomMergeScheduler(limiter *schedule.Limiter) schedule.Scheduler {
 	filters := []schedule.Filter{schedule.StoreStateFilter{MoveRegion: true}}
 	base := newBaseScheduler(limiter)

--- a/tools/pd-ctl/pdctl/command/scheduler.go
+++ b/tools/pd-ctl/pdctl/command/scheduler.go
@@ -73,6 +73,12 @@ func NewAddSchedulerCommand() *cobra.Command {
 	c.AddCommand(NewShuffleLeaderSchedulerCommand())
 	c.AddCommand(NewShuffleRegionSchedulerCommand())
 	c.AddCommand(NewScatterRangeSchedulerCommand())
+	c.AddCommand(NewBalanceLeaderSchedulerCommand())
+	c.AddCommand(NewBalanceRegionSchedulerCommand())
+	c.AddCommand(NewBalanceHotRegionSchedulerCommand())
+	c.AddCommand(NewRandomMergeSchedulerCommand())
+	c.AddCommand(NewBalanceAdjacentRegionSchedulerCommand())
+	c.AddCommand(NewLabelSchedulerCommand())
 	return c
 }
 
@@ -134,6 +140,56 @@ func NewShuffleRegionSchedulerCommand() *cobra.Command {
 	return c
 }
 
+// NewBalanceLeaderSchedulerCommand returns a command to add a balance-leader-scheduler.
+func NewBalanceLeaderSchedulerCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "balance-leader-scheduler",
+		Short: "add a scheduler to balance leaders between stores",
+		Run:   addSchedulerCommandFunc,
+	}
+	return c
+}
+
+// NewBalanceRegionSchedulerCommand returns a command to add a balance-region-scheduler.
+func NewBalanceRegionSchedulerCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "balance-region-scheduler",
+		Short: "add a scheduler to balance regions between stores",
+		Run:   addSchedulerCommandFunc,
+	}
+	return c
+}
+
+// NewBalanceHotRegionSchedulerCommand returns a command to add a balance-hot-region-scheduler.
+func NewBalanceHotRegionSchedulerCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "balance-hot-region-scheduler",
+		Short: "add a scheduler to balance hot regions between stores",
+		Run:   addSchedulerCommandFunc,
+	}
+	return c
+}
+
+// NewRandomMergeSchedulerCommand returns a command to add a random-merge-scheduler.
+func NewRandomMergeSchedulerCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "random-merge-scheduler",
+		Short: "add a scheduler to merge regions randomly",
+		Run:   addSchedulerCommandFunc,
+	}
+	return c
+}
+
+// NewLabelSchedulerCommand returns a command to add a label-scheduler.
+func NewLabelSchedulerCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "label-scheduler",
+		Short: "add a scheduler to schedule regions according to the label",
+		Run:   addSchedulerCommandFunc,
+	}
+	return c
+}
+
 func addSchedulerCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 0 {
 		fmt.Println(cmd.UsageString())
@@ -166,6 +222,33 @@ func addSchedulerForScatterRangeCommandFunc(cmd *cobra.Command, args []string) {
 	input["start_key"] = url.QueryEscape(args[0])
 	input["end_key"] = url.QueryEscape(args[1])
 	input["range_name"] = args[2]
+	postJSON(cmd, schedulersPrefix, input)
+}
+
+// NewBalanceAdjacentRegionSchedulerCommand returns a command to add a balance-adjacent-region-scheduler.
+func NewBalanceAdjacentRegionSchedulerCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "balance-adjacent-region-scheduler [leader_limit] [peer_limit]",
+		Short: "add a scheduler to disperse adjacent regions on each store",
+		Run:   addSchedulerForBalanceAdjacentRegionCommandFunc,
+	}
+	return c
+}
+
+func addSchedulerForBalanceAdjacentRegionCommandFunc(cmd *cobra.Command, args []string) {
+	l := len(args)
+	input := make(map[string]interface{})
+	if l > 2 {
+		fmt.Println(cmd.UsageString())
+		return
+	} else if l == 1 {
+		input["leader_limit"] = url.QueryEscape(args[0])
+	} else if l == 2 {
+		input["leader_limit"] = url.QueryEscape(args[0])
+		input["peer_limit"] = url.QueryEscape(args[1])
+	}
+	input["name"] = cmd.Name()
+
 	postJSON(cmd, schedulersPrefix, input)
 }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Currently, we only support adding some of schedulers by using `pd-ctl`. And some schedulers, such as `balance-leader-scheduler` and `balance-region-scheduler`, can not be added once they has been removed. The only way we can add them back is by using `curl`.
Closes #1286.

### What is changed and how it works?
This PR is going to support adding all schedulers of PD by using `pd-ctl`.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test
 

Related changes

 - Need to update the documentation
 - Need to be included in the release notes