### PR TITLE
pdctl: escape the key before query the corresponding region

### DIFF
--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -16,6 +16,7 @@ package api
 import (
 	"fmt"
 	"math/rand"
+	"net/url"
 	"sort"
 
 	. "github.com/pingcap/check"
@@ -106,25 +107,6 @@ func (s *testRegionSuite) TestRegions(c *C) {
 		c.Assert(r.ID, Equals, regions[i].ID)
 		c.Assert(r.ApproximateSize, Equals, regions[i].ApproximateSize)
 		c.Assert(r.ApproximateKeys, Equals, regions[i].ApproximateKeys)
-	}
-}
-
-func (s *testRegionSuite) TestScanRegionByKey(c *C) {
-	r1 := newTestRegionInfo(2, 1, []byte("a"), []byte("b"))
-	r2 := newTestRegionInfo(3, 1, []byte("b"), []byte("c"))
-	r3 := newTestRegionInfo(4, 2, []byte("c"), []byte("d"))
-	mustRegionHeartbeat(c, s.svr, r1)
-	mustRegionHeartbeat(c, s.svr, r2)
-	mustRegionHeartbeat(c, s.svr, r3)
-
-	url := fmt.Sprintf("%s/regions/key/%s", s.urlPrefix, "b")
-	regionIds := []uint64{3, 4}
-	regions := &regionsInfo{}
-	err := readJSONWithURL(url, regions)
-	c.Assert(err, IsNil)
-	c.Assert(len(regionIds), Equals, regions.Count)
-	for i, v := range regionIds {
-		c.Assert(v, Equals, regions.Regions[i].ID)
 	}
 }
 
@@ -223,5 +205,58 @@ func (s *testRegionSuite) TestTopN(c *C) {
 		for i := range topN {
 			c.Assert(topN[i].GetBytesWritten(), Equals, writtenBytes[i])
 		}
+	}
+}
+
+var _ = Suite(&testGetRegionSuite{})
+
+type testGetRegionSuite struct {
+	svr       *server.Server
+	cleanup   cleanUpFunc
+	urlPrefix string
+}
+
+func (s *testGetRegionSuite) SetUpSuite(c *C) {
+	s.svr, s.cleanup = mustNewServer(c)
+	mustWaitLeader(c, []*server.Server{s.svr})
+
+	addr := s.svr.GetAddr()
+	s.urlPrefix = fmt.Sprintf("%s%s/api/v1", addr, apiPrefix)
+
+	mustBootstrapCluster(c, s.svr)
+}
+
+func (s *testGetRegionSuite) TearDownSuite(c *C) {
+	s.cleanup()
+}
+
+func (s *testGetRegionSuite) TestRegionKey(c *C) {
+	r := newTestRegionInfo(99, 1, []byte{0xFF, 0xFF, 0xAA}, []byte{0xFF, 0xFF, 0xCC}, core.SetWrittenBytes(500), core.SetReadBytes(800), core.SetRegionConfVer(3), core.SetRegionVersion(2))
+	mustRegionHeartbeat(c, s.svr, r)
+	url := fmt.Sprintf("%s/region/key/%s", s.urlPrefix, url.QueryEscape(string([]byte{0xFF, 0xFF, 0xBB})))
+	regionInfo := &regionInfo{}
+	err := readJSONWithURL(url, regionInfo)
+	c.Assert(err, IsNil)
+	c.Assert(r.GetID(), Equals, regionInfo.ID)
+}
+
+func (s *testGetRegionSuite) TestScanRegionByKey(c *C) {
+	r1 := newTestRegionInfo(2, 1, []byte("a"), []byte("b"))
+	r2 := newTestRegionInfo(3, 1, []byte("b"), []byte("c"))
+	r3 := newTestRegionInfo(4, 2, []byte("c"), []byte("d"))
+	r := newTestRegionInfo(99, 1, []byte{0xFF, 0xFF, 0xAA}, []byte{0xFF, 0xFF, 0xCC}, core.SetWrittenBytes(500), core.SetReadBytes(800), core.SetRegionConfVer(3), core.SetRegionVersion(2))
+	mustRegionHeartbeat(c, s.svr, r1)
+	mustRegionHeartbeat(c, s.svr, r2)
+	mustRegionHeartbeat(c, s.svr, r3)
+	mustRegionHeartbeat(c, s.svr, r)
+
+	url := fmt.Sprintf("%s/regions/key/%s", s.urlPrefix, "b")
+	regionIds := []uint64{3, 4, 99}
+	regions := &regionsInfo{}
+	err := readJSONWithURL(url, regions)
+	c.Assert(err, IsNil)
+	c.Assert(len(regionIds), Equals, regions.Count)
+	for i, v := range regionIds {
+		c.Assert(v, Equals, regions.Regions[i].ID)
 	}
 }

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os/exec"
 	"strconv"
 
@@ -233,7 +234,8 @@ func showRegionWithTableCommandFunc(cmd *cobra.Command, args []string) {
 		fmt.Println("Error: unknown format")
 		return
 	}
-	// TODO: Deal with path escaped
+
+	key = url.QueryEscape(key)
 	prefix := regionKeyPrefix + "/" + key
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
@@ -303,7 +305,7 @@ func showRegionsFromStartKeyCommandFunc(cmd *cobra.Command, args []string) {
 		fmt.Println("Error: unknown format")
 		return
 	}
-	// TODO: Deal with path escaped
+	key = url.QueryEscape(key)
 	prefix := regionKeyPrefix + "/" + key
 	if len(args) == 2 {
 		if _, err = strconv.Atoi(args[1]); err != nil {


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
We should escape the key otherwise will not get the corresponding region.

### What is changed and how it works?
escape the key in query URL.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test