### PR TITLE
simulator: rename EventInner to EventDescriptor

### DIFF
--- a/tools/pd-simulator/simulator/cases/add_nodes.go
+++ b/tools/pd-simulator/simulator/cases/add_nodes.go
@@ -46,7 +46,6 @@ func newAddNodes() *Case {
 			Keys:   960000,
 		})
 	}
-	simCase.MaxID = id.maxID
 
 	simCase.Checker = func(regions *core.RegionsInfo) bool {
 		res := true

--- a/tools/pd-simulator/simulator/cases/add_nodes.go
+++ b/tools/pd-simulator/simulator/cases/add_nodes.go
@@ -20,11 +20,10 @@ import (
 
 func newAddNodes() *Case {
 	var simCase Case
-	var id idAllocator
 
 	for i := 1; i <= 8; i++ {
 		simCase.Stores = append(simCase.Stores, &Store{
-			ID:        id.nextID(),
+			ID:        IDAllocator.nextID(),
 			Status:    metapb.StoreState_Up,
 			Capacity:  1 * TB,
 			Available: 900 * GB,
@@ -34,12 +33,12 @@ func newAddNodes() *Case {
 
 	for i := 0; i < 1000; i++ {
 		peers := []*metapb.Peer{
-			{Id: id.nextID(), StoreId: uint64(i)%4 + 1},
-			{Id: id.nextID(), StoreId: uint64(i+1)%4 + 1},
-			{Id: id.nextID(), StoreId: uint64(i+2)%4 + 1},
+			{Id: IDAllocator.nextID(), StoreId: uint64(i)%4 + 1},
+			{Id: IDAllocator.nextID(), StoreId: uint64(i+1)%4 + 1},
+			{Id: IDAllocator.nextID(), StoreId: uint64(i+2)%4 + 1},
 		}
 		simCase.Regions = append(simCase.Regions, Region{
-			ID:     id.nextID(),
+			ID:     IDAllocator.nextID(),
 			Peers:  peers,
 			Leader: peers[0],
 			Size:   96 * MB,

--- a/tools/pd-simulator/simulator/cases/add_nodes_dynamic.go
+++ b/tools/pd-simulator/simulator/cases/add_nodes_dynamic.go
@@ -51,7 +51,6 @@ func newAddNodesDynamic() *Case {
 			Keys:   960000,
 		})
 	}
-	simCase.MaxID = id.maxID
 
 	numNodes := 8
 	e := &AddNodesInner{}

--- a/tools/pd-simulator/simulator/cases/add_nodes_dynamic.go
+++ b/tools/pd-simulator/simulator/cases/add_nodes_dynamic.go
@@ -20,11 +20,10 @@ import (
 
 func newAddNodesDynamic() *Case {
 	var simCase Case
-	var id idAllocator
 
 	for i := 1; i <= 8; i++ {
 		simCase.Stores = append(simCase.Stores, &Store{
-			ID:        id.nextID(),
+			ID:        IDAllocator.nextID(),
 			Status:    metapb.StoreState_Up,
 			Capacity:  1 * TB,
 			Available: 900 * GB,
@@ -34,17 +33,17 @@ func newAddNodesDynamic() *Case {
 
 	var ids []uint64
 	for i := 1; i <= 8; i++ {
-		ids = append(ids, id.nextID())
+		ids = append(ids, IDAllocator.nextID())
 	}
 
 	for i := 0; i < 2000; i++ {
 		peers := []*metapb.Peer{
-			{Id: id.nextID(), StoreId: uint64(i)%8 + 1},
-			{Id: id.nextID(), StoreId: uint64(i+1)%8 + 1},
-			{Id: id.nextID(), StoreId: uint64(i+2)%8 + 1},
+			{Id: IDAllocator.nextID(), StoreId: uint64(i)%8 + 1},
+			{Id: IDAllocator.nextID(), StoreId: uint64(i+1)%8 + 1},
+			{Id: IDAllocator.nextID(), StoreId: uint64(i+2)%8 + 1},
 		}
 		simCase.Regions = append(simCase.Regions, Region{
-			ID:     id.nextID(),
+			ID:     IDAllocator.nextID(),
 			Peers:  peers,
 			Leader: peers[0],
 			Size:   96 * MB,

--- a/tools/pd-simulator/simulator/cases/add_nodes_dynamic.go
+++ b/tools/pd-simulator/simulator/cases/add_nodes_dynamic.go
@@ -53,7 +53,7 @@ func newAddNodesDynamic() *Case {
 	}
 
 	numNodes := 8
-	e := &AddNodesInner{}
+	e := &AddNodesDescriptor{}
 	e.Step = func(tick int64) uint64 {
 		if tick%100 == 0 && numNodes < 16 {
 			numNodes++
@@ -63,7 +63,7 @@ func newAddNodesDynamic() *Case {
 		}
 		return 0
 	}
-	simCase.Events = []EventInner{e}
+	simCase.Events = []EventDescriptor{e}
 
 	simCase.Checker = func(regions *core.RegionsInfo) bool {
 		res := true

--- a/tools/pd-simulator/simulator/cases/balance_leader.go
+++ b/tools/pd-simulator/simulator/cases/balance_leader.go
@@ -21,11 +21,10 @@ import (
 
 func newBalanceLeader() *Case {
 	var simCase Case
-	var id idAllocator
 
 	for i := 1; i <= 3; i++ {
 		simCase.Stores = append(simCase.Stores, &Store{
-			ID:        id.nextID(),
+			ID:        IDAllocator.nextID(),
 			Status:    metapb.StoreState_Up,
 			Capacity:  1 * TB,
 			Available: 900 * GB,
@@ -35,12 +34,12 @@ func newBalanceLeader() *Case {
 
 	for i := 0; i < 1000; i++ {
 		peers := []*metapb.Peer{
-			{Id: id.nextID(), StoreId: 1},
-			{Id: id.nextID(), StoreId: 2},
-			{Id: id.nextID(), StoreId: 3},
+			{Id: IDAllocator.nextID(), StoreId: 1},
+			{Id: IDAllocator.nextID(), StoreId: 2},
+			{Id: IDAllocator.nextID(), StoreId: 3},
 		}
 		simCase.Regions = append(simCase.Regions, Region{
-			ID:     id.nextID(),
+			ID:     IDAllocator.nextID(),
 			Peers:  peers,
 			Leader: peers[0],
 			Size:   96 * MB,

--- a/tools/pd-simulator/simulator/cases/balance_leader.go
+++ b/tools/pd-simulator/simulator/cases/balance_leader.go
@@ -47,7 +47,7 @@ func newBalanceLeader() *Case {
 			Keys:   960000,
 		})
 	}
-	simCase.MaxID = id.maxID
+
 	simCase.Checker = func(regions *core.RegionsInfo) bool {
 		count1 := regions.GetStoreLeaderCount(1)
 		count2 := regions.GetStoreLeaderCount(2)

--- a/tools/pd-simulator/simulator/cases/cases.go
+++ b/tools/pd-simulator/simulator/cases/cases.go
@@ -62,14 +62,29 @@ const (
 	TB
 )
 
+// IDAllocator is used to alloc unique ID.
 type idAllocator struct {
-	maxID uint64
+	id uint64
 }
 
+// nextID gets the next unique ID.
 func (a *idAllocator) nextID() uint64 {
-	a.maxID++
-	return a.maxID
+	a.id++
+	return a.id
 }
+
+// ResetID resets the IDAllocator.
+func (a *idAllocator) ResetID() {
+	a.id = 0
+}
+
+// GetID gets the current ID.
+func (a *idAllocator) GetID() uint64 {
+	return a.id
+}
+
+// IDAllocator is used to alloc unique ID.
+var IDAllocator idAllocator
 
 // CaseMap is a mapping of the cases to the their corresponding initialize functions.
 var CaseMap = map[string]func() *Case{

--- a/tools/pd-simulator/simulator/cases/cases.go
+++ b/tools/pd-simulator/simulator/cases/cases.go
@@ -48,7 +48,7 @@ type Case struct {
 	Regions         []Region
 	RegionSplitSize int64
 	RegionSplitKeys int64
-	Events          []EventInner
+	Events          []EventDescriptor
 
 	Checker CheckerFunc // To check the schedule is finished.
 }

--- a/tools/pd-simulator/simulator/cases/cases.go
+++ b/tools/pd-simulator/simulator/cases/cases.go
@@ -46,7 +46,6 @@ type CheckerFunc func(*core.RegionsInfo) bool
 type Case struct {
 	Stores          []*Store
 	Regions         []Region
-	MaxID           uint64
 	RegionSplitSize int64
 	RegionSplitKeys int64
 	Events          []EventInner

--- a/tools/pd-simulator/simulator/cases/delete_nodes.go
+++ b/tools/pd-simulator/simulator/cases/delete_nodes.go
@@ -22,11 +22,10 @@ import (
 
 func newDeleteNodes() *Case {
 	var simCase Case
-	var id idAllocator
 
 	for i := 1; i <= 8; i++ {
 		simCase.Stores = append(simCase.Stores, &Store{
-			ID:        id.nextID(),
+			ID:        IDAllocator.nextID(),
 			Status:    metapb.StoreState_Up,
 			Capacity:  1 * TB,
 			Available: 900 * GB,
@@ -36,12 +35,12 @@ func newDeleteNodes() *Case {
 
 	for i := 0; i < 1000; i++ {
 		peers := []*metapb.Peer{
-			{Id: id.nextID(), StoreId: uint64(i)%8 + 1},
-			{Id: id.nextID(), StoreId: uint64(i+1)%8 + 1},
-			{Id: id.nextID(), StoreId: uint64(i+2)%8 + 1},
+			{Id: IDAllocator.nextID(), StoreId: uint64(i)%8 + 1},
+			{Id: IDAllocator.nextID(), StoreId: uint64(i+1)%8 + 1},
+			{Id: IDAllocator.nextID(), StoreId: uint64(i+2)%8 + 1},
 		}
 		simCase.Regions = append(simCase.Regions, Region{
-			ID:     id.nextID(),
+			ID:     IDAllocator.nextID(),
 			Peers:  peers,
 			Leader: peers[0],
 			Size:   96 * MB,

--- a/tools/pd-simulator/simulator/cases/delete_nodes.go
+++ b/tools/pd-simulator/simulator/cases/delete_nodes.go
@@ -55,7 +55,7 @@ func newDeleteNodes() *Case {
 	}
 
 	numNodes := 8
-	e := &DeleteNodesInner{}
+	e := &DeleteNodesDescriptor{}
 	e.Step = func(tick int64) uint64 {
 		if numNodes > 7 && tick%100 == 0 {
 			idx := rand.Intn(numNodes)
@@ -66,7 +66,7 @@ func newDeleteNodes() *Case {
 		}
 		return 0
 	}
-	simCase.Events = []EventInner{e}
+	simCase.Events = []EventDescriptor{e}
 
 	simCase.Checker = func(regions *core.RegionsInfo) bool {
 		res := true

--- a/tools/pd-simulator/simulator/cases/delete_nodes.go
+++ b/tools/pd-simulator/simulator/cases/delete_nodes.go
@@ -48,7 +48,6 @@ func newDeleteNodes() *Case {
 			Keys:   960000,
 		})
 	}
-	simCase.MaxID = id.maxID
 
 	var ids []uint64
 	for _, store := range simCase.Stores {

--- a/tools/pd-simulator/simulator/cases/event_inner.go
+++ b/tools/pd-simulator/simulator/cases/event_inner.go
@@ -13,57 +13,57 @@
 
 package cases
 
-// EventInner is a detail template for custom events.
-type EventInner interface {
+// EventDescriptor is a detail template for custom events.
+type EventDescriptor interface {
 	Type() string
 }
 
-// WriteFlowOnSpotInner writes bytes in some range.
-type WriteFlowOnSpotInner struct {
+// WriteFlowOnSpotDescriptor writes bytes in some range.
+type WriteFlowOnSpotDescriptor struct {
 	Step func(tick int64) map[string]int64
 }
 
-// Type implements the EventInner interface.
-func (w *WriteFlowOnSpotInner) Type() string {
+// Type implements the EventDescriptor interface.
+func (w *WriteFlowOnSpotDescriptor) Type() string {
 	return "write-flow-on-spot"
 }
 
-// WriteFlowOnRegionInner writes bytes in some region.
-type WriteFlowOnRegionInner struct {
+// WriteFlowOnRegionDescriptor writes bytes in some region.
+type WriteFlowOnRegionDescriptor struct {
 	Step func(tick int64) map[uint64]int64
 }
 
-// Type implements the EventInner interface.
-func (w *WriteFlowOnRegionInner) Type() string {
+// Type implements the EventDescriptor interface.
+func (w *WriteFlowOnRegionDescriptor) Type() string {
 	return "write-flow-on-region"
 }
 
-// ReadFlowOnRegionInner reads bytes in some region.
-type ReadFlowOnRegionInner struct {
+// ReadFlowOnRegionDescriptor reads bytes in some region.
+type ReadFlowOnRegionDescriptor struct {
 	Step func(tick int64) map[uint64]int64
 }
 
-// Type implements the EventInner interface.
-func (w *ReadFlowOnRegionInner) Type() string {
+// Type implements the EventDescriptor interface.
+func (w *ReadFlowOnRegionDescriptor) Type() string {
 	return "read-flow-on-region"
 }
 
-// AddNodesInner adds nodes.
-type AddNodesInner struct {
+// AddNodesDescriptor adds nodes.
+type AddNodesDescriptor struct {
 	Step func(tick int64) uint64
 }
 
-// Type implements the EventInner interface.
-func (w *AddNodesInner) Type() string {
+// Type implements the EventDescriptor interface.
+func (w *AddNodesDescriptor) Type() string {
 	return "add-nodes"
 }
 
-// DeleteNodesInner removes nodes.
-type DeleteNodesInner struct {
+// DeleteNodesDescriptor removes nodes.
+type DeleteNodesDescriptor struct {
 	Step func(tick int64) uint64
 }
 
-// Type implements the EventInner interface.
-func (w *DeleteNodesInner) Type() string {
+// Type implements the EventDescriptor interface.
+func (w *DeleteNodesDescriptor) Type() string {
 	return "delete-nodes"
 }

--- a/tools/pd-simulator/simulator/cases/hot_read.go
+++ b/tools/pd-simulator/simulator/cases/hot_read.go
@@ -62,11 +62,11 @@ func newHotRead() *Case {
 			}
 		}
 	}
-	e := &ReadFlowOnRegionInner{}
+	e := &ReadFlowOnRegionDescriptor{}
 	e.Step = func(tick int64) map[uint64]int64 {
 		return readFlow
 	}
-	simCase.Events = []EventInner{e}
+	simCase.Events = []EventDescriptor{e}
 	// Checker description
 	simCase.Checker = func(regions *core.RegionsInfo) bool {
 		var leaderCount [5]int

--- a/tools/pd-simulator/simulator/cases/hot_read.go
+++ b/tools/pd-simulator/simulator/cases/hot_read.go
@@ -50,7 +50,6 @@ func newHotRead() *Case {
 			Keys:   960000,
 		})
 	}
-	simCase.MaxID = id.maxID
 
 	// Events description
 	// select 20 regions on store 1 as hot read regions.

--- a/tools/pd-simulator/simulator/cases/hot_read.go
+++ b/tools/pd-simulator/simulator/cases/hot_read.go
@@ -23,11 +23,11 @@ import (
 
 func newHotRead() *Case {
 	var simCase Case
-	var id idAllocator
+
 	// Initialize the cluster
 	for i := 1; i <= 5; i++ {
 		simCase.Stores = append(simCase.Stores, &Store{
-			ID:        id.nextID(),
+			ID:        IDAllocator.nextID(),
 			Status:    metapb.StoreState_Up,
 			Capacity:  1 * TB,
 			Available: 900 * GB,
@@ -38,12 +38,12 @@ func newHotRead() *Case {
 	for i := 0; i < 500; i++ {
 		storeIDs := rand.Perm(5)
 		peers := []*metapb.Peer{
-			{Id: id.nextID(), StoreId: uint64(storeIDs[0] + 1)},
-			{Id: id.nextID(), StoreId: uint64(storeIDs[1] + 1)},
-			{Id: id.nextID(), StoreId: uint64(storeIDs[2] + 1)},
+			{Id: IDAllocator.nextID(), StoreId: uint64(storeIDs[0] + 1)},
+			{Id: IDAllocator.nextID(), StoreId: uint64(storeIDs[1] + 1)},
+			{Id: IDAllocator.nextID(), StoreId: uint64(storeIDs[2] + 1)},
 		}
 		simCase.Regions = append(simCase.Regions, Region{
-			ID:     id.nextID(),
+			ID:     IDAllocator.nextID(),
 			Peers:  peers,
 			Leader: peers[0],
 			Size:   96 * MB,

--- a/tools/pd-simulator/simulator/cases/hot_write.go
+++ b/tools/pd-simulator/simulator/cases/hot_write.go
@@ -50,7 +50,6 @@ func newHotWrite() *Case {
 			Keys:   960000,
 		})
 	}
-	simCase.MaxID = id.maxID
 
 	// Events description
 	// select 5 regions on store 1 as hot write regions.

--- a/tools/pd-simulator/simulator/cases/hot_write.go
+++ b/tools/pd-simulator/simulator/cases/hot_write.go
@@ -23,11 +23,11 @@ import (
 
 func newHotWrite() *Case {
 	var simCase Case
-	var id idAllocator
+
 	// Initialize the cluster
 	for i := 1; i <= 10; i++ {
 		simCase.Stores = append(simCase.Stores, &Store{
-			ID:        id.nextID(),
+			ID:        IDAllocator.nextID(),
 			Status:    metapb.StoreState_Up,
 			Capacity:  1 * TB,
 			Available: 900 * GB,
@@ -38,12 +38,12 @@ func newHotWrite() *Case {
 	for i := 0; i < 500; i++ {
 		storeIDs := rand.Perm(10)
 		peers := []*metapb.Peer{
-			{Id: id.nextID(), StoreId: uint64(storeIDs[0] + 1)},
-			{Id: id.nextID(), StoreId: uint64(storeIDs[1] + 1)},
-			{Id: id.nextID(), StoreId: uint64(storeIDs[2] + 1)},
+			{Id: IDAllocator.nextID(), StoreId: uint64(storeIDs[0] + 1)},
+			{Id: IDAllocator.nextID(), StoreId: uint64(storeIDs[1] + 1)},
+			{Id: IDAllocator.nextID(), StoreId: uint64(storeIDs[2] + 1)},
 		}
 		simCase.Regions = append(simCase.Regions, Region{
-			ID:     id.nextID(),
+			ID:     IDAllocator.nextID(),
 			Peers:  peers,
 			Leader: peers[0],
 			Size:   96 * MB,

--- a/tools/pd-simulator/simulator/cases/hot_write.go
+++ b/tools/pd-simulator/simulator/cases/hot_write.go
@@ -62,12 +62,12 @@ func newHotWrite() *Case {
 			}
 		}
 	}
-	e := &WriteFlowOnRegionInner{}
+	e := &WriteFlowOnRegionDescriptor{}
 	e.Step = func(tick int64) map[uint64]int64 {
 		return writeFlow
 	}
 
-	simCase.Events = []EventInner{e}
+	simCase.Events = []EventDescriptor{e}
 
 	// Checker description
 	simCase.Checker = func(regions *core.RegionsInfo) bool {

--- a/tools/pd-simulator/simulator/cases/makeup_down_replica.go
+++ b/tools/pd-simulator/simulator/cases/makeup_down_replica.go
@@ -46,7 +46,6 @@ func newMakeupDownReplicas() *Case {
 			Keys:   960000,
 		})
 	}
-	simCase.MaxID = id.maxID
 
 	numNodes := 4
 	down := false

--- a/tools/pd-simulator/simulator/cases/makeup_down_replica.go
+++ b/tools/pd-simulator/simulator/cases/makeup_down_replica.go
@@ -20,11 +20,10 @@ import (
 
 func newMakeupDownReplicas() *Case {
 	var simCase Case
-	var id idAllocator
 
 	for i := 1; i <= 4; i++ {
 		simCase.Stores = append(simCase.Stores, &Store{
-			ID:        id.nextID(),
+			ID:        IDAllocator.nextID(),
 			Status:    metapb.StoreState_Up,
 			Capacity:  1 * TB,
 			Available: 900 * GB,
@@ -34,12 +33,12 @@ func newMakeupDownReplicas() *Case {
 
 	for i := 0; i < 400; i++ {
 		peers := []*metapb.Peer{
-			{Id: id.nextID(), StoreId: uint64(i)%4 + 1},
-			{Id: id.nextID(), StoreId: uint64(i+1)%4 + 1},
-			{Id: id.nextID(), StoreId: uint64(i+2)%4 + 1},
+			{Id: IDAllocator.nextID(), StoreId: uint64(i)%4 + 1},
+			{Id: IDAllocator.nextID(), StoreId: uint64(i+1)%4 + 1},
+			{Id: IDAllocator.nextID(), StoreId: uint64(i+2)%4 + 1},
 		}
 		simCase.Regions = append(simCase.Regions, Region{
-			ID:     id.nextID(),
+			ID:     IDAllocator.nextID(),
 			Peers:  peers,
 			Leader: peers[0],
 			Size:   96 * MB,

--- a/tools/pd-simulator/simulator/cases/makeup_down_replica.go
+++ b/tools/pd-simulator/simulator/cases/makeup_down_replica.go
@@ -49,7 +49,7 @@ func newMakeupDownReplicas() *Case {
 
 	numNodes := 4
 	down := false
-	e := &DeleteNodesInner{}
+	e := &DeleteNodesDescriptor{}
 	e.Step = func(tick int64) uint64 {
 		if numNodes > 3 && tick%100 == 0 {
 			numNodes--
@@ -60,7 +60,7 @@ func newMakeupDownReplicas() *Case {
 		}
 		return 0
 	}
-	simCase.Events = []EventInner{e}
+	simCase.Events = []EventDescriptor{e}
 
 	simCase.Checker = func(regions *core.RegionsInfo) bool {
 		sum := 0

--- a/tools/pd-simulator/simulator/cases/region_merge.go
+++ b/tools/pd-simulator/simulator/cases/region_merge.go
@@ -50,7 +50,6 @@ func newRegionMerge() *Case {
 			Keys:   100000,
 		})
 	}
-	simCase.MaxID = id.maxID
 
 	// Checker description
 	simCase.Checker = func(regions *core.RegionsInfo) bool {

--- a/tools/pd-simulator/simulator/cases/region_merge.go
+++ b/tools/pd-simulator/simulator/cases/region_merge.go
@@ -23,11 +23,10 @@ import (
 
 func newRegionMerge() *Case {
 	var simCase Case
-	var id idAllocator
 	// Initialize the cluster
 	for i := 1; i <= 4; i++ {
 		simCase.Stores = append(simCase.Stores, &Store{
-			ID:        id.nextID(),
+			ID:        IDAllocator.nextID(),
 			Status:    metapb.StoreState_Up,
 			Capacity:  1 * TB,
 			Available: 900 * GB,
@@ -38,12 +37,12 @@ func newRegionMerge() *Case {
 	for i := 0; i < 40; i++ {
 		storeIDs := rand.Perm(4)
 		peers := []*metapb.Peer{
-			{Id: id.nextID(), StoreId: uint64(storeIDs[0] + 1)},
-			{Id: id.nextID(), StoreId: uint64(storeIDs[1] + 1)},
-			{Id: id.nextID(), StoreId: uint64(storeIDs[2] + 1)},
+			{Id: IDAllocator.nextID(), StoreId: uint64(storeIDs[0] + 1)},
+			{Id: IDAllocator.nextID(), StoreId: uint64(storeIDs[1] + 1)},
+			{Id: IDAllocator.nextID(), StoreId: uint64(storeIDs[2] + 1)},
 		}
 		simCase.Regions = append(simCase.Regions, Region{
-			ID:     id.nextID(),
+			ID:     IDAllocator.nextID(),
 			Peers:  peers,
 			Leader: peers[0],
 			Size:   10 * MB,

--- a/tools/pd-simulator/simulator/cases/region_split.go
+++ b/tools/pd-simulator/simulator/cases/region_split.go
@@ -41,7 +41,7 @@ func newRegionSplit() *Case {
 		Size:   1 * MB,
 		Keys:   10000,
 	})
-	simCase.MaxID = 5
+
 	simCase.RegionSplitSize = 128 * MB
 	simCase.RegionSplitKeys = 10000
 	// Events description

--- a/tools/pd-simulator/simulator/cases/region_split.go
+++ b/tools/pd-simulator/simulator/cases/region_split.go
@@ -45,13 +45,13 @@ func newRegionSplit() *Case {
 	simCase.RegionSplitSize = 128 * MB
 	simCase.RegionSplitKeys = 10000
 	// Events description
-	e := &WriteFlowOnSpotInner{}
+	e := &WriteFlowOnSpotDescriptor{}
 	e.Step = func(tick int64) map[string]int64 {
 		return map[string]int64{
 			"foobar": 8 * MB,
 		}
 	}
-	simCase.Events = []EventInner{e}
+	simCase.Events = []EventDescriptor{e}
 
 	// Checker description
 	simCase.Checker = func(regions *core.RegionsInfo) bool {

--- a/tools/pd-simulator/simulator/drive.go
+++ b/tools/pd-simulator/simulator/drive.go
@@ -75,18 +75,6 @@ func (d *Driver) Prepare() error {
 		simutil.Logger.Debug("Bootstrap success")
 	}
 
-	// Setup alloc id.
-	for {
-		var id uint64
-		id, err = d.client.AllocID(context.Background())
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		if id > d.simCase.MaxID {
-			break
-		}
-	}
-
 	err = d.Start()
 	if err != nil {
 		return err

--- a/tools/pd-simulator/simulator/drive.go
+++ b/tools/pd-simulator/simulator/drive.go
@@ -75,6 +75,20 @@ func (d *Driver) Prepare() error {
 		simutil.Logger.Debug("Bootstrap success")
 	}
 
+	// Setup alloc id.
+	maxID := cases.IDAllocator.GetID()
+	for {
+		var id uint64
+		id, err = d.client.AllocID(context.Background())
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if id > maxID {
+			cases.IDAllocator.ResetID()
+			break
+		}
+	}
+
 	err = d.Start()
 	if err != nil {
 		return err


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Currently, we have an interface named `EventInner` and it is public, which is wired.

### What is changed and how it works?
This PR renames `EventInner` to `EventDescriptor` and use a global id allocator. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test