### PR TITLE
*: fix ScheduleConfig data race

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -495,7 +495,7 @@ func (c *RaftCluster) SetStoreWeight(storeID uint64, leader, region float64) err
 
 func (c *RaftCluster) checkStores() {
 	var offlineStores []*metapb.Store
-	var upStoreCount uint64
+	var upStoreCount int
 
 	cluster := c.cachedCluster
 
@@ -524,7 +524,7 @@ func (c *RaftCluster) checkStores() {
 		return
 	}
 
-	if upStoreCount < c.s.GetConfig().Replication.MaxReplicas {
+	if upStoreCount < cluster.GetMaxReplicas() {
 		for _, offlineStore := range offlineStores {
 			log.Warnf("store %v may not turn into Tombstone, there are no extra up node has enough space to accommodate the extra replica", offlineStore)
 		}

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -189,7 +189,7 @@ func (c *coordinator) run() {
 	log.Info("coordinator: Run scheduler")
 
 	k := 0
-	scheduleCfg := c.cluster.opt.load()
+	scheduleCfg := c.cluster.opt.load().clone()
 	for _, schedulerCfg := range scheduleCfg.Schedulers {
 		if schedulerCfg.Disable {
 			scheduleCfg.Schedulers[k] = schedulerCfg
@@ -216,6 +216,7 @@ func (c *coordinator) run() {
 
 	// remove invalid scheduler config and persist
 	scheduleCfg.Schedulers = scheduleCfg.Schedulers[:k]
+	c.cluster.opt.store(scheduleCfg)
 	if err := c.cluster.opt.persist(c.cluster.kv); err != nil {
 		log.Errorf("can't persist schedule config: %v", err)
 	}


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
When we call `run()` in `coordinator`, it will write `scheduleCfg`. However, some functions such as `GetMaxStoreDownTime()` may read this variable at the same time which will lead to a data race.

### What is changed and how it works?
This PR fixes this problem by cloning the `scheduleCfg`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (make test)

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release notes
