### PR TITLE
pdctl: fix decode key

### DIFF
--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"os/exec"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -261,19 +262,16 @@ func decodeKey(text string) (string, error) {
 			continue
 		}
 		n := r.Next(1)
+		if len(n) == 0 {
+			return "", io.EOF
+		}
+		// See: https://golang.org/ref/spec#Rune_literals
+		if idx := strings.IndexByte(`abfnrtv\'"`, n[0]); idx != -1 {
+			buf = append(buf, []byte("\a\b\f\n\r\t\v\\'\"")[idx])
+			continue
+		}
+
 		switch n[0] {
-		case '"':
-			buf = append(buf, '"')
-		case '\'':
-			buf = append(buf, '\'')
-		case '\\':
-			buf = append(buf, '\\')
-		case 'n':
-			buf = append(buf, '\n')
-		case 't':
-			buf = append(buf, '\t')
-		case 'r':
-			buf = append(buf, '\r')
 		case 'x':
 			fmt.Sscanf(string(r.Next(2)), "%02x", &c)
 			buf = append(buf, c)


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
The command `region key` does not support all escaped keys generated by golang "%q".

### What is changed and how it works?
Support all runes listed in https://golang.org/ref/spec#Rune_literals

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)
 