### PR TITLE
server/api: fix the issue about `regions/check` API 

### DIFF
--- a/server/api/region.go
+++ b/server/api/region.go
@@ -124,6 +124,17 @@ func newRegionsHandler(svr *server.Server, rd *render.Render) *regionsHandler {
 	}
 }
 
+func convertToAPIRegions(regions []*core.RegionInfo) *regionsInfo {
+	regionInfos := make([]*regionInfo, len(regions))
+	for i, r := range regions {
+		regionInfos[i] = newRegionInfo(r)
+	}
+	return &regionsInfo{
+		Count:   len(regions),
+		Regions: regionInfos,
+	}
+}
+
 func (h *regionsHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 	cluster := h.svr.GetRaftCluster()
 	if cluster == nil {
@@ -131,14 +142,7 @@ func (h *regionsHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	regions := cluster.GetRegions()
-	regionInfos := make([]*regionInfo, len(regions))
-	for i, r := range regions {
-		regionInfos[i] = newRegionInfo(r)
-	}
-	regionsInfo := &regionsInfo{
-		Count:   len(regions),
-		Regions: regionInfos,
-	}
+	regionsInfo := convertToAPIRegions(regions)
 	h.rd.JSON(w, http.StatusOK, regionsInfo)
 }
 
@@ -164,15 +168,7 @@ func (h *regionsHandler) ScanRegionsByKey(w http.ResponseWriter, r *http.Request
 		limit = maxRegionLimit
 	}
 	regions := cluster.ScanRegionsByKey([]byte(startKey), limit)
-
-	regionInfos := make([]*regionInfo, 0, len(regions))
-	for _, region := range regions {
-		regionInfos = append(regionInfos, newRegionInfo(region))
-	}
-	regionsInfo := &regionsInfo{
-		Count:   len(regionInfos),
-		Regions: regionInfos,
-	}
+	regionsInfo := convertToAPIRegions(regions)
 	h.rd.JSON(w, http.StatusOK, regionsInfo)
 }
 
@@ -190,65 +186,63 @@ func (h *regionsHandler) GetStoreRegions(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	regions := cluster.GetStoreRegions(uint64(id))
-	regionInfos := make([]*regionInfo, len(regions))
-	for i, r := range regions {
-		regionInfos[i] = newRegionInfo(r)
-	}
-	regionsInfo := &regionsInfo{
-		Count:   len(regions),
-		Regions: regionInfos,
-	}
+	regionsInfo := convertToAPIRegions(regions)
 	h.rd.JSON(w, http.StatusOK, regionsInfo)
 }
 
 func (h *regionsHandler) GetMissPeerRegions(w http.ResponseWriter, r *http.Request) {
 	handler := h.svr.GetHandler()
-	res, err := handler.GetMissPeerRegions()
+	regions, err := handler.GetMissPeerRegions()
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.rd.JSON(w, http.StatusOK, res)
+	regionsInfo := convertToAPIRegions(regions)
+	h.rd.JSON(w, http.StatusOK, regionsInfo)
 }
 
 func (h *regionsHandler) GetExtraPeerRegions(w http.ResponseWriter, r *http.Request) {
 	handler := h.svr.GetHandler()
-	res, err := handler.GetExtraPeerRegions()
+	regions, err := handler.GetExtraPeerRegions()
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.rd.JSON(w, http.StatusOK, res)
+	regionsInfo := convertToAPIRegions(regions)
+	h.rd.JSON(w, http.StatusOK, regionsInfo)
 }
 
 func (h *regionsHandler) GetPendingPeerRegions(w http.ResponseWriter, r *http.Request) {
 	handler := h.svr.GetHandler()
-	res, err := handler.GetPendingPeerRegions()
+	regions, err := handler.GetPendingPeerRegions()
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.rd.JSON(w, http.StatusOK, res)
+	regionsInfo := convertToAPIRegions(regions)
+	h.rd.JSON(w, http.StatusOK, regionsInfo)
 }
 
 func (h *regionsHandler) GetDownPeerRegions(w http.ResponseWriter, r *http.Request) {
 	handler := h.svr.GetHandler()
-	res, err := handler.GetDownPeerRegions()
+	regions, err := handler.GetDownPeerRegions()
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.rd.JSON(w, http.StatusOK, res)
+	regionsInfo := convertToAPIRegions(regions)
+	h.rd.JSON(w, http.StatusOK, regionsInfo)
 }
 
 func (h *regionsHandler) GetIncorrectNamespaceRegions(w http.ResponseWriter, r *http.Request) {
 	handler := h.svr.GetHandler()
-	res, err := handler.GetIncorrectNamespaceRegions()
+	regions, err := handler.GetIncorrectNamespaceRegions()
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.rd.JSON(w, http.StatusOK, res)
+	regionsInfo := convertToAPIRegions(regions)
+	h.rd.JSON(w, http.StatusOK, regionsInfo)
 }
 
 func (h *regionsHandler) GetRegionSiblings(w http.ResponseWriter, r *http.Request) {
@@ -325,14 +319,7 @@ func (h *regionsHandler) GetTopNRegions(w http.ResponseWriter, r *http.Request, 
 		limit = maxRegionLimit
 	}
 	regions := topNRegions(cluster.GetRegions(), less, limit)
-	regionInfos := make([]*regionInfo, len(regions))
-	for i, r := range regions {
-		regionInfos[i] = newRegionInfo(r)
-	}
-	res := &regionsInfo{
-		Count:   len(regions),
-		Regions: regionInfos,
-	}
+	res := convertToAPIRegions(regions)
 	h.rd.JSON(w, http.StatusOK, res)
 }
 

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -19,6 +19,8 @@ import (
 	"net/url"
 	"sort"
 
+	"github.com/pingcap/kvproto/pkg/pdpb"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/server"
@@ -82,6 +84,31 @@ func (s *testRegionSuite) TestRegion(c *C) {
 	err = readJSONWithURL(url, r2)
 	c.Assert(err, IsNil)
 	c.Assert(r2, DeepEquals, newRegionInfo(r))
+}
+
+func (s *testRegionSuite) TestRegionCheck(c *C) {
+	r := newTestRegionInfo(2, 1, []byte("a"), []byte("b"))
+	downPeer := &metapb.Peer{Id: 13, StoreId: 2}
+	r = r.Clone(core.WithAddPeer(downPeer), core.WithDownPeers([]*pdpb.PeerStats{{Peer: downPeer, DownSeconds: 3600}}), core.WithPendingPeers([]*metapb.Peer{downPeer}))
+	mustRegionHeartbeat(c, s.svr, r)
+	url := fmt.Sprintf("%s/region/id/%d", s.urlPrefix, r.GetID())
+	r1 := &regionInfo{}
+	err := readJSONWithURL(url, r1)
+	c.Assert(err, IsNil)
+	c.Assert(r1, DeepEquals, newRegionInfo(r))
+
+	url = fmt.Sprintf("%s/regions/check/%s", s.urlPrefix, "down-peer")
+	r2 := &regionsInfo{}
+	err = readJSONWithURL(url, r2)
+	c.Assert(err, IsNil)
+	c.Assert(r2, DeepEquals, &regionsInfo{Count: 1, Regions: []*regionInfo{newRegionInfo(r)}})
+
+	url = fmt.Sprintf("%s/regions/check/%s", s.urlPrefix, "pending-peer")
+	r3 := &regionsInfo{}
+	err = readJSONWithURL(url, r3)
+	c.Assert(err, IsNil)
+	c.Assert(r3, DeepEquals, &regionsInfo{Count: 1, Regions: []*regionInfo{newRegionInfo(r)}})
+
 }
 
 func (s *testRegionSuite) TestRegions(c *C) {


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
related  https://github.com/pingcap/pd/issues/1297, the `region check` command show `{}` for each region. like:
```
[
    {},
    {},
]
``` 

### What is changed and how it works?
use the `regionsInfo` struct in `api` to response the request.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
- Manual test (add detailed scripts or steps below)
region check down-peer
```
{
  "count": 1,
  "regions": [
    {
      "id": 2,
      "start_key": "a",
      "end_key": "b",
      "epoch": {
        "conf_ver": 1,
        "version": 1
      },
      "peers": [
        {
          "id": 2,
          "store_id": 1
        },
        {
          "id": 13,
          "store_id": 2
        }
      ],
      "leader": {
        "id": 2,
        "store_id": 1
      },
      "down_peers": [
        {
          "peer": {
            "id": 13,
            "store_id": 2
          },
          "down_seconds": 3600
        }
      ],
      "pending_peers": [
        {
          "id": 13,
          "store_id": 2
        }
      ],
      "approximate_size": 10,
      "approximate_keys": 10
    }
  ]
}
```