### PR TITLE
tso: add sanity check for the count field of request

### DIFF
--- a/server/tso.go
+++ b/server/tso.go
@@ -182,6 +182,11 @@ const maxRetryCount = 100
 
 func (s *Server) getRespTS(count uint32) (pdpb.Timestamp, error) {
 	var resp pdpb.Timestamp
+
+	if count == 0 {
+		return resp, errors.New("tso count should be positive")
+	}
+
 	for i := 0; i < maxRetryCount; i++ {
 		current, ok := s.ts.Load().(*atomicObject)
 		if !ok || current.physical == zeroTime {

--- a/server/tso_test.go
+++ b/server/tso_test.go
@@ -92,6 +92,17 @@ func (s *testTsoSuite) TestTso(c *C) {
 	wg.Wait()
 }
 
+func (s *testTsoSuite) TestTsoCount0(c *C) {
+	req := &pdpb.TsoRequest{Header: newRequestHeader(s.svr.clusterID)}
+	tsoClient, err := s.grpcPDClient.Tso(context.Background())
+	c.Assert(err, IsNil)
+	defer tsoClient.CloseSend()
+	err = tsoClient.Send(req)
+	c.Assert(err, IsNil)
+	_, err = tsoClient.Recv()
+	c.Assert(err, NotNil)
+}
+
 var _ = Suite(&testTimeFallBackSuite{})
 
 type testTimeFallBackSuite struct {


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
If client forgets to set the `count` field of tso request. pd-server will respond timestamp without increasing logical counter.

### What is changed and how it works?
Check count before allcating tso.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
