### PR TITLE
pdctl: use cobra print function

### DIFF
--- a/tools/pd-ctl/pdctl/command/cluster_command.go
+++ b/tools/pd-ctl/pdctl/command/cluster_command.go
@@ -14,7 +14,6 @@
 package command
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/spf13/cobra"
@@ -35,8 +34,8 @@ func NewClusterCommand() *cobra.Command {
 func showClusterCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, clusterPrefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get the cluster information: %s\n", err)
+		cmd.Printf("Failed to get the cluster information: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }

--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -16,7 +16,6 @@ package command
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"path"
 	"strconv"
@@ -187,60 +186,60 @@ func NewDeleteLabelPropertyConfigCommand() *cobra.Command {
 func showConfigCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, schedulePrefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get config: %s\n", err)
+		cmd.Printf("Failed to get config: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func showReplicationConfigCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, replicationPrefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get config: %s\n", err)
+		cmd.Printf("Failed to get config: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func showLabelPropertyConfigCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, labelPropertyPrefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get config: %s\n", err)
+		cmd.Printf("Failed to get config: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func showAllConfigCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, configPrefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get config: %s\n", err)
+		cmd.Printf("Failed to get config: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func showNamespaceConfigCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 	prefix := path.Join(namespacePrefix, args[0])
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get config: %s\n", err)
+		cmd.Printf("Failed to get config: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func showClusterVersionCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, clusterVersionPrefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get cluster version: %s\n", err)
+		cmd.Printf("Failed to get cluster version: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func postConfigDataWithPath(cmd *cobra.Command, key, value, path string) error {
@@ -268,36 +267,36 @@ func postConfigDataWithPath(cmd *cobra.Command, key, value, path string) error {
 
 func setConfigCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 	opt, val := args[0], args[1]
 	err := postConfigDataWithPath(cmd, opt, val, configPrefix)
 	if err != nil {
-		fmt.Printf("Failed to set config: %s\n", err)
+		cmd.Printf("Failed to set config: %s\n", err)
 		return
 	}
-	fmt.Println("Success!")
+	cmd.Println("Success!")
 }
 
 func setNamespaceConfigCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 3 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 	name, opt, val := args[0], args[1], args[2]
 	prefix := path.Join(namespacePrefix, name)
 	err := postConfigDataWithPath(cmd, opt, val, prefix)
 	if err != nil {
-		fmt.Printf("Failed to set namespace:%s config: %s\n", name, err)
+		cmd.Printf("Failed to set namespace:%s config: %s\n", name, err)
 		return
 	}
-	fmt.Println("Success!")
+	cmd.Println("Success!")
 }
 
 func deleteNamespaceConfigCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 && len(args) != 2 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 	name, opt := args[0], args[1]
@@ -312,10 +311,10 @@ func deleteNamespaceConfigCommandFunc(cmd *cobra.Command, args []string) {
 	}
 
 	if err != nil {
-		fmt.Printf("Failed to delete namespace:%s config %s: %s\n", name, opt, err)
+		cmd.Printf("Failed to delete namespace:%s config %s: %s\n", name, opt, err)
 		return
 	}
-	fmt.Println("Success!")
+	cmd.Println("Success!")
 }
 
 func setLabelPropertyConfigCommandFunc(cmd *cobra.Command, args []string) {
@@ -328,7 +327,7 @@ func deleteLabelPropertyConfigCommandFunc(cmd *cobra.Command, args []string) {
 
 func postLabelProperty(cmd *cobra.Command, action string, args []string) {
 	if len(args) != 3 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 	input := map[string]interface{}{
@@ -343,7 +342,7 @@ func postLabelProperty(cmd *cobra.Command, action string, args []string) {
 
 func setClusterVersionCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 	input := map[string]interface{}{

--- a/tools/pd-ctl/pdctl/command/global.go
+++ b/tools/pd-ctl/pdctl/command/global.go
@@ -101,13 +101,13 @@ func genResponseError(r *http.Response) error {
 func getAddressFromCmd(cmd *cobra.Command, prefix string) string {
 	p, err := cmd.Flags().GetString("pd")
 	if err != nil {
-		fmt.Println("Get pd address error,should set flag with '-u'")
+		cmd.Println("Get pd address error,should set flag with '-u'")
 		os.Exit(1)
 	}
 
 	u, err := url.Parse(p)
 	if err != nil {
-		fmt.Println("address is wrong format,should like 'http://127.0.0.1:2379'")
+		cmd.Println("address is wrong format,should like 'http://127.0.0.1:2379'")
 	}
 	if u.Scheme == "" {
 		u.Scheme = "http"
@@ -124,14 +124,14 @@ func printResponseError(r *http.Response) {
 func postJSON(cmd *cobra.Command, prefix string, input map[string]interface{}) {
 	data, err := json.Marshal(input)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
 
 	url := getAddressFromCmd(cmd, prefix)
 	r, err := dialClient.Post(url, "application/json", bytes.NewBuffer(data))
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
 	defer r.Body.Close()

--- a/tools/pd-ctl/pdctl/command/health_command.go
+++ b/tools/pd-ctl/pdctl/command/health_command.go
@@ -14,7 +14,6 @@
 package command
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/spf13/cobra"
@@ -37,8 +36,8 @@ func NewHealthCommand() *cobra.Command {
 func showHealthCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, healthPrefix, http.MethodGet)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }

--- a/tools/pd-ctl/pdctl/command/hot_command.go
+++ b/tools/pd-ctl/pdctl/command/hot_command.go
@@ -14,7 +14,6 @@
 package command
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/spf13/cobra"
@@ -51,10 +50,10 @@ func NewHotWriteRegionCommand() *cobra.Command {
 func showHotWriteRegionsCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, hotWriteRegionsPrefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get hotspot: %s\n", err)
+		cmd.Printf("Failed to get hotspot: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 // NewHotReadRegionCommand return a hot read regions subcommand of hotSpotCmd
@@ -70,10 +69,10 @@ func NewHotReadRegionCommand() *cobra.Command {
 func showHotReadRegionsCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, hotReadRegionsPrefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get hotspot: %s\n", err)
+		cmd.Printf("Failed to get hotspot: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 // NewHotStoreCommand return a hot stores subcommand of hotSpotCmd
@@ -89,8 +88,8 @@ func NewHotStoreCommand() *cobra.Command {
 func showHotStoresCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, hotStoresPrefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get hotspot: %s\n", err)
+		cmd.Printf("Failed to get hotspot: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }

--- a/tools/pd-ctl/pdctl/command/label_command.go
+++ b/tools/pd-ctl/pdctl/command/label_command.go
@@ -49,10 +49,10 @@ func NewLabelListStoresCommand() *cobra.Command {
 func showLabelsCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, labelsPrefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get labels: %s\n", err)
+		cmd.Printf("Failed to get labels: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func getValue(args []string, i int) string {
@@ -64,7 +64,7 @@ func getValue(args []string, i int) string {
 
 func showLabelListStoresCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) > 2 {
-		fmt.Println("Usage: label store name [value]")
+		cmd.Println("Usage: label store name [value]")
 		return
 	}
 	namePrefix := fmt.Sprintf("name=%s", getValue(args, 0))
@@ -72,8 +72,8 @@ func showLabelListStoresCommandFunc(cmd *cobra.Command, args []string) {
 	prefix := fmt.Sprintf("%s?%s&%s", labelsStorePrefix, namePrefix, valuePrefix)
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get stores through label: %s\n", err)
+		cmd.Printf("Failed to get stores through label: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }

--- a/tools/pd-ctl/pdctl/command/log_command.go
+++ b/tools/pd-ctl/pdctl/command/log_command.go
@@ -16,7 +16,6 @@ package command
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/spf13/cobra"
@@ -39,24 +38,24 @@ func NewLogCommand() *cobra.Command {
 func logCommandFunc(cmd *cobra.Command, args []string) {
 	var err error
 	if len(args) != 1 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 
 	data, err := json.Marshal(args[0])
 	if err != nil {
-		fmt.Printf("Failed to set log level: %s\n", err)
+		cmd.Printf("Failed to set log level: %s\n", err)
 		return
 	}
 	req, err := getRequest(cmd, logPrefix, http.MethodPost, "application/json", bytes.NewBuffer(data))
 	if err != nil {
-		fmt.Printf("Failed to set log level: %s\n", err)
+		cmd.Printf("Failed to set log level: %s\n", err)
 		return
 	}
 	_, err = dail(req)
 	if err != nil {
-		fmt.Printf("Failed to set log level: %s\n", err)
+		cmd.Printf("Failed to set log level: %s\n", err)
 		return
 	}
-	fmt.Println("Success!")
+	cmd.Println("Success!")
 }

--- a/tools/pd-ctl/pdctl/command/member_command.go
+++ b/tools/pd-ctl/pdctl/command/member_command.go
@@ -16,7 +16,6 @@ package command
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 
@@ -92,95 +91,95 @@ func NewLeaderMemberCommand() *cobra.Command {
 func showMemberCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, membersPrefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get pd members: %s\n", err)
+		cmd.Printf("Failed to get pd members: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func deleteMemberByNameCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println("Usage: member delete <member_name>")
+		cmd.Println("Usage: member delete <member_name>")
 		return
 	}
 	prefix := membersPrefix + "/name/" + args[0]
 	_, err := doRequest(cmd, prefix, http.MethodDelete)
 	if err != nil {
-		fmt.Printf("Failed to delete member %s: %s\n", args[0], err)
+		cmd.Printf("Failed to delete member %s: %s\n", args[0], err)
 		return
 	}
-	fmt.Println("Success!")
+	cmd.Println("Success!")
 }
 
 func deleteMemberByIDCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println("Usage: member delete id <member_id>")
+		cmd.Println("Usage: member delete id <member_id>")
 		return
 	}
 	prefix := membersPrefix + "/id/" + args[0]
 	_, err := doRequest(cmd, prefix, http.MethodDelete)
 	if err != nil {
-		fmt.Printf("Failed to delete member %s: %s\n", args[0], err)
+		cmd.Printf("Failed to delete member %s: %s\n", args[0], err)
 		return
 	}
-	fmt.Println("Success!")
+	cmd.Println("Success!")
 }
 
 func getLeaderMemberCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, leaderMemberPrefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get the leader of pd members: %s\n", err)
+		cmd.Printf("Failed to get the leader of pd members: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func resignLeaderCommandFunc(cmd *cobra.Command, args []string) {
 	prefix := leaderMemberPrefix + "/resign"
 	_, err := doRequest(cmd, prefix, http.MethodPost)
 	if err != nil {
-		fmt.Printf("Failed to resign: %s\n", err)
+		cmd.Printf("Failed to resign: %s\n", err)
 		return
 	}
-	fmt.Println("Success!")
+	cmd.Println("Success!")
 }
 
 func transferPDLeaderCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println("Usage: leader transfer <member_name>")
+		cmd.Println("Usage: leader transfer <member_name>")
 		return
 	}
 	prefix := leaderMemberPrefix + "/transfer/" + args[0]
 	_, err := doRequest(cmd, prefix, http.MethodPost)
 	if err != nil {
-		fmt.Printf("Failed to trasfer leadership: %s\n", err)
+		cmd.Printf("Failed to trasfer leadership: %s\n", err)
 		return
 	}
-	fmt.Println("Success!")
+	cmd.Println("Success!")
 }
 
 func setLeaderPriorityFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
-		fmt.Println("Usage: leader_priority <member_name> <priority>")
+		cmd.Println("Usage: leader_priority <member_name> <priority>")
 		return
 	}
 	prefix := membersPrefix + "/name/" + args[0]
 	priority, err := strconv.ParseFloat(args[1], 64)
 	if err != nil {
-		fmt.Printf("failed to parse priority: %v\n", err)
+		cmd.Printf("failed to parse priority: %v\n", err)
 		return
 	}
 	data := map[string]interface{}{"leader-priority": priority}
 	reqData, _ := json.Marshal(data)
 	req, err := getRequest(cmd, prefix, http.MethodPost, "application/json", bytes.NewBuffer(reqData))
 	if err != nil {
-		fmt.Printf("failed to set leader priority: %v\n", err)
+		cmd.Printf("failed to set leader priority: %v\n", err)
 		return
 	}
 	_, err = dail(req)
 	if err != nil {
-		fmt.Printf("failed to set leader priority: %v\n", err)
+		cmd.Printf("failed to set leader priority: %v\n", err)
 		return
 	}
-	fmt.Println("Success!")
+	cmd.Println("Success!")
 }

--- a/tools/pd-ctl/pdctl/command/operator.go
+++ b/tools/pd-ctl/pdctl/command/operator.go
@@ -55,16 +55,16 @@ func showOperatorCommandFunc(cmd *cobra.Command, args []string) {
 	} else if len(args) == 1 {
 		path = fmt.Sprintf("%s?kind=%s", operatorsPrefix, args[0])
 	} else {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 
 	r, err := doRequest(cmd, path, http.MethodGet)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 // NewAddOperatorCommand returns a command to add operators.
@@ -96,13 +96,13 @@ func NewTransferLeaderCommand() *cobra.Command {
 
 func transferLeaderCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 
 	ids, err := parseUint64s(args)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
 
@@ -125,13 +125,13 @@ func NewTransferRegionCommand() *cobra.Command {
 
 func transferRegionCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) <= 2 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 
 	ids, err := parseUint64s(args)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
 
@@ -154,13 +154,13 @@ func NewTransferPeerCommand() *cobra.Command {
 
 func transferPeerCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 3 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 
 	ids, err := parseUint64s(args)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
 
@@ -184,13 +184,13 @@ func NewAddPeerCommand() *cobra.Command {
 
 func addPeerCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 
 	ids, err := parseUint64s(args)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
 
@@ -213,13 +213,13 @@ func NewMergeRegionCommand() *cobra.Command {
 
 func mergeRegionCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 
 	ids, err := parseUint64s(args)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
 
@@ -242,13 +242,13 @@ func NewRemovePeerCommand() *cobra.Command {
 
 func removePeerCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 
 	ids, err := parseUint64s(args)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
 
@@ -272,13 +272,13 @@ func NewSplitRegionCommand() *cobra.Command {
 
 func splitRegionCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 
 	ids, err := parseUint64s(args)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
 
@@ -287,7 +287,7 @@ func splitRegionCommandFunc(cmd *cobra.Command, args []string) {
 	case "scan", "approximate":
 		break
 	default:
-		fmt.Println("Error: unknown policy")
+		cmd.Println("Error: unknown policy")
 		return
 	}
 
@@ -310,13 +310,13 @@ func NewScatterRegionCommand() *cobra.Command {
 
 func scatterRegionCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 
 	ids, err := parseUint64s(args)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
 
@@ -338,14 +338,14 @@ func NewRemoveOperatorCommand() *cobra.Command {
 
 func removeOperatorCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 
 	path := operatorsPrefix + "/" + args[0]
 	_, err := doRequest(cmd, path, http.MethodDelete)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
 }

--- a/tools/pd-ctl/pdctl/command/ping_command.go
+++ b/tools/pd-ctl/pdctl/command/ping_command.go
@@ -14,7 +14,6 @@
 package command
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
@@ -35,9 +34,9 @@ func showPingCommandFunc(cmd *cobra.Command, args []string) {
 	start := time.Now()
 	_, err := doRequest(cmd, pingPrefix, http.MethodGet)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
 	elapsed := time.Since(start)
-	fmt.Println("time:", elapsed)
+	cmd.Println("time:", elapsed)
 }

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -99,14 +99,14 @@ func showRegionCommandFunc(cmd *cobra.Command, args []string) {
 	prefix := regionsPrefix
 	if len(args) == 1 {
 		if _, err := strconv.Atoi(args[0]); err != nil {
-			fmt.Println("region_id should be a number")
+			cmd.Println("region_id should be a number")
 			return
 		}
 		prefix = regionIDPrefix + "/" + args[0]
 	}
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get region: %s\n", err)
+		cmd.Printf("Failed to get region: %s\n", err)
 		return
 	}
 	if flag := cmd.Flag("jq"); flag != nil && flag.Value.String() != "" {
@@ -114,92 +114,92 @@ func showRegionCommandFunc(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func showRegionTopWriteCommandFunc(cmd *cobra.Command, args []string) {
 	prefix := regionsWriteflowPrefix
 	if len(args) == 1 {
 		if _, err := strconv.Atoi(args[0]); err != nil {
-			fmt.Println("limit should be a number")
+			cmd.Println("limit should be a number")
 			return
 		}
 		prefix += "?limit=" + args[0]
 	}
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get regions: %s\n", err)
+		cmd.Printf("Failed to get regions: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func showRegionTopReadCommandFunc(cmd *cobra.Command, args []string) {
 	prefix := regionsReadflowPrefix
 	if len(args) == 1 {
 		if _, err := strconv.Atoi(args[0]); err != nil {
-			fmt.Println("limit should be a number")
+			cmd.Println("limit should be a number")
 			return
 		}
 		prefix += "?limit=" + args[0]
 	}
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get regions: %s\n", err)
+		cmd.Printf("Failed to get regions: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func showRegionTopConfVerCommandFunc(cmd *cobra.Command, args []string) {
 	prefix := regionsConfVerPrefix
 	if len(args) == 1 {
 		if _, err := strconv.Atoi(args[0]); err != nil {
-			fmt.Println("limit should be a number")
+			cmd.Println("limit should be a number")
 			return
 		}
 		prefix += "?limit=" + args[0]
 	}
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get regions: %s\n", err)
+		cmd.Printf("Failed to get regions: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func showRegionTopVersionCommandFunc(cmd *cobra.Command, args []string) {
 	prefix := regionsVersionPrefix
 	if len(args) == 1 {
 		if _, err := strconv.Atoi(args[0]); err != nil {
-			fmt.Println("limit should be a number")
+			cmd.Println("limit should be a number")
 			return
 		}
 		prefix += "?limit=" + args[0]
 	}
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get regions: %s\n", err)
+		cmd.Printf("Failed to get regions: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func showRegionTopSizeCommandFunc(cmd *cobra.Command, args []string) {
 	prefix := regionsSizePrefix
 	if len(args) == 1 {
 		if _, err := strconv.Atoi(args[0]); err != nil {
-			fmt.Println("limit should be a number")
+			cmd.Println("limit should be a number")
 			return
 		}
 		prefix += "?limit=" + args[0]
 	}
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get regions: %s\n", err)
+		cmd.Printf("Failed to get regions: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 // NewRegionWithKeyCommand return a region with key subcommand of regionCmd
@@ -215,22 +215,22 @@ func NewRegionWithKeyCommand() *cobra.Command {
 
 func showRegionWithTableCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 	key, err := parseKey(cmd.Flags(), args[0])
 	if err != nil {
-		fmt.Println("Error: ", err)
+		cmd.Println("Error: ", err)
 		return
 	}
 	key = url.QueryEscape(key)
 	prefix := regionKeyPrefix + "/" + key
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get region: %s\n", err)
+		cmd.Printf("Failed to get region: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func parseKey(flags *pflag.FlagSet, key string) (string, error) {
@@ -304,29 +304,29 @@ func NewRegionsWithStartKeyCommand() *cobra.Command {
 
 func showRegionsFromStartKeyCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) < 1 || len(args) > 2 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 	key, err := parseKey(cmd.Flags(), args[0])
 	if err != nil {
-		fmt.Println("Error: ", err)
+		cmd.Println("Error: ", err)
 		return
 	}
 	key = url.QueryEscape(key)
 	prefix := regionKeyPrefix + "/" + key
 	if len(args) == 2 {
 		if _, err = strconv.Atoi(args[1]); err != nil {
-			fmt.Println("limit should be a number")
+			cmd.Println("limit should be a number")
 			return
 		}
 		prefix += "?limit=" + args[1]
 	}
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get region: %s\n", err)
+		cmd.Printf("Failed to get region: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 // NewRegionWithCheckCommand returns a region with check subcommand of regionCmd
@@ -341,17 +341,17 @@ func NewRegionWithCheckCommand() *cobra.Command {
 
 func showRegionWithCheckCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 	state := args[0]
 	prefix := regionsCheckPrefix + "/" + state
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get region: %s\n", err)
+		cmd.Printf("Failed to get region: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 // NewRegionWithSiblingCommand returns a region with sibling subcommand of regionCmd
@@ -366,17 +366,17 @@ func NewRegionWithSiblingCommand() *cobra.Command {
 
 func showRegionWithSiblingCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 	regionID := args[0]
 	prefix := regionsSiblingPrefix + "/" + regionID
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get region sibling: %s\n", err)
+		cmd.Printf("Failed to get region sibling: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 // NewRegionWithStoreCommand returns regions with store subcommand of regionCmd
@@ -391,17 +391,17 @@ func NewRegionWithStoreCommand() *cobra.Command {
 
 func showRegionWithStoreCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 	storeID := args[0]
 	prefix := regionsStorePrefix + "/" + storeID
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get regions with the given storeID: %s\n", err)
+		cmd.Printf("Failed to get regions with the given storeID: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func printWithJQFilter(data, filter string) {

--- a/tools/pd-ctl/pdctl/command/scheduler.go
+++ b/tools/pd-ctl/pdctl/command/scheduler.go
@@ -14,7 +14,6 @@
 package command
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -50,16 +49,16 @@ func NewShowSchedulerCommand() *cobra.Command {
 
 func showSchedulerCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 0 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 
 	r, err := doRequest(cmd, schedulersPrefix, http.MethodGet)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 // NewAddSchedulerCommand returns a command to add scheduler.
@@ -104,13 +103,13 @@ func NewEvictLeaderSchedulerCommand() *cobra.Command {
 
 func addSchedulerForStoreCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 
 	storeID, err := strconv.ParseUint(args[0], 10, 64)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
 
@@ -192,7 +191,7 @@ func NewLabelSchedulerCommand() *cobra.Command {
 
 func addSchedulerCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 0 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 
@@ -214,17 +213,17 @@ func NewScatterRangeSchedulerCommand() *cobra.Command {
 
 func addSchedulerForScatterRangeCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 3 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	}
 	startKey, err := parseKey(cmd.Flags(), args[0])
 	if err != nil {
-		fmt.Println("Error: ", err)
+		cmd.Println("Error: ", err)
 		return
 	}
 	endKey, err := parseKey(cmd.Flags(), args[1])
 	if err != nil {
-		fmt.Println("Error: ", err)
+		cmd.Println("Error: ", err)
 		return
 	}
 
@@ -250,7 +249,7 @@ func addSchedulerForBalanceAdjacentRegionCommandFunc(cmd *cobra.Command, args []
 	l := len(args)
 	input := make(map[string]interface{})
 	if l > 2 {
-		fmt.Println(cmd.UsageString())
+		cmd.Println(cmd.UsageString())
 		return
 	} else if l == 1 {
 		input["leader_limit"] = url.QueryEscape(args[0])
@@ -275,14 +274,14 @@ func NewRemoveSchedulerCommand() *cobra.Command {
 
 func removeSchedulerCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println(cmd.Usage())
+		cmd.Println(cmd.Usage())
 		return
 	}
 
 	path := schedulersPrefix + "/" + args[0]
 	_, err := doRequest(cmd, path, http.MethodDelete)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
 }

--- a/tools/pd-ctl/pdctl/command/store_command.go
+++ b/tools/pd-ctl/pdctl/command/store_command.go
@@ -74,48 +74,48 @@ func showStoreCommandFunc(cmd *cobra.Command, args []string) {
 	prefix := storesPrefix
 	if len(args) == 1 {
 		if _, err := strconv.Atoi(args[0]); err != nil {
-			fmt.Println("store_id should be a number")
+			cmd.Println("store_id should be a number")
 			return
 		}
 		prefix = fmt.Sprintf(storePrefix, args[0])
 	}
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get store: %s\n", err)
+		cmd.Printf("Failed to get store: %s\n", err)
 		return
 	}
 	if flag := cmd.Flag("jq"); flag != nil && flag.Value.String() != "" {
 		printWithJQFilter(r, flag.Value.String())
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func deleteStoreCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println("Usage: store delete <store_id>")
+		cmd.Println("Usage: store delete <store_id>")
 		return
 	}
 	if _, err := strconv.Atoi(args[0]); err != nil {
-		fmt.Println("store_id should be a number")
+		cmd.Println("store_id should be a number")
 		return
 	}
 	prefix := fmt.Sprintf(storePrefix, args[0])
 	_, err := doRequest(cmd, prefix, http.MethodDelete)
 	if err != nil {
-		fmt.Printf("Failed to delete store %s: %s\n", args[0], err)
+		cmd.Printf("Failed to delete store %s: %s\n", args[0], err)
 		return
 	}
-	fmt.Println("Success!")
+	cmd.Println("Success!")
 }
 
 func labelStoreCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 3 {
-		fmt.Println("Usage: store label <store_id> <key> <value>")
+		cmd.Println("Usage: store label <store_id> <key> <value>")
 		return
 	}
 	if _, err := strconv.Atoi(args[0]); err != nil {
-		fmt.Println("store_id should be a number")
+		cmd.Println("store_id should be a number")
 		return
 	}
 	prefix := fmt.Sprintf(path.Join(storePrefix, "label"), args[0])
@@ -124,17 +124,17 @@ func labelStoreCommandFunc(cmd *cobra.Command, args []string) {
 
 func setStoreWeightCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 3 {
-		fmt.Println("Usage: store weight <store_id> <leader_weight> <region_weight>")
+		cmd.Println("Usage: store weight <store_id> <leader_weight> <region_weight>")
 		return
 	}
 	leader, err := strconv.ParseFloat(args[1], 64)
 	if err != nil || leader < 0 {
-		fmt.Println("leader_weight should be a number that >= 0.")
+		cmd.Println("leader_weight should be a number that >= 0.")
 		return
 	}
 	region, err := strconv.ParseFloat(args[2], 64)
 	if err != nil || region < 0 {
-		fmt.Println("region_weight should be a number that >= 0")
+		cmd.Println("region_weight should be a number that >= 0")
 		return
 	}
 	prefix := fmt.Sprintf(path.Join(storePrefix, "weight"), args[0])

--- a/tools/pd-ctl/pdctl/command/table_namespace_command.go
+++ b/tools/pd-ctl/pdctl/command/table_namespace_command.go
@@ -78,15 +78,15 @@ func NewRemoveTableIDCommand() *cobra.Command {
 func showNamespaceCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, namespacesPrefix, http.MethodGet)
 	if err != nil {
-		fmt.Printf("Failed to get the namespace information: %s\n", err)
+		cmd.Printf("Failed to get the namespace information: %s\n", err)
 		return
 	}
-	fmt.Println(r)
+	cmd.Println(r)
 }
 
 func createNamespaceCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println("Usage: namespace create <name>")
+		cmd.Println("Usage: namespace create <name>")
 		return
 	}
 
@@ -99,11 +99,11 @@ func createNamespaceCommandFunc(cmd *cobra.Command, args []string) {
 
 func addTableCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
-		fmt.Println("Usage: namespace add <name> <table_id>")
+		cmd.Println("Usage: namespace add <name> <table_id>")
 		return
 	}
 	if _, err := strconv.Atoi(args[1]); err != nil {
-		fmt.Println("table_id shoud be a number")
+		cmd.Println("table_id shoud be a number")
 		return
 	}
 
@@ -118,11 +118,11 @@ func addTableCommandFunc(cmd *cobra.Command, args []string) {
 
 func removeTableCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
-		fmt.Println("Usage: namespace remove <name> <table_id>")
+		cmd.Println("Usage: namespace remove <name> <table_id>")
 		return
 	}
 	if _, err := strconv.Atoi(args[1]); err != nil {
-		fmt.Println("table_id shoud be a number")
+		cmd.Println("table_id shoud be a number")
 		return
 	}
 
@@ -159,12 +159,12 @@ func NewRemoveNamespaceStoreCommand() *cobra.Command {
 
 func setNamespaceStoreCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
-		fmt.Println("Usage: namespace set_ns <store_id> <namespace>")
+		cmd.Println("Usage: namespace set_ns <store_id> <namespace>")
 		return
 	}
 	_, err := strconv.Atoi(args[0])
 	if err != nil {
-		fmt.Println("store_id should be a number")
+		cmd.Println("store_id should be a number")
 		return
 	}
 	prefix := fmt.Sprintf(storeNsPrefix, args[0])
@@ -176,12 +176,12 @@ func setNamespaceStoreCommandFunc(cmd *cobra.Command, args []string) {
 
 func removeNamespaceStoreCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
-		fmt.Println("Usage: namespace rm_ns <store_id> <namespace>")
+		cmd.Println("Usage: namespace rm_ns <store_id> <namespace>")
 		return
 	}
 	_, err := strconv.Atoi(args[0])
 	if err != nil {
-		fmt.Println("store_id should be a number")
+		cmd.Println("store_id should be a number")
 		return
 	}
 	prefix := fmt.Sprintf(storeNsPrefix, args[0])
@@ -209,7 +209,7 @@ func newRemoveMetaNamespaceCommand() *cobra.Command {
 
 func setMetaNamespaceCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println("Usage: set_meta <namespace>")
+		cmd.Println("Usage: set_meta <namespace>")
 		return
 	}
 	input := map[string]interface{}{
@@ -221,7 +221,7 @@ func setMetaNamespaceCommandFunc(cmd *cobra.Command, args []string) {
 
 func removeMetaNamespaceCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println("Usage: rm_meta <namespace>")
+		cmd.Println("Usage: rm_meta <namespace>")
 		return
 	}
 	input := map[string]interface{}{

--- a/tools/pd-ctl/pdctl/command/tso_command.go
+++ b/tools/pd-ctl/pdctl/command/tso_command.go
@@ -14,7 +14,6 @@
 package command
 
 import (
-	"fmt"
 	"strconv"
 	"time"
 
@@ -38,17 +37,17 @@ func NewTSOCommand() *cobra.Command {
 
 func showTSOCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		fmt.Println("Usage: tso <timestamp>")
+		cmd.Println("Usage: tso <timestamp>")
 		return
 	}
 	ts, err := strconv.ParseUint(args[0], 10, 64)
 	if err != nil {
-		fmt.Printf("Failed to parse TSO: %s\n", err)
+		cmd.Printf("Failed to parse TSO: %s\n", err)
 		return
 	}
 	logical := ts & logicalBits
 	physical := ts >> physicalShiftBits
 	physicalTime := time.Unix(int64(physical/1000), int64(physical%1000)*time.Millisecond.Nanoseconds())
-	fmt.Println("system: ", physicalTime)
-	fmt.Println("logic: ", logical)
+	cmd.Println("system: ", physicalTime)
+	cmd.Println("logic: ", logical)
 }

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -14,7 +14,7 @@
 package pdctl
 
 import (
-	"fmt"
+	"os"
 
 	"github.com/pingcap/pd/tools/pd-ctl/pdctl/command"
 	"github.com/spf13/cobra"
@@ -68,15 +68,16 @@ func Start(args []string) {
 	rootCmd.SilenceErrors = true
 	rootCmd.ParseFlags(args)
 	rootCmd.SetUsageTemplate(command.UsageTemplate)
+	rootCmd.SetOutput(os.Stdout)
 
 	if len(commandFlags.CAPath) != 0 {
 		if err := command.InitHTTPSClient(commandFlags.CAPath, commandFlags.CertPath, commandFlags.KeyPath); err != nil {
-			fmt.Println(err)
+			rootCmd.Println(err)
 			return
 		}
 	}
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(rootCmd.UsageString())
+		rootCmd.Println(rootCmd.UsageString())
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Cobra has its own print functions which can be used to specify the output. In addition, we can use it to write some `pd-ctl` tests.

### What is changed and how it works?
This PR replaces all standard print functions in `pd-ctl` with `cobra`'s print functions.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test