### PR TITLE
config: check undefined config item

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -327,7 +327,7 @@ func (m *configMetaData) CheckUndecoded() error {
 	for _, key := range undecoded {
 		errInfo += key.String() + ", "
 	}
-	return errors.New(errInfo)
+	return errors.New(errInfo[:len(errInfo)-2])
 }
 
 // Adjust is used to adjust the PD configurations.

--- a/server/config.go
+++ b/server/config.go
@@ -315,9 +315,28 @@ func (m *configMetaData) Child(path ...string) *configMetaData {
 	}
 }
 
+func (m *configMetaData) CheckUndecoded() error {
+	if m.meta == nil {
+		return nil
+	}
+	undecoded := m.meta.Undecoded()
+	if len(undecoded) == 0 {
+		return nil
+	}
+	errInfo := "Config contains undefined item: "
+	for _, key := range undecoded {
+		errInfo += key.String() + ", "
+	}
+	return errors.New(errInfo)
+}
+
 // Adjust is used to adjust the PD configurations.
 func (c *Config) Adjust(meta *toml.MetaData) error {
 	configMetaData := newConfigMetadata(meta)
+	if err := configMetaData.CheckUndecoded(); err != nil {
+		return err
+	}
+
 	adjustString(&c.Name, defaultName)
 	adjustString(&c.DataDir, fmt.Sprintf("default.%s", c.Name))
 

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -110,4 +110,18 @@ leader-schedule-limit = 0
 	// When undefined, use default values.
 	c.Assert(cfg.PreVote, IsTrue)
 	c.Assert(cfg.Schedule.MaxMergeRegionKeys, Equals, uint64(defaultMaxMergeRegionKeys))
+
+	cfgData = `
+lalala = ""
+name = ""
+lease = 0
+
+[schedule]
+type = "random-merge"
+`
+	cfg = NewConfig()
+	meta, err = toml.Decode(cfgData, &cfg)
+	c.Assert(err, IsNil)
+	err = cfg.Adjust(&meta)
+	c.Assert(err, NotNil)
 }

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -199,7 +199,7 @@ func (c *coordinator) run() {
 		}
 		s, err := schedule.CreateScheduler(schedulerCfg.Type, c.opController, schedulerCfg.Args...)
 		if err != nil {
-			panic(fmt.Sprintf("can not create scheduler %s: %v", schedulerCfg.Type, err))
+			log.Fatalf("can not create scheduler %s: %v", schedulerCfg.Type, err)
 		} else {
 			log.Infof("create scheduler %s", s.GetName())
 			if err = c.addScheduler(s, schedulerCfg.Args...); err != nil {

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -199,7 +199,7 @@ func (c *coordinator) run() {
 		}
 		s, err := schedule.CreateScheduler(schedulerCfg.Type, c.opController, schedulerCfg.Args...)
 		if err != nil {
-			log.Errorf("can not create scheduler %s: %v", schedulerCfg.Type, err)
+			panic(fmt.Sprintf("can not create scheduler %s: %v", schedulerCfg.Type, err))
 		} else {
 			log.Infof("create scheduler %s", s.GetName())
 			if err = c.addScheduler(s, schedulerCfg.Args...); err != nil {


### PR DESCRIPTION
### What problem does this PR solve? 
We may miswrite the config name, and it is hard to find unless we check the config log carefully.

### What is changed and how it works?
When PD restart, check the config undecoded field to find whether there is any undefined config.

### Check List 
 - Unit test
 - Manual test (add detailed scripts or steps below)

### Test steps
- start PD with the default config file
```shell
>> ./bin/pd-server -config conf/config.toml
......
2018/12/06 21:38:16.482 leader.go:264: [info] PD cluster leader pd is ready to serve
```
- start PD with config file having undefined config
```shell
>> cat config1.toml
type = "pd"
>> ./bin/pd-server -config config1.toml
FATA[0000] parse cmd flags error: Config contains undefined item: type,
```
- start PD with config file having a wrong scheduler name
```shell
>> cat config2.toml
[[schedule.schedulers]]
type = "random-merge-schedulers"
args = [""]
>> ./bin/pd-server -config config2.toml
2018/12/06 21:50:04.637 log.go:274: [fatal] panic: can not create scheduler random-merge-schedulers: create func of random-merge-schedulers is not registered,


