### PR TITLE
pd-ctl: fix delete namespace command

### DIFF
--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -299,20 +299,24 @@ func deleteNamespaceConfigCommandFunc(cmd *cobra.Command, args []string) {
 		cmd.Println(cmd.UsageString())
 		return
 	}
-	name, opt := args[0], args[1]
+
+	name := args[0]
 	prefix := path.Join(namespacePrefix, name)
 
-	var err error
 	if len(args) == 2 {
 		// delete namespace config's option by setting the option with zero value
-		err = postConfigDataWithPath(cmd, opt, "0", prefix)
+		opt := args[1]
+		err := postConfigDataWithPath(cmd, opt, "0", prefix)
+		if err != nil {
+			cmd.Printf("Failed to delete namespace %s config, option: %s, error: %s\n", name, opt, err)
+			return
+		}
 	} else {
-		_, err = doRequest(cmd, prefix, http.MethodDelete)
-	}
-
-	if err != nil {
-		cmd.Printf("Failed to delete namespace:%s config %s: %s\n", name, opt, err)
-		return
+		_, err := doRequest(cmd, prefix, http.MethodDelete)
+		if err != nil {
+			cmd.Printf("Failed to delete namespace %s config, error: %s\n", name, err)
+			return
+		}
 	}
 	cmd.Println("Success!")
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
When we use `config delete namespace` in `pd-ctl`, if we only provide the namespace name, it will panic.
```
» config delete namespace ts1
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/pingcap/pd/tools/pd-ctl/pdctl/command.deleteNamespaceConfigCommandFunc(0xc00045b680, 0xc000131ce0, 0x1, 0x3)
	/.../PingCAP/go/src/github.com/pingcap/pd/tools/pd-ctl/pdctl/command/config_command.go:304 +0x642
github.com/spf13/cobra.(*Command).execute(0xc00045b680, 0xc000131bf0, 0x3, 0x3, 0xc00045b680, 0xc000131bf0)
	/.../PingCAP/go/pkg/mod/github.com/spf13/cobra@v0.0.2/command.go:760 +0x2cc
github.com/spf13/cobra.(*Command).ExecuteC(0xc00042d400, 0x10, 0xe, 0xc000467b80)
	/.../PingCAP/go/pkg/mod/github.com/spf13/cobra@v0.0.2/command.go:846 +0x2fd
github.com/spf13/cobra.(*Command).Execute(0xc00042d400, 0xc000212b00, 0x6)
	/.../PingCAP/go/pkg/mod/github.com/spf13/cobra@v0.0.2/command.go:794 +0x2b
github.com/pingcap/pd/tools/pd-ctl/pdctl.Start(0xc000212b00, 0x6, 0x8)
	/.../PingCAP/go/src/github.com/pingcap/pd/tools/pd-ctl/pdctl/ctl.go:80 +0x717
main.loop()
	/.../PingCAP/go/src/github.com/pingcap/pd/tools/pd-ctl/main.go:136 +0x458
main.main()
	/.../PingCAP/go/src/github.com/pingcap/pd/tools/pd-ctl/main.go:95 +0x36c
```

### What is changed and how it works?
This PR fixes this problem.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test

Related changes

 - Need to be included in the release notes
