### PR TITLE
api: fix redundant header

### DIFF
--- a/server/api/redirector.go
+++ b/server/api/redirector.go
@@ -119,8 +119,20 @@ func (p *customReverseProxies) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 func copyHeader(dst, src http.Header) {
 	for k, vv := range src {
+		values := dst[k]
 		for _, v := range vv {
-			dst.Add(k, v)
+			if !contains(values, v) {
+				dst.Add(k, v)
+			}
 		}
 	}
+}
+
+func contains(s []string, x string) bool {
+	for _, n := range s {
+		if x == n {
+			return true
+		}
+	}
+	return false
 }

--- a/server/api/redirector_test.go
+++ b/server/api/redirector_test.go
@@ -36,8 +36,12 @@ func (s *testRedirectorSuite) TearDownSuite(c *C) {
 }
 
 func (s *testRedirectorSuite) TestRedirect(c *C) {
+	leader := mustWaitLeader(c, s.servers)
+	header := mustRequestSuccess(c, leader)
 	for _, svr := range s.servers {
-		mustRequestSuccess(c, svr)
+		if svr != leader {
+			c.Assert(header, DeepEquals, mustRequestSuccess(c, svr))
+		}
 	}
 }
 
@@ -76,7 +80,8 @@ func mustRequest(c *C, s *server.Server) *http.Response {
 	return resp
 }
 
-func mustRequestSuccess(c *C, s *server.Server) {
+func mustRequestSuccess(c *C, s *server.Server) http.Header {
 	resp := mustRequest(c, s)
 	c.Assert(resp.StatusCode, Equals, http.StatusOK)
+	return resp.Header
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
If we send a request to a follower, it will be redirected to the leader and we use the `Add` function to copy the header. In this situation, the redundant informations could be appended. 

### What is changed and how it works?
Before appending the informations to the header, we firstly check if it already has the same message.
Fixes pingcap/tikv#3894.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test 