### PR TITLE
server: Fix the issue about RaftCluster cannot be stopped

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -30,9 +30,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var (
-	backgroundJobInterval = time.Minute
-)
+var backgroundJobInterval = time.Minute
 
 // RaftCluster is used for cluster config management.
 // Raft cluster key format:
@@ -121,8 +119,8 @@ func (c *RaftCluster) start() error {
 	c.wg.Add(3)
 	go c.runCoordinator()
 	// gofail: var highFrequencyClusterJobs bool
-	// if highFrequencyClusterJobs{
-	//		backgroundJobInterval = 100 * time.Microsecond
+	// if highFrequencyClusterJobs {
+	//     backgroundJobInterval = 100 * time.Microsecond
 	// }
 	go c.runBackgroundJobs(backgroundJobInterval)
 	go c.syncRegions()

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -30,7 +30,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
+var (
 	backgroundJobInterval = time.Minute
 )
 
@@ -120,6 +120,10 @@ func (c *RaftCluster) start() error {
 
 	c.wg.Add(3)
 	go c.runCoordinator()
+	// gofail: var highFrequencyClusterJobs bool
+	// if highFrequencyClusterJobs{
+	//		backgroundJobInterval = 100 * time.Microsecond
+	// }
 	go c.runBackgroundJobs(backgroundJobInterval)
 	go c.syncRegions()
 	c.running = true
@@ -144,9 +148,9 @@ func (c *RaftCluster) syncRegions() {
 
 func (c *RaftCluster) stop() {
 	c.Lock()
-	defer c.Unlock()
 
 	if !c.running {
+		c.Unlock()
 		return
 	}
 
@@ -154,6 +158,7 @@ func (c *RaftCluster) stop() {
 
 	close(c.quit)
 	c.coordinator.stop()
+	c.Unlock()
 	c.wg.Wait()
 }
 

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -440,7 +440,7 @@ func (s *testClusterSuite) TestRaftClusterMultipleRestar(c *C) {
 	mustWaitLeader(c, []*Server{s.svr})
 	_, err = s.svr.bootstrapCluster(s.newBootstrapRequest(c, s.svr.clusterID, "127.0.0.1:0"))
 	c.Assert(err, IsNil)
-	// add a offline store
+	// add an offline store
 	store := s.newStore(c, s.allocID(c), "127.0.0.1:4")
 	store.State = metapb.StoreState_Offline
 	cluster := s.svr.GetRaftCluster()

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -18,9 +18,11 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	. "github.com/pingcap/check"
+	gofail "github.com/pingcap/gofail/runtime"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/pd/server/core"
@@ -427,6 +429,35 @@ func (s *testClusterSuite) TestRaftClusterRestart(c *C) {
 	cluster = svr.GetRaftCluster()
 	c.Assert(cluster, NotNil)
 	cluster.stop()
+}
+
+// Make sure PD will not deadlock if it start and stop again and again.
+func (s *testClusterSuite) TestRaftClusterMultipleRestar(c *C) {
+	var err error
+	_, s.svr, s.cleanup, err = NewTestServer()
+	defer s.cleanup()
+	c.Assert(err, IsNil)
+	mustWaitLeader(c, []*Server{s.svr})
+	_, err = s.svr.bootstrapCluster(s.newBootstrapRequest(c, s.svr.clusterID, "127.0.0.1:0"))
+	c.Assert(err, IsNil)
+	// add a offline store
+	store := s.newStore(c, s.allocID(c), "127.0.0.1:4")
+	store.State = metapb.StoreState_Offline
+	cluster := s.svr.GetRaftCluster()
+	err = cluster.putStore(store)
+	c.Assert(err, IsNil)
+	c.Assert(cluster, NotNil)
+
+	// let the job run at small interval
+	gofail.Enable("github.com/pingcap/pd/server/highFrequencyClusterJobs", `return(true)`)
+	for i := 0; i < 100; i++ {
+		err = s.svr.createRaftCluster()
+		c.Assert(err, IsNil)
+		time.Sleep(time.Millisecond)
+		cluster = s.svr.GetRaftCluster()
+		c.Assert(cluster, NotNil)
+		cluster.stop()
+	}
 }
 
 func (s *testClusterSuite) TestGetPDMembers(c *C) {


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
the `RaftCluster` probability can't stop cause by deadlock.
### What is changed and how it works?
fix the mutex usage.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test
 