### PR TITLE
server: check overlaps for new region

### DIFF
--- a/server/cluster_info.go
+++ b/server/cluster_info.go
@@ -462,6 +462,14 @@ func (c *clusterInfo) updateStoreStatusLocked(id uint64) {
 func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 	c.RLock()
 	origin := c.core.Regions.GetRegion(region.GetID())
+	if origin == nil {
+		for _, item := range c.core.Regions.GetOverlaps(region) {
+			if region.GetRegionEpoch().GetVersion() < item.GetRegionEpoch().GetVersion() {
+				c.RUnlock()
+				return ErrRegionIsStale(region.GetMeta(), nil)
+			}
+		}
+	}
 	isWriteUpdate, writeItem := c.core.CheckWriteStatus(region)
 	isReadUpdate, readItem := c.core.CheckReadStatus(region)
 	c.RUnlock()
@@ -472,11 +480,6 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 	var saveKV, saveCache, isNew bool
 	if origin == nil {
 		log.Debugf("[region %d] Insert new region {%v}", region.GetID(), core.HexRegionMeta(region.GetMeta()))
-		for _, item := range c.core.Regions.GetOverlaps(region) {
-			if region.GetRegionEpoch().GetVersion() < item.GetRegionEpoch().GetVersion() {
-				return ErrRegionIsStale(region.GetMeta(), nil)
-			}
-		}
 		saveKV, saveCache, isNew = true, true, true
 	} else {
 		r := region.GetRegionEpoch()

--- a/server/cluster_info.go
+++ b/server/cluster_info.go
@@ -472,6 +472,11 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 	var saveKV, saveCache, isNew bool
 	if origin == nil {
 		log.Debugf("[region %d] Insert new region {%v}", region.GetID(), core.HexRegionMeta(region.GetMeta()))
+		for _, item := range c.core.Regions.GetOverlaps(region) {
+			if region.GetRegionEpoch().GetVersion() < item.GetRegionEpoch().GetVersion() {
+				return ErrRegionIsStale(region.GetMeta(), nil)
+			}
+		}
 		saveKV, saveCache, isNew = true, true, true
 	} else {
 		r := region.GetRegionEpoch()

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -502,7 +502,7 @@ func NewRegionsInfo() *RegionsInfo {
 	}
 }
 
-// GetRegion return the RegionInfo with regionID
+// GetRegion returns the RegionInfo with regionID
 func (r *RegionsInfo) GetRegion(regionID uint64) *RegionInfo {
 	region := r.regions.Get(regionID)
 	if region == nil {
@@ -511,7 +511,7 @@ func (r *RegionsInfo) GetRegion(regionID uint64) *RegionInfo {
 	return region
 }
 
-// SetRegion set the RegionInfo with regionID
+// SetRegion sets the RegionInfo with regionID
 func (r *RegionsInfo) SetRegion(region *RegionInfo) []*metapb.Region {
 	if origin := r.regions.Get(region.GetID()); origin != nil {
 		r.RemoveRegion(origin)
@@ -519,17 +519,22 @@ func (r *RegionsInfo) SetRegion(region *RegionInfo) []*metapb.Region {
 	return r.AddRegion(region)
 }
 
-// Length return the RegionsInfo length
+// Length returns the RegionsInfo length
 func (r *RegionsInfo) Length() int {
 	return r.regions.Len()
 }
 
-// TreeLength return the RegionsInfo tree length(now only used in test)
+// TreeLength returns the RegionsInfo tree length(now only used in test)
 func (r *RegionsInfo) TreeLength() int {
 	return r.tree.length()
 }
 
-// AddRegion add RegionInfo to regionTree and regionMap, also update leadres and followers by region peers
+// GetOverlaps returns the regions which are overlapped with the specified region range.
+func (r *RegionsInfo) GetOverlaps(region *RegionInfo) []*metapb.Region {
+	return r.tree.getOverlaps(region.meta)
+}
+
+// AddRegion adds RegionInfo to regionTree and regionMap, also update leadres and followers by region peers
 func (r *RegionsInfo) AddRegion(region *RegionInfo) []*metapb.Region {
 	// Add to tree and regions.
 	overlaps := r.tree.update(region.meta)
@@ -585,7 +590,7 @@ func (r *RegionsInfo) AddRegion(region *RegionInfo) []*metapb.Region {
 	return overlaps
 }
 
-// RemoveRegion remove RegionInfo from regionTree and regionMap
+// RemoveRegion removes RegionInfo from regionTree and regionMap
 func (r *RegionsInfo) RemoveRegion(region *RegionInfo) {
 	// Remove from tree and regions.
 	r.tree.remove(region.meta)

--- a/server/core/region_option.go
+++ b/server/core/region_option.go
@@ -102,12 +102,32 @@ func WithIncVersion() RegionCreateOption {
 	}
 }
 
-// WithIncConfVer increase the config version of the region.
+// WithDecVersion decreases the version of the region.
+func WithDecVersion() RegionCreateOption {
+	return func(region *RegionInfo) {
+		e := region.meta.GetRegionEpoch()
+		if e != nil {
+			e.Version--
+		}
+	}
+}
+
+// WithIncConfVer increases the config version of the region.
 func WithIncConfVer() RegionCreateOption {
 	return func(region *RegionInfo) {
 		e := region.meta.GetRegionEpoch()
 		if e != nil {
 			e.ConfVer++
+		}
+	}
+}
+
+// WithDecConfVer decreases the config version of the region.
+func WithDecConfVer() RegionCreateOption {
+	return func(region *RegionInfo) {
+		e := region.meta.GetRegionEpoch()
+		if e != nil {
+			e.ConfVer--
 		}
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve? 
When a region is merged, and then PD receives a stale heartbeat of it for some kind of reasons. It may overlap with some regions and update region tree improperly. 

### What is changed and how it works?
When inserting a new region, check are there any overlapped regions and compare the version to decide whether the heartbeat is stale or not.

### Check List 
 - Unit test

Related changes
 - Need to be included in the release notes
