### PR TITLE
server: remove the disturbing log when store is tombstone

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -444,6 +444,11 @@ func (c *RaftCluster) BuryStore(storeID uint64, force bool) error { // revive:di
 		return core.NewStoreNotFoundErr(storeID)
 	}
 
+	// Bury a tombstone store should be OK, nothing to do.
+	if store.IsTombstone() {
+		return nil
+	}
+
 	if store.IsUp() {
 		if !force {
 			return errors.New("store is still up, please remove store gracefully")


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Currently, when there is tombstone store, it will print the log `[info] buried store id:x address:"xxx" state:Tombstone` every minute, which is kind of disturbing.

### What is changed and how it works?
This PR removes this unused log and makes some cleanup.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (`make test`)