### PR TITLE
*: add go mod tidy into Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ check-fail:
 	  $$($(PACKAGE_DIRECTORIES))
 	CGO_ENABLED=0 ./scripts/retool do gosec $$($(PACKAGE_DIRECTORIES))
 
-check-all: static lint
+check-all: static lint tidy
 	@echo "checking"
 
 retool-setup: export GO111MODULE=off
@@ -90,6 +90,11 @@ static:
 lint:
 	@echo "linting"
 	CGO_ENABLED=0 ./scripts/retool do revive -formatter friendly -config revive.toml $$($(PACKAGES))
+
+tidy:
+	@echo "go mod tidy"
+	GO111MODULE=on go mod tidy
+	git diff --quiet
 
 travis_coverage:
 ifeq ("$(TRAVIS_COVERAGE)", "1")
@@ -115,4 +120,4 @@ gofail-disable:
 	# Restoring gofail failpoints...
 	@$(GOFAIL_DISABLE)
 
-.PHONY: all ci vendor clean-test
+.PHONY: all ci vendor clean-test tidy


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
It's better to run `go mod tidy` before sending a PR. 

### What is changed and how it works?
This PR adds `go mod tidy` into `make check`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test