### PR TITLE
test: split integration tests into different packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ PD_PKG := github.com/pingcap/pd
 
 TEST_PKGS := $(shell find . -iname "*_test.go" -exec dirname {} \; | \
                      uniq | sed -e "s/^\./github.com\/pingcap\/pd/")
-BASIC_TEST_PKGS := $(filter-out github.com/pingcap/pd/pkg/integration_test,$(TEST_PKGS))
+INTEGRATION_TEST_PKGS := $(shell find . -iname "*_test.go" -exec dirname {} \; | \
+                     uniq | sed -e "s/^\./github.com\/pingcap\/pd/" | grep -E "tests")
+BASIC_TEST_PKGS := $(filter-out $(INTEGRATION_TEST_PKGS),$(TEST_PKGS))
 
 PACKAGES := go list ./...
 PACKAGE_DIRECTORIES := $(PACKAGES) | sed 's|github.com/pingcap/pd/||'
@@ -115,7 +117,7 @@ simulator:
 
 clean-test:
 	rm -rf /tmp/test_pd*
-	rm -rf /tmp/pd-integration-test*
+	rm -rf /tmp/pd-tests*
 	rm -rf /tmp/test_etcd*
 
 gofail-enable:

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -280,14 +280,14 @@ func (c *RaftCluster) GetMetaRegions() []*metapb.Region {
 	return c.cachedCluster.getMetaRegions()
 }
 
-// GetRegions returns all regions info in detail.
+// GetRegions returns all regions' information in detail.
 func (c *RaftCluster) GetRegions() []*core.RegionInfo {
 	c.RLock()
 	defer c.RUnlock()
 	return c.cachedCluster.getRegions()
 }
 
-// GetStoreRegions returns all regions info with a given storeID.
+// GetStoreRegions returns all regions' information with a given storeID.
 func (c *RaftCluster) GetStoreRegions(storeID uint64) []*core.RegionInfo {
 	c.RLock()
 	defer c.RUnlock()
@@ -330,7 +330,7 @@ func (c *RaftCluster) GetStore(storeID uint64) (*core.StoreInfo, error) {
 	return store, nil
 }
 
-// GetAdjacentRegions returns region's info that is adjacent with specific region id.
+// GetAdjacentRegions returns regions' information that are adjacent with the specific region ID.
 func (c *RaftCluster) GetAdjacentRegions(region *core.RegionInfo) (*core.RegionInfo, *core.RegionInfo) {
 	c.RLock()
 	defer c.RUnlock()

--- a/server/leader.go
+++ b/server/leader.go
@@ -30,7 +30,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// IsLeader returns whether server is leader or not.
+// IsLeader returns whether the server is leader or not.
 func (s *Server) IsLeader() bool {
 	// If server is not started. Both leaderID and ID could be 0.
 	return !s.isClosed() && s.GetLeaderID() == s.ID()
@@ -41,7 +41,7 @@ func (s *Server) GetLeaderID() uint64 {
 	return s.GetLeader().GetMemberId()
 }
 
-// GetLeader returns current leader of pd cluster.
+// GetLeader returns current leader of PD cluster.
 func (s *Server) GetLeader() *pdpb.Member {
 	leader := s.leader.Load()
 	if leader == nil {

--- a/server/server.go
+++ b/server/server.go
@@ -673,7 +673,7 @@ func (s *Server) getClusterRootPath() string {
 	return path.Join(s.rootPath, "raft")
 }
 
-// GetRaftCluster gets raft cluster.
+// GetRaftCluster gets Raft cluster.
 // If cluster has not been bootstrapped, return nil.
 func (s *Server) GetRaftCluster() *RaftCluster {
 	if s.isClosed() || !s.cluster.isRunning() {
@@ -755,7 +755,7 @@ func (s *Server) SetLogLevel(level string) {
 
 var healthURL = "/pd/ping"
 
-// CheckHealth checks if members are healthy
+// CheckHealth checks if members are healthy.
 func (s *Server) CheckHealth(members []*pdpb.Member) map[uint64]*pdpb.Member {
 	unhealthMembers := make(map[uint64]*pdpb.Member)
 	for _, member := range members {

--- a/tests/cmd/pdctl_test.go
+++ b/tests/cmd/pdctl_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package integration
+package cmd_test
 
 import (
 	"bytes"
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/coreos/go-semver/semver"
@@ -30,6 +31,7 @@ import (
 	"github.com/pingcap/pd/server"
 	"github.com/pingcap/pd/server/api"
 	"github.com/pingcap/pd/server/core"
+	"github.com/pingcap/pd/tests"
 	"github.com/pingcap/pd/tools/pd-ctl/pdctl"
 	"github.com/pingcap/pd/tools/pd-ctl/pdctl/command"
 	"github.com/spf13/cobra"
@@ -38,15 +40,27 @@ import (
 	_ "github.com/pingcap/pd/server/schedulers"
 )
 
-func (s *integrationTestSuite) TestCluster(c *C) {
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&cmdTestSuite{})
+
+type cmdTestSuite struct{}
+
+func (s *cmdTestSuite) SetUpSuite(c *C) {
+	server.EnableZap = true
+}
+
+func (s *cmdTestSuite) TestCluster(c *C) {
 	c.Parallel()
 
-	cluster, err := newTestCluster(1)
+	cluster, err := tests.NewTestCluster(1)
 	c.Assert(err, IsNil)
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.config.GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURLs()
 	cmd := initCommand()
 	defer cluster.Destroy()
 
@@ -66,15 +80,15 @@ func (s *integrationTestSuite) TestCluster(c *C) {
 	c.Assert(ci, DeepEquals, cluster.GetCluster())
 }
 
-func (s *integrationTestSuite) TestHealth(c *C) {
+func (s *cmdTestSuite) TestHealth(c *C) {
 	c.Parallel()
 
-	cluster, err := newTestCluster(3)
+	cluster, err := tests.NewTestCluster(3)
 	c.Assert(err, IsNil)
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.config.GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURLs()
 	cmd := initCommand()
 	defer cluster.Destroy()
 
@@ -106,15 +120,15 @@ func (s *integrationTestSuite) TestHealth(c *C) {
 	c.Assert(h, DeepEquals, healths)
 }
 
-func (s *integrationTestSuite) TestStore(c *C) {
+func (s *cmdTestSuite) TestStore(c *C) {
 	c.Parallel()
 
-	cluster, err := newTestCluster(1)
+	cluster, err := tests.NewTestCluster(1)
 	c.Assert(err, IsNil)
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.config.GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURLs()
 	cmd := initCommand()
 
 	stores := []*metapb.Store{
@@ -133,10 +147,10 @@ func (s *integrationTestSuite) TestStore(c *C) {
 	}
 
 	leaderServer := cluster.GetServer(cluster.GetLeader())
-	s.bootstrapCluster(leaderServer, c)
+	c.Assert(leaderServer.BootstrapCluster(), IsNil)
 
 	for _, store := range stores {
-		mustPutStore(c, leaderServer.server, store.Id, store.State, store.Labels)
+		mustPutStore(c, leaderServer.GetServer(), store.Id, store.State, store.Labels)
 	}
 	defer cluster.Destroy()
 
@@ -194,15 +208,15 @@ func (s *integrationTestSuite) TestStore(c *C) {
 	c.Assert(storeInfo.Store.State, Equals, metapb.StoreState_Offline)
 }
 
-func (s *integrationTestSuite) TestLabel(c *C) {
+func (s *cmdTestSuite) TestLabel(c *C) {
 	c.Parallel()
 
-	cluster, err := newTestCluster(1)
+	cluster, err := tests.NewTestCluster(1)
 	c.Assert(err, IsNil)
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.config.GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURLs()
 	cmd := initCommand()
 
 	stores := []*metapb.Store{
@@ -245,10 +259,10 @@ func (s *integrationTestSuite) TestLabel(c *C) {
 	}
 
 	leaderServer := cluster.GetServer(cluster.GetLeader())
-	s.bootstrapCluster(leaderServer, c)
+	c.Assert(leaderServer.BootstrapCluster(), IsNil)
 
 	for _, store := range stores {
-		mustPutStore(c, leaderServer.server, store.Id, store.State, store.Labels)
+		mustPutStore(c, leaderServer.GetServer(), store.Id, store.State, store.Labels)
 	}
 	defer cluster.Destroy()
 
@@ -286,7 +300,7 @@ func (s *integrationTestSuite) TestLabel(c *C) {
 	checkStoresInfo(c, storesInfo.Stores, ss)
 }
 
-func (s *integrationTestSuite) TestTSO(c *C) {
+func (s *cmdTestSuite) TestTSO(c *C) {
 	c.Parallel()
 	cmd := initCommand()
 
@@ -310,15 +324,15 @@ func (s *integrationTestSuite) TestTSO(c *C) {
 	c.Assert(str, Equals, string(output))
 }
 
-func (s *integrationTestSuite) TestScheduler(c *C) {
+func (s *cmdTestSuite) TestScheduler(c *C) {
 	c.Parallel()
 
-	cluster, err := newTestCluster(1)
+	cluster, err := tests.NewTestCluster(1)
 	c.Assert(err, IsNil)
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.config.GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURLs()
 	cmd := initCommand()
 
 	stores := []*metapb.Store{
@@ -341,9 +355,9 @@ func (s *integrationTestSuite) TestScheduler(c *C) {
 	}
 
 	leaderServer := cluster.GetServer(cluster.GetLeader())
-	s.bootstrapCluster(leaderServer, c)
+	c.Assert(leaderServer.BootstrapCluster(), IsNil)
 	for _, store := range stores {
-		mustPutStore(c, leaderServer.server, store.Id, store.State, store.Labels)
+		mustPutStore(c, leaderServer.GetServer(), store.Id, store.State, store.Labels)
 	}
 
 	mustPutRegion(c, cluster, 1, 1, []byte("a"), []byte("b"))
@@ -406,15 +420,15 @@ func (s *integrationTestSuite) TestScheduler(c *C) {
 	}
 }
 
-func (s *integrationTestSuite) TestRegion(c *C) {
+func (s *cmdTestSuite) TestRegion(c *C) {
 	c.Parallel()
 
-	cluster, err := newTestCluster(1)
+	cluster, err := tests.NewTestCluster(1)
 	c.Assert(err, IsNil)
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.config.GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURLs()
 	cmd := initCommand()
 
 	store := metapb.Store{
@@ -422,8 +436,8 @@ func (s *integrationTestSuite) TestRegion(c *C) {
 		State: metapb.StoreState_Up,
 	}
 	leaderServer := cluster.GetServer(cluster.GetLeader())
-	s.bootstrapCluster(leaderServer, c)
-	mustPutStore(c, leaderServer.server, store.Id, store.State, store.Labels)
+	c.Assert(leaderServer.BootstrapCluster(), IsNil)
+	mustPutStore(c, leaderServer.GetServer(), store.Id, store.State, store.Labels)
 
 	downPeer := &metapb.Peer{Id: 8, StoreId: 3}
 	r1 := mustPutRegion(c, cluster, 1, 1, []byte("a"), []byte("b"),
@@ -597,15 +611,15 @@ func (s *integrationTestSuite) TestRegion(c *C) {
 	checkRegionsInfo(c, regionsInfo, []*core.RegionInfo{r3, r4})
 }
 
-func (s *integrationTestSuite) TestConfig(c *C) {
+func (s *cmdTestSuite) TestConfig(c *C) {
 	c.Parallel()
 
-	cluster, err := newTestCluster(1)
+	cluster, err := tests.NewTestCluster(1)
 	c.Assert(err, IsNil)
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.config.GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURLs()
 	cmd := initCommand()
 
 	store := metapb.Store{
@@ -613,8 +627,9 @@ func (s *integrationTestSuite) TestConfig(c *C) {
 		State: metapb.StoreState_Up,
 	}
 	leaderServer := cluster.GetServer(cluster.GetLeader())
-	s.bootstrapCluster(leaderServer, c)
-	mustPutStore(c, leaderServer.server, store.Id, store.State, store.Labels)
+	c.Assert(leaderServer.BootstrapCluster(), IsNil)
+	svr := leaderServer.GetServer()
+	mustPutStore(c, svr, store.Id, store.State, store.Labels)
 	defer cluster.Destroy()
 
 	// config show
@@ -623,7 +638,7 @@ func (s *integrationTestSuite) TestConfig(c *C) {
 	c.Assert(err, IsNil)
 	scheduleCfg := server.ScheduleConfig{}
 	json.Unmarshal(output, &scheduleCfg)
-	c.Assert(&scheduleCfg, DeepEquals, leaderServer.server.GetScheduleConfig())
+	c.Assert(&scheduleCfg, DeepEquals, svr.GetScheduleConfig())
 
 	// config show replication
 	args = []string{"-u", pdAddr, "config", "show", "replication"}
@@ -631,7 +646,7 @@ func (s *integrationTestSuite) TestConfig(c *C) {
 	c.Assert(err, IsNil)
 	replicationCfg := server.ReplicationConfig{}
 	json.Unmarshal(output, &replicationCfg)
-	c.Assert(&replicationCfg, DeepEquals, leaderServer.server.GetReplicationConfig())
+	c.Assert(&replicationCfg, DeepEquals, svr.GetReplicationConfig())
 
 	// config show cluster-version
 	args1 := []string{"-u", pdAddr, "config", "show", "cluster-version"}
@@ -639,18 +654,18 @@ func (s *integrationTestSuite) TestConfig(c *C) {
 	c.Assert(err, IsNil)
 	clusterVersion := semver.Version{}
 	json.Unmarshal(output, &clusterVersion)
-	c.Assert(clusterVersion, DeepEquals, leaderServer.server.GetClusterVersion())
+	c.Assert(clusterVersion, DeepEquals, svr.GetClusterVersion())
 
 	// config set cluster-version <value>
 	args2 := []string{"-u", pdAddr, "config", "set", "cluster-version", "2.1.0-rc.5"}
 	_, _, err = executeCommandC(cmd, args2...)
 	c.Assert(err, IsNil)
-	c.Assert(clusterVersion, Not(DeepEquals), leaderServer.server.GetClusterVersion())
+	c.Assert(clusterVersion, Not(DeepEquals), svr.GetClusterVersion())
 	_, output, err = executeCommandC(cmd, args1...)
 	c.Assert(err, IsNil)
 	clusterVersion = semver.Version{}
 	json.Unmarshal(output, &clusterVersion)
-	c.Assert(clusterVersion, DeepEquals, leaderServer.server.GetClusterVersion())
+	c.Assert(clusterVersion, DeepEquals, svr.GetClusterVersion())
 
 	// config show namespace <name> && config set namespace <type> <key> <value>
 	args = []string{"-u", pdAddr, "table_ns", "create", "ts1"}
@@ -667,12 +682,12 @@ func (s *integrationTestSuite) TestConfig(c *C) {
 	args2 = []string{"-u", pdAddr, "config", "set", "namespace", "ts1", "region-schedule-limit", "128"}
 	_, _, err = executeCommandC(cmd, args2...)
 	c.Assert(err, IsNil)
-	c.Assert(namespaceCfg.RegionScheduleLimit, Not(Equals), leaderServer.server.GetNamespaceConfig("ts1").RegionScheduleLimit)
+	c.Assert(namespaceCfg.RegionScheduleLimit, Not(Equals), svr.GetNamespaceConfig("ts1").RegionScheduleLimit)
 	_, output, err = executeCommandC(cmd, args1...)
 	c.Assert(err, IsNil)
 	namespaceCfg = server.NamespaceConfig{}
 	json.Unmarshal(output, &namespaceCfg)
-	c.Assert(namespaceCfg.RegionScheduleLimit, Equals, leaderServer.server.GetNamespaceConfig("ts1").RegionScheduleLimit)
+	c.Assert(namespaceCfg.RegionScheduleLimit, Equals, svr.GetNamespaceConfig("ts1").RegionScheduleLimit)
 
 	// config delete namespace <name>
 	args3 := []string{"-u", pdAddr, "config", "delete", "namespace", "ts1"}
@@ -682,7 +697,7 @@ func (s *integrationTestSuite) TestConfig(c *C) {
 	c.Assert(err, IsNil)
 	namespaceCfg = server.NamespaceConfig{}
 	json.Unmarshal(output, &namespaceCfg)
-	c.Assert(namespaceCfg.RegionScheduleLimit, Not(Equals), leaderServer.server.GetNamespaceConfig("ts1").RegionScheduleLimit)
+	c.Assert(namespaceCfg.RegionScheduleLimit, Not(Equals), svr.GetNamespaceConfig("ts1").RegionScheduleLimit)
 
 	// config show label-property
 	args1 = []string{"-u", pdAddr, "config", "show", "label-property"}
@@ -690,29 +705,29 @@ func (s *integrationTestSuite) TestConfig(c *C) {
 	c.Assert(err, IsNil)
 	labelPropertyCfg := server.LabelPropertyConfig{}
 	json.Unmarshal(output, &labelPropertyCfg)
-	c.Assert(labelPropertyCfg, DeepEquals, leaderServer.server.GetLabelProperty())
+	c.Assert(labelPropertyCfg, DeepEquals, svr.GetLabelProperty())
 
 	// config set label-property <type> <key> <value>
 	args2 = []string{"-u", pdAddr, "config", "set", "label-property", "reject-leader", "zone", "cn"}
 	_, _, err = executeCommandC(cmd, args2...)
 	c.Assert(err, IsNil)
-	c.Assert(labelPropertyCfg, Not(DeepEquals), leaderServer.server.GetLabelProperty())
+	c.Assert(labelPropertyCfg, Not(DeepEquals), svr.GetLabelProperty())
 	_, output, err = executeCommandC(cmd, args1...)
 	c.Assert(err, IsNil)
 	labelPropertyCfg = server.LabelPropertyConfig{}
 	json.Unmarshal(output, &labelPropertyCfg)
-	c.Assert(labelPropertyCfg, DeepEquals, leaderServer.server.GetLabelProperty())
+	c.Assert(labelPropertyCfg, DeepEquals, svr.GetLabelProperty())
 
 	// config delete label-property <type> <key> <value>
 	args3 = []string{"-u", pdAddr, "config", "delete", "label-property", "reject-leader", "zone", "cn"}
 	_, _, err = executeCommandC(cmd, args3...)
 	c.Assert(err, IsNil)
-	c.Assert(labelPropertyCfg, Not(DeepEquals), leaderServer.server.GetLabelProperty())
+	c.Assert(labelPropertyCfg, Not(DeepEquals), svr.GetLabelProperty())
 	_, output, err = executeCommandC(cmd, args1...)
 	c.Assert(err, IsNil)
 	labelPropertyCfg = server.LabelPropertyConfig{}
 	json.Unmarshal(output, &labelPropertyCfg)
-	c.Assert(labelPropertyCfg, DeepEquals, leaderServer.server.GetLabelProperty())
+	c.Assert(labelPropertyCfg, DeepEquals, svr.GetLabelProperty())
 
 	// config set <option> <value>
 	args1 = []string{"-u", pdAddr, "config", "set", "leader-schedule-limit", "64"}
@@ -723,7 +738,7 @@ func (s *integrationTestSuite) TestConfig(c *C) {
 	c.Assert(err, IsNil)
 	scheduleCfg = server.ScheduleConfig{}
 	json.Unmarshal(output, &scheduleCfg)
-	c.Assert(scheduleCfg.LeaderScheduleLimit, Equals, leaderServer.server.GetScheduleConfig().LeaderScheduleLimit)
+	c.Assert(scheduleCfg.LeaderScheduleLimit, Equals, svr.GetScheduleConfig().LeaderScheduleLimit)
 	args1 = []string{"-u", pdAddr, "config", "set", "disable-raft-learner", "true"}
 	_, _, err = executeCommandC(cmd, args1...)
 	c.Assert(err, IsNil)
@@ -732,18 +747,18 @@ func (s *integrationTestSuite) TestConfig(c *C) {
 	c.Assert(err, IsNil)
 	scheduleCfg = server.ScheduleConfig{}
 	json.Unmarshal(output, &scheduleCfg)
-	c.Assert(scheduleCfg.DisableLearner, Equals, leaderServer.server.GetScheduleConfig().DisableLearner)
+	c.Assert(scheduleCfg.DisableLearner, Equals, svr.GetScheduleConfig().DisableLearner)
 }
 
-func (s *integrationTestSuite) TestLog(c *C) {
+func (s *cmdTestSuite) TestLog(c *C) {
 	c.Parallel()
 
-	cluster, err := newTestCluster(1)
+	cluster, err := tests.NewTestCluster(1)
 	c.Assert(err, IsNil)
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.config.GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURLs()
 	cmd := initCommand()
 
 	store := metapb.Store{
@@ -751,8 +766,9 @@ func (s *integrationTestSuite) TestLog(c *C) {
 		State: metapb.StoreState_Up,
 	}
 	leaderServer := cluster.GetServer(cluster.GetLeader())
-	s.bootstrapCluster(leaderServer, c)
-	mustPutStore(c, leaderServer.server, store.Id, store.State, store.Labels)
+	c.Assert(leaderServer.BootstrapCluster(), IsNil)
+	svr := leaderServer.GetServer()
+	mustPutStore(c, svr, store.Id, store.State, store.Labels)
 	defer cluster.Destroy()
 
 	var testCases = []struct {
@@ -785,19 +801,19 @@ func (s *integrationTestSuite) TestLog(c *C) {
 	for _, testCase := range testCases {
 		_, _, err = executeCommandC(cmd, testCase.cmd...)
 		c.Assert(err, IsNil)
-		c.Assert(leaderServer.server.GetConfig().Log.Level, Equals, testCase.expect)
+		c.Assert(svr.GetConfig().Log.Level, Equals, testCase.expect)
 	}
 }
 
-func (s *integrationTestSuite) TestTableNS(c *C) {
+func (s *cmdTestSuite) TestTableNS(c *C) {
 	c.Parallel()
 
-	cluster, err := newTestCluster(1)
+	cluster, err := tests.NewTestCluster(1)
 	c.Assert(err, IsNil)
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.config.GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURLs()
 	cmd := initCommand()
 
 	store := metapb.Store{
@@ -805,17 +821,18 @@ func (s *integrationTestSuite) TestTableNS(c *C) {
 		State: metapb.StoreState_Up,
 	}
 	leaderServer := cluster.GetServer(cluster.GetLeader())
-	s.bootstrapCluster(leaderServer, c)
-	mustPutStore(c, leaderServer.server, store.Id, store.State, store.Labels)
-	classifier := leaderServer.server.GetClassifier()
+	c.Assert(leaderServer.BootstrapCluster(), IsNil)
+	svr := leaderServer.GetServer()
+	mustPutStore(c, svr, store.Id, store.State, store.Labels)
+	classifier := svr.GetClassifier()
 	defer cluster.Destroy()
 
 	// table_ns create <namespace>
-	c.Assert(leaderServer.server.IsNamespaceExist("ts1"), IsFalse)
+	c.Assert(svr.IsNamespaceExist("ts1"), IsFalse)
 	args := []string{"-u", pdAddr, "table_ns", "create", "ts1"}
 	_, _, err = executeCommandC(cmd, args...)
 	c.Assert(err, IsNil)
-	c.Assert(leaderServer.server.IsNamespaceExist("ts1"), IsTrue)
+	c.Assert(svr.IsNamespaceExist("ts1"), IsTrue)
 
 	// table_ns add <name> <table_id>
 	args = []string{"-u", pdAddr, "table_ns", "add", "ts1", "1"}
@@ -854,16 +871,16 @@ func (s *integrationTestSuite) TestTableNS(c *C) {
 	c.Assert(classifier.IsStoreIDExist(1), IsFalse)
 }
 
-func (s *integrationTestSuite) TestOperator(c *C) {
+func (s *cmdTestSuite) TestOperator(c *C) {
 	c.Parallel()
 
 	var err error
-	cluster, err := newTestCluster(3, func(conf *server.Config) { conf.Replication.MaxReplicas = 2 })
+	cluster, err := tests.NewTestCluster(3, func(conf *server.Config) { conf.Replication.MaxReplicas = 2 })
 	c.Assert(err, IsNil)
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.config.GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURLs()
 	cmd := initCommand()
 
 	stores := []*metapb.Store{
@@ -882,9 +899,9 @@ func (s *integrationTestSuite) TestOperator(c *C) {
 	}
 
 	leaderServer := cluster.GetServer(cluster.GetLeader())
-	s.bootstrapCluster(leaderServer, c)
+	c.Assert(leaderServer.BootstrapCluster(), IsNil)
 	for _, store := range stores {
-		mustPutStore(c, leaderServer.server, store.Id, store.State, store.Labels)
+		mustPutStore(c, leaderServer.GetServer(), store.Id, store.State, store.Labels)
 	}
 
 	mustPutRegion(c, cluster, 1, 1, []byte("a"), []byte("b"), core.SetPeers([]*metapb.Peer{
@@ -1057,7 +1074,7 @@ func mustPutStore(c *C, svr *server.Server, id uint64, state metapb.StoreState, 
 	c.Assert(err, IsNil)
 }
 
-func mustPutRegion(c *C, cluster *testCluster, regionID, storeID uint64, start, end []byte, opts ...core.RegionCreateOption) *core.RegionInfo {
+func mustPutRegion(c *C, cluster *tests.TestCluster, regionID, storeID uint64, start, end []byte, opts ...core.RegionCreateOption) *core.RegionInfo {
 	leader := &metapb.Peer{
 		Id:      regionID,
 		StoreId: storeID,

--- a/tests/config.go
+++ b/tests/config.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package integration
+package tests
 
 import (
 	"fmt"
@@ -34,7 +34,7 @@ type serverConfig struct {
 }
 
 func newServerConfig(name string, cc *clusterConfig, join bool) *serverConfig {
-	tempDir, _ := ioutil.TempDir("/tmp", "pd-integration-test")
+	tempDir, _ := ioutil.TempDir("/tmp", "pd-tests")
 	return &serverConfig{
 		Name:          name,
 		DataDir:       tempDir,

--- a/tests/server/api_test.go
+++ b/tests/server/api_test.go
@@ -11,19 +11,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package integration
+package server_test
 
 import (
 	"net/http"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/pd/pkg/testutil"
+	"github.com/pingcap/pd/tests"
 )
 
-func (s *integrationTestSuite) TestReconnect(c *C) {
+func (s *serverTestSuite) TestReconnect(c *C) {
 	c.Parallel()
 
-	cluster, err := newTestCluster(3)
+	cluster, err := tests.NewTestCluster(3)
 	c.Assert(err, IsNil)
 	defer cluster.Destroy()
 
@@ -33,7 +34,7 @@ func (s *integrationTestSuite) TestReconnect(c *C) {
 	// Make connections to followers.
 	// Make sure they proxy requests to the leader.
 	leader := cluster.WaitLeader()
-	for name, s := range cluster.servers {
+	for name, s := range cluster.GetServers() {
 		if name != leader {
 			res, e := http.Get(s.GetConfig().AdvertiseClientUrls + "/pd/api/v1/version")
 			c.Assert(e, IsNil)
@@ -47,7 +48,7 @@ func (s *integrationTestSuite) TestReconnect(c *C) {
 	newLeader := cluster.WaitLeader()
 
 	// Make sure they proxy requests to the new leader.
-	for name, s := range cluster.servers {
+	for name, s := range cluster.GetServers() {
 		if name != leader {
 			testutil.WaitUntil(c, func(c *C) bool {
 				res, e := http.Get(s.GetConfig().AdvertiseClientUrls + "/pd/api/v1/version")
@@ -62,7 +63,7 @@ func (s *integrationTestSuite) TestReconnect(c *C) {
 	c.Assert(err, IsNil)
 
 	// Request will fail with no leader.
-	for name, s := range cluster.servers {
+	for name, s := range cluster.GetServers() {
 		if name != leader && name != newLeader {
 			testutil.WaitUntil(c, func(c *C) bool {
 				res, err := http.Get(s.GetConfig().AdvertiseClientUrls + "/pd/api/v1/version")

--- a/tests/server/join_test.go
+++ b/tests/server/join_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package integration
+package server_test
 
 import (
 	"context"
@@ -22,12 +22,13 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/pd/pkg/etcdutil"
 	"github.com/pingcap/pd/server"
+	"github.com/pingcap/pd/tests"
 )
 
-func (s *integrationTestSuite) TestSimpleJoin(c *C) {
+func (s *serverTestSuite) TestSimpleJoin(c *C) {
 	c.Parallel()
 
-	cluster, err := newTestCluster(1)
+	cluster, err := tests.NewTestCluster(1)
 	c.Assert(err, IsNil)
 	defer cluster.Destroy()
 
@@ -71,10 +72,10 @@ func (s *integrationTestSuite) TestSimpleJoin(c *C) {
 
 // A failed PD tries to join the previous cluster but it has been deleted
 // during its downtime.
-func (s *integrationTestSuite) TestFailedAndDeletedPDJoinsPreviousCluster(c *C) {
+func (s *serverTestSuite) TestFailedAndDeletedPDJoinsPreviousCluster(c *C) {
 	c.Parallel()
 
-	cluster, err := newTestCluster(3)
+	cluster, err := tests.NewTestCluster(3)
 	c.Assert(err, IsNil)
 	defer cluster.Destroy()
 
@@ -107,10 +108,10 @@ func (s *integrationTestSuite) TestFailedAndDeletedPDJoinsPreviousCluster(c *C) 
 }
 
 // A deleted PD joins the previous cluster.
-func (s *integrationTestSuite) TestDeletedPDJoinsPreviousCluster(c *C) {
+func (s *serverTestSuite) TestDeletedPDJoinsPreviousCluster(c *C) {
 	c.Parallel()
 
-	cluster, err := newTestCluster(3)
+	cluster, err := tests.NewTestCluster(3)
 	c.Assert(err, IsNil)
 	defer cluster.Destroy()
 
@@ -142,10 +143,10 @@ func (s *integrationTestSuite) TestDeletedPDJoinsPreviousCluster(c *C) {
 	c.Assert(members.Members, HasLen, 2)
 }
 
-func (s *integrationTestSuite) TestFailedPDJoinsPreviousCluster(c *C) {
+func (s *serverTestSuite) TestFailedPDJoinsPreviousCluster(c *C) {
 	c.Parallel()
 
-	cluster, err := newTestCluster(1)
+	cluster, err := tests.NewTestCluster(1)
 	c.Assert(err, IsNil)
 	defer cluster.Destroy()
 

--- a/tests/server/leader_watch_test.go
+++ b/tests/server/leader_watch_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package integration
+package server_test
 
 import (
 	"context"
@@ -21,11 +21,12 @@ import (
 	gofail "github.com/pingcap/gofail/runtime"
 	"github.com/pingcap/pd/pkg/testutil"
 	"github.com/pingcap/pd/server"
+	"github.com/pingcap/pd/tests"
 )
 
-func (s *integrationTestSuite) TestWatcher(c *C) {
+func (s *serverTestSuite) TestWatcher(c *C) {
 	c.Parallel()
-	cluster, err := newTestCluster(1)
+	cluster, err := tests.NewTestCluster(1)
 	c.Assert(err, IsNil)
 	defer cluster.Destroy()
 
@@ -59,9 +60,9 @@ func (s *integrationTestSuite) TestWatcher(c *C) {
 	c.Succeed()
 }
 
-func (s *integrationTestSuite) TestWatcherCompacted(c *C) {
+func (s *serverTestSuite) TestWatcherCompacted(c *C) {
 	c.Parallel()
-	cluster, err := newTestCluster(1, func(conf *server.Config) { conf.AutoCompactionRetention = "1s" })
+	cluster, err := tests.NewTestCluster(1, func(conf *server.Config) { conf.AutoCompactionRetention = "1s" })
 	c.Assert(err, IsNil)
 	defer cluster.Destroy()
 

--- a/tests/server/member_test.go
+++ b/tests/server/member_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package integration
+package server_test
 
 import (
 	"bytes"
@@ -25,13 +25,14 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/pd/pkg/testutil"
 	"github.com/pingcap/pd/server"
+	"github.com/pingcap/pd/tests"
 	"github.com/pkg/errors"
 )
 
-func (s *integrationTestSuite) TestMemberDelete(c *C) {
+func (s *serverTestSuite) TestMemberDelete(c *C) {
 	c.Parallel()
 
-	cluster, err := newTestCluster(3)
+	cluster, err := tests.NewTestCluster(3)
 	c.Assert(err, IsNil)
 	defer cluster.Destroy()
 
@@ -40,8 +41,8 @@ func (s *integrationTestSuite) TestMemberDelete(c *C) {
 	leaderName := cluster.WaitLeader()
 	c.Assert(leaderName, Not(Equals), "")
 	leader := cluster.GetServer(leaderName)
-	var members []*testServer
-	for _, s := range cluster.config.InitialServers {
+	var members []*tests.TestServer
+	for _, s := range cluster.GetConfig().InitialServers {
 		if s.Name != leaderName {
 			members = append(members, cluster.GetServer(s.Name))
 		}
@@ -89,7 +90,7 @@ func (s *integrationTestSuite) TestMemberDelete(c *C) {
 	}
 }
 
-func (s *integrationTestSuite) checkMemberList(c *C, clientURL string, configs []*server.Config) error {
+func (s *serverTestSuite) checkMemberList(c *C, clientURL string, configs []*server.Config) error {
 	httpClient := &http.Client{Timeout: 15 * time.Second}
 	addr := clientURL + "/pd/api/v1/members"
 	res, err := httpClient.Get(addr)
@@ -116,10 +117,10 @@ func (s *integrationTestSuite) checkMemberList(c *C, clientURL string, configs [
 	return nil
 }
 
-func (s *integrationTestSuite) TestLeaderPriority(c *C) {
+func (s *serverTestSuite) TestLeaderPriority(c *C) {
 	c.Parallel()
 
-	cluster, err := newTestCluster(3)
+	cluster, err := tests.NewTestCluster(3)
 	c.Assert(err, IsNil)
 	defer cluster.Destroy()
 
@@ -146,7 +147,7 @@ func (s *integrationTestSuite) TestLeaderPriority(c *C) {
 	})
 }
 
-func (s *integrationTestSuite) post(c *C, url string, body string) {
+func (s *serverTestSuite) post(c *C, url string, body string) {
 	testutil.WaitUntil(c, func(c *C) bool {
 		res, err := http.Post(url, "", bytes.NewBufferString(body))
 		c.Assert(err, IsNil)
@@ -158,7 +159,7 @@ func (s *integrationTestSuite) post(c *C, url string, body string) {
 	})
 }
 
-func (s *integrationTestSuite) waitEtcdLeaderChange(c *C, server *testServer, old string) string {
+func (s *serverTestSuite) waitEtcdLeaderChange(c *C, server *tests.TestServer, old string) string {
 	var leader string
 	testutil.WaitUntil(c, func(c *C) bool {
 		var err error
@@ -175,10 +176,10 @@ func (s *integrationTestSuite) waitEtcdLeaderChange(c *C, server *testServer, ol
 	return leader
 }
 
-func (s *integrationTestSuite) TestLeaderResign(c *C) {
+func (s *serverTestSuite) TestLeaderResign(c *C) {
 	c.Parallel()
 
-	cluster, err := newTestCluster(3)
+	cluster, err := tests.NewTestCluster(3)
 	c.Assert(err, IsNil)
 	defer cluster.Destroy()
 
@@ -197,7 +198,7 @@ func (s *integrationTestSuite) TestLeaderResign(c *C) {
 	c.Assert(leader3, Equals, leader1)
 }
 
-func (s *integrationTestSuite) waitLeaderChange(c *C, cluster *testCluster, old string) string {
+func (s *serverTestSuite) waitLeaderChange(c *C, cluster *tests.TestCluster, old string) string {
 	var leader string
 	testutil.WaitUntil(c, func(c *C) bool {
 		leader = cluster.GetLeader()

--- a/tests/server/region_syncer_test.go
+++ b/tests/server/region_syncer_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package integration
+package server_test
 
 import (
 	"time"
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pingcap/pd/server"
 	"github.com/pingcap/pd/server/core"
+	"github.com/pingcap/pd/tests"
 )
 
 type idAllocator struct {
@@ -32,9 +33,9 @@ func (alloc *idAllocator) Alloc() uint64 {
 	return alloc.id
 }
 
-func (s *integrationTestSuite) TestRegionSyncer(c *C) {
+func (s *serverTestSuite) TestRegionSyncer(c *C) {
 	c.Parallel()
-	cluster, err := newTestCluster(3, func(conf *server.Config) { conf.PDServerCfg.UseRegionStorage = true })
+	cluster, err := tests.NewTestCluster(3, func(conf *server.Config) { conf.PDServerCfg.UseRegionStorage = true })
 	c.Assert(err, IsNil)
 	defer cluster.Destroy()
 
@@ -42,8 +43,8 @@ func (s *integrationTestSuite) TestRegionSyncer(c *C) {
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
 	leaderServer := cluster.GetServer(cluster.GetLeader())
-	s.bootstrapCluster(leaderServer, c)
-	rc := leaderServer.server.GetRaftCluster()
+	c.Assert(leaderServer.BootstrapCluster(), IsNil)
+	rc := leaderServer.GetServer().GetRaftCluster()
 	c.Assert(rc, NotNil)
 	regionLen := 110
 	id := &idAllocator{}
@@ -72,6 +73,6 @@ func (s *integrationTestSuite) TestRegionSyncer(c *C) {
 	cluster.WaitLeader()
 	leaderServer = cluster.GetServer(cluster.GetLeader())
 	c.Assert(leaderServer, NotNil)
-	loadRegions := leaderServer.server.GetRaftCluster().GetRegions()
+	loadRegions := leaderServer.GetServer().GetRaftCluster().GetRegions()
 	c.Assert(len(loadRegions), Equals, regionLen)
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Currently, the tests in `pkg/integration_test` often fail since the port has been used. The more test cases we have, the easier the test is to fail.

### What is changed and how it works?
This PR divides these tests into different packages in order to utilize our `jenkins` CI to speed up the tests and avoid port conflicts.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/pd/1391)
<!-- Reviewable:end -->
