### PR TITLE
server: return nil when server is closed

### DIFF
--- a/server/leader.go
+++ b/server/leader.go
@@ -284,7 +284,9 @@ func (s *Server) campaignLeader() error {
 				return nil
 			}
 		case <-ctx.Done():
-			return errors.New("server closed")
+			// Server is closed and it should return nil.
+			log.Info("server is closed")
+			return nil
 		}
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Currently, when we stop PD, it will print the error stack which is confused even if there is only one PD.
```
2018/12/26 05:10:45.332 leader.go:116: [error] campaign leader err server closed
github.com/pingcap/pd/server.(*Server).campaignLeader
	/.../pd/server/leader.go:287
github.com/pingcap/pd/server.(*Server).leaderLoop
	/.../pd/server/leader.go:115
runtime.goexit
	/usr/local/go1.11.1/src/runtime/asm_amd64.s:1333
```

### What is changed and how it works?
This PR fixes this problem. It will returns nil rather than an error when the server is closed in `campaignLeader`'s loop.

Tests <!-- At least one of them must be included. -->

 - Manual test