### PR TITLE
server/leader: use the compact revision to watch leader (#1396)

### DIFF
--- a/pkg/integration_test/leader_watch_test.go
+++ b/pkg/integration_test/leader_watch_test.go
@@ -25,7 +25,7 @@ import (
 
 func (s *integrationTestSuite) TestWatcher(c *C) {
 	c.Parallel()
-	cluster, err := newTestCluster(1)
+	cluster, err := newTestCluster(1, func(conf *server.Config) { conf.AutoCompactionRetention = "1s" })
 	c.Assert(err, IsNil)
 	defer cluster.Destroy()
 


### PR DESCRIPTION
* server/leader: use the compact revision to watch leader


<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Cherry pick #1396  to 2.1 branch.