### PR TITLE
make some region_command support jq

### DIFF
--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -48,7 +48,7 @@ var (
 // NewRegionCommand returns a region subcommand of rootCmd
 func NewRegionCommand() *cobra.Command {
 	r := &cobra.Command{
-		Use:   `region <region_id> [--jq="<query string>"]`,
+		Use:   `region <region_id> [-jq="<query string>"]`,
 		Short: "show the region status",
 		Run:   showRegionCommandFunc,
 	}
@@ -71,6 +71,7 @@ func NewRegionCommand() *cobra.Command {
 		Short: "show regions with top write flow",
 		Run:   showRegionTopWriteCommandFunc,
 	}
+	topWrite.Flags().String("jq", "", "jq query")
 	r.AddCommand(topWrite)
 
 	topConfVer := &cobra.Command{
@@ -78,6 +79,7 @@ func NewRegionCommand() *cobra.Command {
 		Short: "show regions with top conf version",
 		Run:   showRegionTopConfVerCommandFunc,
 	}
+	topConfVer.Flags().String("jq", "", "jq query")
 	r.AddCommand(topConfVer)
 
 	topVersion := &cobra.Command{
@@ -85,6 +87,7 @@ func NewRegionCommand() *cobra.Command {
 		Short: "show regions with top version",
 		Run:   showRegionTopVersionCommandFunc,
 	}
+	topVersion.Flags().String("jq", "", "jq query")
 	r.AddCommand(topVersion)
 
 	topSize := &cobra.Command{
@@ -92,6 +95,7 @@ func NewRegionCommand() *cobra.Command {
 		Short: "show regions with top size",
 		Run:   showRegionTopSizeCommandFunc,
 	}
+	topSize.Flags().String("jq", "", "jq query")
 	r.AddCommand(topSize)
 
 	scanRegion := &cobra.Command{
@@ -102,7 +106,7 @@ func NewRegionCommand() *cobra.Command {
 	scanRegion.Flags().String("jq", "", "jq query")
 	r.AddCommand(scanRegion)
 
-	//r.Flags().String("jq", "", "jq query")
+	r.Flags().String("jq", "", "jq query")
 
 	return r
 }

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -48,7 +48,7 @@ var (
 // NewRegionCommand returns a region subcommand of rootCmd
 func NewRegionCommand() *cobra.Command {
 	r := &cobra.Command{
-		Use:   `region <region_id> [-jq="<query string>"]`,
+		Use:   `region <region_id> [--jq="<query string>"]`,
 		Short: "show the region status",
 		Run:   showRegionCommandFunc,
 	}
@@ -59,49 +59,50 @@ func NewRegionCommand() *cobra.Command {
 	r.AddCommand(NewRegionsWithStartKeyCommand())
 
 	topRead := &cobra.Command{
-		Use:   "topread <limit>",
+		Use:   `topread <limit> [--jq="<query string>"]`,
 		Short: "show regions with top read flow",
 		Run:   showRegionTopReadCommandFunc,
 	}
+	topRead.Flags().String("jq", "", "jq query")
 	r.AddCommand(topRead)
 
 	topWrite := &cobra.Command{
-		Use:   "topwrite <limit>",
+		Use:   `topwrite <limit> [--jq="<query string>"]`,
 		Short: "show regions with top write flow",
 		Run:   showRegionTopWriteCommandFunc,
 	}
 	r.AddCommand(topWrite)
 
 	topConfVer := &cobra.Command{
-		Use:   "topconfver <limit>",
+		Use:   `topconfver <limit> [--jq="<query string>"]`,
 		Short: "show regions with top conf version",
 		Run:   showRegionTopConfVerCommandFunc,
 	}
 	r.AddCommand(topConfVer)
 
 	topVersion := &cobra.Command{
-		Use:   "topversion <limit>",
+		Use:   `topversion <limit> [--jq="<query string>"]`,
 		Short: "show regions with top version",
 		Run:   showRegionTopVersionCommandFunc,
 	}
 	r.AddCommand(topVersion)
 
 	topSize := &cobra.Command{
-		Use:   "topsize <limit>",
+		Use:   `topsize <limit> [--jq="<query string>"]`,
 		Short: "show regions with top size",
 		Run:   showRegionTopSizeCommandFunc,
 	}
 	r.AddCommand(topSize)
 
 	scanRegion := &cobra.Command{
-		Use:   `scan [-jq="<query string>"]`,
+		Use:   `scan [--jq="<query string>"]`,
 		Short: "scan all regions",
 		Run:   scanRegionCommandFunc,
 	}
 	scanRegion.Flags().String("jq", "", "jq query")
 	r.AddCommand(scanRegion)
 
-	r.Flags().String("jq", "", "jq query")
+	//r.Flags().String("jq", "", "jq query")
 
 	return r
 }
@@ -188,6 +189,10 @@ func showRegionTopWriteCommandFunc(cmd *cobra.Command, args []string) {
 		cmd.Printf("Failed to get regions: %s\n", err)
 		return
 	}
+	if flag := cmd.Flag("jq"); flag != nil && flag.Value.String() != "" {
+		printWithJQFilter(r, flag.Value.String())
+		return
+	}
 	cmd.Println(r)
 }
 
@@ -203,6 +208,10 @@ func showRegionTopReadCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
 		cmd.Printf("Failed to get regions: %s\n", err)
+		return
+	}
+	if flag := cmd.Flag("jq"); flag != nil && flag.Value.String() != "" {
+		printWithJQFilter(r, flag.Value.String())
 		return
 	}
 	cmd.Println(r)
@@ -222,6 +231,10 @@ func showRegionTopConfVerCommandFunc(cmd *cobra.Command, args []string) {
 		cmd.Printf("Failed to get regions: %s\n", err)
 		return
 	}
+	if flag := cmd.Flag("jq"); flag != nil && flag.Value.String() != "" {
+		printWithJQFilter(r, flag.Value.String())
+		return
+	}
 	cmd.Println(r)
 }
 
@@ -239,6 +252,10 @@ func showRegionTopVersionCommandFunc(cmd *cobra.Command, args []string) {
 		cmd.Printf("Failed to get regions: %s\n", err)
 		return
 	}
+	if flag := cmd.Flag("jq"); flag != nil && flag.Value.String() != "" {
+		printWithJQFilter(r, flag.Value.String())
+		return
+	}
 	cmd.Println(r)
 }
 
@@ -254,6 +271,10 @@ func showRegionTopSizeCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
 		cmd.Printf("Failed to get regions: %s\n", err)
+		return
+	}
+	if flag := cmd.Flag("jq"); flag != nil && flag.Value.String() != "" {
+		printWithJQFilter(r, flag.Value.String())
 		return
 	}
 	cmd.Println(r)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
make some region_command, such as `region topwrite` support `--jq`.

Tests <!-- At least one of them must be included. -->
 - Manual test 


Side effects

> bin/pd-ctl -u http://10.136.133.23:2379 -d region topwrite 1 --jq=".regions[] | {start_key: .start_key, end_key: .end_key, peer_stores: [.peers[].store_id], leader:.leader.store_id, id: .id, written_bytes: .written_bytes}"
unknown flag: --jq
{"start_key":"fm_bench_mark_user:-1254349631","end_key":"fm_bench_mark_user:-1256054961","peer_stores":[17,8,1],"leader":17,"id":86367,"written_bytes":28664496}

See above, it ouputs unexpected message "unknown flag: --jq".

