### PR TITLE
*: use address instead of storeID for metrics

### DIFF
--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -15,7 +15,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -303,17 +302,17 @@ func (c *coordinator) collectHotSpotMetrics() {
 	stores := c.cluster.GetStores()
 	status := s.Scheduler.(hasHotStatus).GetHotWriteStatus()
 	for _, s := range stores {
-		store := fmt.Sprintf("store_%d", s.GetID())
+		storeAddress := s.GetAddress()
 		stat, ok := status.AsPeer[s.GetID()]
 		if ok {
 			totalWriteBytes := float64(stat.TotalFlowBytes)
 			hotWriteRegionCount := float64(stat.RegionsCount)
 
-			hotSpotStatusGauge.WithLabelValues(store, "total_written_bytes_as_peer").Set(totalWriteBytes)
-			hotSpotStatusGauge.WithLabelValues(store, "hot_write_region_as_peer").Set(hotWriteRegionCount)
+			hotSpotStatusGauge.WithLabelValues(storeAddress, "total_written_bytes_as_peer").Set(totalWriteBytes)
+			hotSpotStatusGauge.WithLabelValues(storeAddress, "hot_write_region_as_peer").Set(hotWriteRegionCount)
 		} else {
-			hotSpotStatusGauge.WithLabelValues(store, "total_written_bytes_as_peer").Set(0)
-			hotSpotStatusGauge.WithLabelValues(store, "hot_write_region_as_peer").Set(0)
+			hotSpotStatusGauge.WithLabelValues(storeAddress, "total_written_bytes_as_peer").Set(0)
+			hotSpotStatusGauge.WithLabelValues(storeAddress, "hot_write_region_as_peer").Set(0)
 		}
 
 		stat, ok = status.AsLeader[s.GetID()]
@@ -321,28 +320,28 @@ func (c *coordinator) collectHotSpotMetrics() {
 			totalWriteBytes := float64(stat.TotalFlowBytes)
 			hotWriteRegionCount := float64(stat.RegionsCount)
 
-			hotSpotStatusGauge.WithLabelValues(store, "total_written_bytes_as_leader").Set(totalWriteBytes)
-			hotSpotStatusGauge.WithLabelValues(store, "hot_write_region_as_leader").Set(hotWriteRegionCount)
+			hotSpotStatusGauge.WithLabelValues(storeAddress, "total_written_bytes_as_leader").Set(totalWriteBytes)
+			hotSpotStatusGauge.WithLabelValues(storeAddress, "hot_write_region_as_leader").Set(hotWriteRegionCount)
 		} else {
-			hotSpotStatusGauge.WithLabelValues(store, "total_written_bytes_as_leader").Set(0)
-			hotSpotStatusGauge.WithLabelValues(store, "hot_write_region_as_leader").Set(0)
+			hotSpotStatusGauge.WithLabelValues(storeAddress, "total_written_bytes_as_leader").Set(0)
+			hotSpotStatusGauge.WithLabelValues(storeAddress, "hot_write_region_as_leader").Set(0)
 		}
 	}
 
 	// Collects hot read region metrics.
 	status = s.Scheduler.(hasHotStatus).GetHotReadStatus()
 	for _, s := range stores {
-		store := fmt.Sprintf("store_%d", s.GetID())
+		storeAddress := s.GetAddress()
 		stat, ok := status.AsLeader[s.GetID()]
 		if ok {
 			totalReadBytes := float64(stat.TotalFlowBytes)
 			hotReadRegionCount := float64(stat.RegionsCount)
 
-			hotSpotStatusGauge.WithLabelValues(store, "total_read_bytes_as_leader").Set(totalReadBytes)
-			hotSpotStatusGauge.WithLabelValues(store, "hot_read_region_as_leader").Set(hotReadRegionCount)
+			hotSpotStatusGauge.WithLabelValues(storeAddress, "total_read_bytes_as_leader").Set(totalReadBytes)
+			hotSpotStatusGauge.WithLabelValues(storeAddress, "hot_read_region_as_leader").Set(hotReadRegionCount)
 		} else {
-			hotSpotStatusGauge.WithLabelValues(store, "total_read_bytes_as_leader").Set(0)
-			hotSpotStatusGauge.WithLabelValues(store, "hot_read_region_as_leader").Set(0)
+			hotSpotStatusGauge.WithLabelValues(storeAddress, "total_read_bytes_as_leader").Set(0)
+			hotSpotStatusGauge.WithLabelValues(storeAddress, "hot_read_region_as_leader").Set(0)
 		}
 	}
 

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -513,7 +513,7 @@ func (s *testCoordinatorSuite) TestShouldRunWithNonLeaderRegions(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID())
+	hbStreams := getHeartBeatStreams(c, tc)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -144,7 +144,7 @@ func (s *testCoordinatorSuite) TestBasic(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.clusterInfo.getClusterID())
+	hbStreams := newHeartbeatStreams(tc.clusterInfo.getClusterID(), tc.kv, tc.clusterInfo)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -201,7 +201,7 @@ func (s *testCoordinatorSuite) TestDispatch(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID())
+	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -266,7 +266,7 @@ func (s *testCoordinatorSuite) TestCollectMetrics(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID())
+	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -291,7 +291,7 @@ func (s *testCoordinatorSuite) TestCheckRegion(c *C) {
 	c.Assert(err, IsNil)
 	cfg.DisableLearner = false
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID())
+	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -350,7 +350,7 @@ func (s *testCoordinatorSuite) TestReplica(c *C) {
 	cfg.RegionScheduleLimit = 0
 
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID())
+	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -413,7 +413,7 @@ func (s *testCoordinatorSuite) TestPeerState(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID())
+	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -463,7 +463,7 @@ func (s *testCoordinatorSuite) TestShouldRun(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID())
+	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -562,7 +562,7 @@ func (s *testCoordinatorSuite) TestAddScheduler(c *C) {
 	cfg.ReplicaScheduleLimit = 0
 
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID())
+	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
 	defer hbStreams.Close()
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
 	co.run()
@@ -621,7 +621,7 @@ func (s *testCoordinatorSuite) TestPersistScheduler(c *C) {
 	cfg.ReplicaScheduleLimit = 0
 
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID())
+	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -715,7 +715,7 @@ func (s *testCoordinatorSuite) TestRestart(c *C) {
 	cfg.RegionScheduleLimit = 0
 
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID())
+	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
 	defer hbStreams.Close()
 
 	// Add 3 stores (1, 2, 3) and a region with 1 replica on store 1.
@@ -810,7 +810,7 @@ func (s *testScheduleControllerSuite) TestController(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID())
+	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
 	defer hbStreams.Close()
 
 	c.Assert(tc.addLeaderRegion(1, 1), IsNil)
@@ -888,7 +888,7 @@ func (s *testScheduleControllerSuite) TestInterval(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID())
+	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -16,6 +16,7 @@ package server
 import (
 	"fmt"
 	"math/rand"
+	"path/filepath"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -144,7 +145,7 @@ func (s *testCoordinatorSuite) TestBasic(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.clusterInfo.getClusterID(), tc.kv, tc.clusterInfo)
+	hbStreams := getHeartBeatStreams(c, tc)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -201,7 +202,7 @@ func (s *testCoordinatorSuite) TestDispatch(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
+	hbStreams := getHeartBeatStreams(c, tc)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -266,7 +267,7 @@ func (s *testCoordinatorSuite) TestCollectMetrics(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
+	hbStreams := getHeartBeatStreams(c, tc)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -291,7 +292,7 @@ func (s *testCoordinatorSuite) TestCheckRegion(c *C) {
 	c.Assert(err, IsNil)
 	cfg.DisableLearner = false
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
+	hbStreams := getHeartBeatStreams(c, tc)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -350,7 +351,7 @@ func (s *testCoordinatorSuite) TestReplica(c *C) {
 	cfg.RegionScheduleLimit = 0
 
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
+	hbStreams := getHeartBeatStreams(c, tc)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -413,7 +414,7 @@ func (s *testCoordinatorSuite) TestPeerState(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
+	hbStreams := getHeartBeatStreams(c, tc)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -463,7 +464,7 @@ func (s *testCoordinatorSuite) TestShouldRun(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
+	hbStreams := getHeartBeatStreams(c, tc)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -562,7 +563,7 @@ func (s *testCoordinatorSuite) TestAddScheduler(c *C) {
 	cfg.ReplicaScheduleLimit = 0
 
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
+	hbStreams := getHeartBeatStreams(c, tc)
 	defer hbStreams.Close()
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
 	co.run()
@@ -621,7 +622,7 @@ func (s *testCoordinatorSuite) TestPersistScheduler(c *C) {
 	cfg.ReplicaScheduleLimit = 0
 
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
+	hbStreams := getHeartBeatStreams(c, tc)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -715,7 +716,7 @@ func (s *testCoordinatorSuite) TestRestart(c *C) {
 	cfg.RegionScheduleLimit = 0
 
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
+	hbStreams := getHeartBeatStreams(c, tc)
 	defer hbStreams.Close()
 
 	// Add 3 stores (1, 2, 3) and a region with 1 replica on store 1.
@@ -810,7 +811,7 @@ func (s *testScheduleControllerSuite) TestController(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
+	hbStreams := getHeartBeatStreams(c, tc)
 	defer hbStreams.Close()
 
 	c.Assert(tc.addLeaderRegion(1, 1), IsNil)
@@ -888,7 +889,7 @@ func (s *testScheduleControllerSuite) TestInterval(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestClusterInfo(opt)
-	hbStreams := newHeartbeatStreams(tc.getClusterID(), tc.kv, tc.clusterInfo)
+	hbStreams := getHeartBeatStreams(c, tc)
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.clusterInfo, hbStreams, namespace.DefaultClassifier)
@@ -974,4 +975,19 @@ func waitNoResponse(c *C, stream *mockHeartbeatStream) {
 		res := stream.Recv()
 		return res == nil
 	})
+}
+
+func getHeartBeatStreams(c *C, tc *testClusterInfo) *heartbeatStreams {
+	config := NewTestSingleConfig(c)
+	svr, err := CreateServer(config, nil)
+	c.Assert(err, IsNil)
+	kvBase := newEtcdKVBase(svr)
+	path := filepath.Join(svr.cfg.DataDir, "region-meta")
+	regionKV, err := core.NewRegionKV(path)
+	c.Assert(err, IsNil)
+	svr.kv = core.NewKV(kvBase).SetRegionKV(regionKV)
+	cluster := newRaftCluster(svr, tc.getClusterID())
+	cluster.cachedCluster = tc.clusterInfo
+	hbStreams := newHeartbeatStreams(tc.getClusterID(), cluster)
+	return hbStreams
 }

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -347,17 +346,21 @@ func (s *Server) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error {
 		}
 
 		storeID := request.GetLeader().GetStoreId()
-		storeLabel := strconv.FormatUint(storeID, 10)
+		store, err := cluster.GetStore(storeID)
+		if err != nil {
+			return err
+		}
+		storeAddress := store.GetAddress()
 
-		regionHeartbeatCounter.WithLabelValues(storeLabel, "report", "recv").Inc()
-		regionHeartbeatLatency.WithLabelValues(storeLabel).Observe(float64(time.Now().Unix()) - float64(request.GetInterval().GetEndTimestamp()))
+		regionHeartbeatCounter.WithLabelValues(storeAddress, "report", "recv").Inc()
+		regionHeartbeatLatency.WithLabelValues(storeAddress).Observe(float64(time.Now().Unix()) - float64(request.GetInterval().GetEndTimestamp()))
 
 		cluster.RLock()
 		hbStreams := cluster.coordinator.hbStreams
 		cluster.RUnlock()
 
 		if time.Since(lastBind) > s.cfg.heartbeatStreamBindInterval.Duration {
-			regionHeartbeatCounter.WithLabelValues(storeLabel, "report", "bind").Inc()
+			regionHeartbeatCounter.WithLabelValues(storeAddress, "report", "bind").Inc()
 			hbStreams.bindStream(storeID, server)
 			lastBind = time.Now()
 		}
@@ -365,22 +368,22 @@ func (s *Server) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error {
 		region := core.RegionFromHeartbeat(request)
 		if region.GetID() == 0 {
 			msg := fmt.Sprintf("invalid request region, %v", request)
-			hbStreams.sendErr(region, pdpb.ErrorType_UNKNOWN, msg, storeLabel)
+			hbStreams.sendErr(region, pdpb.ErrorType_UNKNOWN, msg, storeAddress)
 			continue
 		}
 		if region.GetLeader() == nil {
 			msg := fmt.Sprintf("invalid request leader, %v", request)
-			hbStreams.sendErr(region, pdpb.ErrorType_UNKNOWN, msg, storeLabel)
+			hbStreams.sendErr(region, pdpb.ErrorType_UNKNOWN, msg, storeAddress)
 			continue
 		}
 
 		err = cluster.HandleRegionHeartbeat(region)
 		if err != nil {
 			msg := err.Error()
-			hbStreams.sendErr(region, pdpb.ErrorType_UNKNOWN, msg, storeLabel)
+			hbStreams.sendErr(region, pdpb.ErrorType_UNKNOWN, msg, storeAddress)
 		}
 
-		regionHeartbeatCounter.WithLabelValues(storeLabel, "report", "ok").Inc()
+		regionHeartbeatCounter.WithLabelValues(storeAddress, "report", "ok").Inc()
 	}
 }
 

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -368,19 +368,19 @@ func (s *Server) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error {
 		region := core.RegionFromHeartbeat(request)
 		if region.GetID() == 0 {
 			msg := fmt.Sprintf("invalid request region, %v", request)
-			hbStreams.sendErr(region, pdpb.ErrorType_UNKNOWN, msg, storeAddress)
+			hbStreams.sendErr(pdpb.ErrorType_UNKNOWN, msg, storeAddress)
 			continue
 		}
 		if region.GetLeader() == nil {
 			msg := fmt.Sprintf("invalid request leader, %v", request)
-			hbStreams.sendErr(region, pdpb.ErrorType_UNKNOWN, msg, storeAddress)
+			hbStreams.sendErr(pdpb.ErrorType_UNKNOWN, msg, storeAddress)
 			continue
 		}
 
 		err = cluster.HandleRegionHeartbeat(region)
 		if err != nil {
 			msg := err.Error()
-			hbStreams.sendErr(region, pdpb.ErrorType_UNKNOWN, msg, storeAddress)
+			hbStreams.sendErr(pdpb.ErrorType_UNKNOWN, msg, storeAddress)
 		}
 
 		regionHeartbeatCounter.WithLabelValues(storeAddress, "report", "ok").Inc()

--- a/server/heartbeat_stream_test.go
+++ b/server/heartbeat_stream_test.go
@@ -69,7 +69,6 @@ func (s *testHeartbeatStreamSuite) TestActivity(c *C) {
 			return 0
 		}
 	}
-
 	req := &pdpb.RegionHeartbeatRequest{
 		Header: newRequestHeader(s.svr.clusterID),
 		Leader: s.region.Peers[0],

--- a/server/heartbeat_streams.go
+++ b/server/heartbeat_streams.go
@@ -81,7 +81,10 @@ func (s *heartbeatStreams) run() {
 			storeID := msg.GetTargetPeer().GetStoreId()
 			store, err := s.cluster.GetStore(storeID)
 			if err != nil {
-				log.Errorf("[region %v] fail to get store %v: %v", msg.RegionId, storeID, err)
+				log.Error("fail to get store",
+					zap.Uint64("region-id", msg.RegionId),
+					zap.Uint64("store-id", storeID),
+					zap.Error(err))
 				delete(s.streams, storeID)
 				continue
 			}
@@ -96,14 +99,16 @@ func (s *heartbeatStreams) run() {
 					regionHeartbeatCounter.WithLabelValues(storeAddress, "push", "ok").Inc()
 				}
 			} else {
-				log.Debug("heartbeat stream not found, skip send message", zap.Uint64("region-id", msg.RegionId), zap.Uint64("store-id", storeID))
+				log.Debug("heartbeat stream not found, skip send message",
+					zap.Uint64("region-id", msg.RegionId),
+					zap.Uint64("store-id", storeID))
 				regionHeartbeatCounter.WithLabelValues(storeAddress, "push", "skip").Inc()
 			}
 		case <-keepAliveTicker.C:
 			for storeID, stream := range s.streams {
 				store, err := s.cluster.GetStore(storeID)
 				if err != nil {
-					log.Errorf("[store %v] fail to get store: %v", storeID, err)
+					log.Error("fail to get store", zap.Uint64("store-id", storeID), zap.Error(err))
 					delete(s.streams, storeID)
 					continue
 				}

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -95,7 +95,7 @@ var (
 			Subsystem: "scheduler",
 			Name:      "region_heartbeat",
 			Help:      "Counter of region hearbeat.",
-		}, []string{"store", "type", "status"})
+		}, []string{"address", "type", "status"})
 
 	regionHeartbeatLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -104,7 +104,7 @@ var (
 			Name:      "region_heartbeat_latency_seconds",
 			Help:      "Bucketed histogram of latency (s) of receiving heartbeat.",
 			Buckets:   prometheus.ExponentialBuckets(1, 2, 12),
-		}, []string{"store"})
+		}, []string{"address"})
 
 	storeStatusGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -112,7 +112,7 @@ var (
 			Subsystem: "scheduler",
 			Name:      "store_status",
 			Help:      "Store status for schedule",
-		}, []string{"namespace", "store", "type"})
+		}, []string{"namespace", "address", "type"})
 
 	hotSpotStatusGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -120,7 +120,7 @@ var (
 			Subsystem: "hotspot",
 			Name:      "status",
 			Help:      "Status of the hotspot.",
-		}, []string{"store", "type"})
+		}, []string{"address", "type"})
 
 	tsoCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{

--- a/server/schedule/filters.go
+++ b/server/schedule/filters.go
@@ -14,8 +14,6 @@
 package schedule
 
 import (
-	"fmt"
-
 	"github.com/pingcap/pd/server/cache"
 	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/server/namespace"
@@ -34,10 +32,10 @@ type Filter interface {
 
 // FilterSource checks if store can pass all Filters as source store.
 func FilterSource(opt Options, store *core.StoreInfo, filters []Filter) bool {
-	storeID := fmt.Sprintf("store%d", store.GetID())
+	storeAddress := store.GetAddress()
 	for _, filter := range filters {
 		if filter.FilterSource(opt, store) {
-			filterCounter.WithLabelValues("filter-source", storeID, filter.Type()).Inc()
+			filterCounter.WithLabelValues("filter-source", storeAddress, filter.Type()).Inc()
 			return true
 		}
 	}
@@ -46,10 +44,10 @@ func FilterSource(opt Options, store *core.StoreInfo, filters []Filter) bool {
 
 // FilterTarget checks if store can pass all Filters as target store.
 func FilterTarget(opt Options, store *core.StoreInfo, filters []Filter) bool {
-	storeID := fmt.Sprintf("store%d", store.GetID())
+	storeAddress := store.GetAddress()
 	for _, filter := range filters {
 		if filter.FilterTarget(opt, store) {
-			filterCounter.WithLabelValues("filter-target", storeID, filter.Type()).Inc()
+			filterCounter.WithLabelValues("filter-target", storeAddress, filter.Type()).Inc()
 			return true
 		}
 	}

--- a/server/schedule/metrics.go
+++ b/server/schedule/metrics.go
@@ -47,7 +47,7 @@ var (
 			Subsystem: "schedule",
 			Name:      "filter",
 			Help:      "Counter of the filter",
-		}, []string{"action", "store", "type"})
+		}, []string{"action", "address", "type"})
 
 	operatorCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{

--- a/server/schedulers/metrics.go
+++ b/server/schedulers/metrics.go
@@ -37,7 +37,7 @@ var balanceLeaderCounter = prometheus.NewCounterVec(
 		Subsystem: "scheduler",
 		Name:      "balance_leader",
 		Help:      "Counter of balance leader scheduler.",
-	}, []string{"type", "store"})
+	}, []string{"type", "address"})
 
 var balanceRegionCounter = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
@@ -45,7 +45,7 @@ var balanceRegionCounter = prometheus.NewCounterVec(
 		Subsystem: "scheduler",
 		Name:      "balance_region",
 		Help:      "Counter of balance region scheduler.",
-	}, []string{"type", "store"})
+	}, []string{"type", "address"})
 
 func init() {
 	prometheus.MustRegister(schedulerCounter)

--- a/server/server.go
+++ b/server/server.go
@@ -228,7 +228,7 @@ func (s *Server) startServer() error {
 	}
 	s.kv = core.NewKV(kvBase).SetRegionKV(regionKV)
 	s.cluster = newRaftCluster(s, s.clusterID)
-	s.hbStreams = newHeartbeatStreams(s.clusterID, s.kv, s.cluster.cachedCluster)
+	s.hbStreams = newHeartbeatStreams(s.clusterID, s.cluster)
 	if s.classifier, err = namespace.CreateClassifier(s.cfg.NamespaceClassifier, s.kv, s.idAlloc); err != nil {
 		return err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -228,7 +228,7 @@ func (s *Server) startServer() error {
 	}
 	s.kv = core.NewKV(kvBase).SetRegionKV(regionKV)
 	s.cluster = newRaftCluster(s, s.clusterID)
-	s.hbStreams = newHeartbeatStreams(s.clusterID)
+	s.hbStreams = newHeartbeatStreams(s.clusterID, s.kv, s.cluster.cachedCluster)
 	if s.classifier, err = namespace.CreateClassifier(s.cfg.NamespaceClassifier, s.kv, s.idAlloc); err != nil {
 		return err
 	}

--- a/server/store_statistics.go
+++ b/server/store_statistics.go
@@ -15,7 +15,6 @@ package server
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/server/core"
@@ -61,7 +60,7 @@ func (s *storeStatistics) Observe(store *core.StoreInfo) {
 		key := fmt.Sprintf("%s:%s", k, v)
 		s.LabelCounter[key]++
 	}
-	id := strconv.FormatUint(store.GetID(), 10)
+	storeAddress := store.GetAddress()
 	// Store state.
 	switch store.GetState() {
 	case metapb.StoreState_Up:
@@ -78,7 +77,7 @@ func (s *storeStatistics) Observe(store *core.StoreInfo) {
 		s.Offline++
 	case metapb.StoreState_Tombstone:
 		s.Tombstone++
-		s.resetStoreStatistics(id)
+		s.resetStoreStatistics(storeAddress)
 		return
 	}
 	if store.IsLowSpace(s.opt.GetLowSpaceRatio()) {
@@ -91,15 +90,15 @@ func (s *storeStatistics) Observe(store *core.StoreInfo) {
 	s.RegionCount += store.GetRegionCount()
 	s.LeaderCount += store.GetLeaderCount()
 
-	storeStatusGauge.WithLabelValues(s.namespace, id, "region_score").Set(store.RegionScore(s.opt.GetHighSpaceRatio(), s.opt.GetLowSpaceRatio(), 0))
-	storeStatusGauge.WithLabelValues(s.namespace, id, "leader_score").Set(store.LeaderScore(0))
-	storeStatusGauge.WithLabelValues(s.namespace, id, "region_size").Set(float64(store.GetRegionSize()))
-	storeStatusGauge.WithLabelValues(s.namespace, id, "region_count").Set(float64(store.GetRegionCount()))
-	storeStatusGauge.WithLabelValues(s.namespace, id, "leader_size").Set(float64(store.GetLeaderSize()))
-	storeStatusGauge.WithLabelValues(s.namespace, id, "leader_count").Set(float64(store.GetLeaderCount()))
-	storeStatusGauge.WithLabelValues(s.namespace, id, "store_available").Set(float64(store.GetAvailable()))
-	storeStatusGauge.WithLabelValues(s.namespace, id, "store_used").Set(float64(store.GetUsedSize()))
-	storeStatusGauge.WithLabelValues(s.namespace, id, "store_capacity").Set(float64(store.GetCapacity()))
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "region_score").Set(store.RegionScore(s.opt.GetHighSpaceRatio(), s.opt.GetLowSpaceRatio(), 0))
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "leader_score").Set(store.LeaderScore(0))
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "region_size").Set(float64(store.GetRegionSize()))
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "region_count").Set(float64(store.GetRegionCount()))
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "leader_size").Set(float64(store.GetLeaderSize()))
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "leader_count").Set(float64(store.GetLeaderCount()))
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "store_available").Set(float64(store.GetAvailable()))
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "store_used").Set(float64(store.GetUsedSize()))
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "store_capacity").Set(float64(store.GetCapacity()))
 }
 
 func (s *storeStatistics) Collect() {
@@ -163,16 +162,16 @@ func (s *storeStatistics) Collect() {
 	}
 }
 
-func (s *storeStatistics) resetStoreStatistics(id string) {
-	storeStatusGauge.WithLabelValues(s.namespace, id, "region_score").Set(0)
-	storeStatusGauge.WithLabelValues(s.namespace, id, "leader_score").Set(0)
-	storeStatusGauge.WithLabelValues(s.namespace, id, "region_size").Set(0)
-	storeStatusGauge.WithLabelValues(s.namespace, id, "region_count").Set(0)
-	storeStatusGauge.WithLabelValues(s.namespace, id, "leader_size").Set(0)
-	storeStatusGauge.WithLabelValues(s.namespace, id, "leader_count").Set(0)
-	storeStatusGauge.WithLabelValues(s.namespace, id, "store_available").Set(0)
-	storeStatusGauge.WithLabelValues(s.namespace, id, "store_used").Set(0)
-	storeStatusGauge.WithLabelValues(s.namespace, id, "store_capacity").Set(0)
+func (s *storeStatistics) resetStoreStatistics(storeAddress string) {
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "region_score").Set(0)
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "leader_score").Set(0)
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "region_size").Set(0)
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "region_count").Set(0)
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "leader_size").Set(0)
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "leader_count").Set(0)
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "store_available").Set(0)
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "store_used").Set(0)
+	storeStatusGauge.WithLabelValues(s.namespace, storeAddress, "store_capacity").Set(0)
 }
 
 type storeStatisticsMap struct {


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Closes #1427.

### What is changed and how it works?
This PR is going to use TiKV address instead of `storeID` for the metrics.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to update the `tidb-ansible` repository
