### PR TITLE
[WIP] tools: Add API to evict owner in etcd

### DIFF
--- a/tests/cmd/pdctl_test.go
+++ b/tests/cmd/pdctl_test.go
@@ -1169,19 +1169,22 @@ func (s *cmdTestSuite) TestEtcd(c *C) {
 
 	//etcd ddlinfo
 	args := []string{"-u", pdAddr, "etcd", "ddlinfo"}
-	_, output, err = executeCommandC(cmd, args...)
-	//	fmt.Printf("\n\n\n\n\n\n\n\n\n*******************\n\n")
-	//	fmt.Println(string(output))
-	//	fmt.Printf("\n\n*******************\n\n\n\n\n\n\n\n\n")
+	_, output, err := executeCommandC(cmd, args...)
 	c.Assert(err, IsNil)
 	c.Assert(output, NotNil)
 
-	//	args = []string{"-u", pdAddr, "etcd", "delowner"}
-	//	_, output, err = executeCommandC(cmd, args...)
-	//	fmt.Printf("\n\n\n\n\n\n\n\n\n*******************\n\n")
-	//	fmt.Println(string(output))
-	//	fmt.Println(err)
-	//	fmt.Printf("\n\n*******************\n\n\n\n\n\n\n\n\n")
+	//TODO: Add more strong test
+	//etcd delowner
+	args = []string{"-u", pdAddr, "etcd", "delowner", "LeaseID"}
+	_, output, err = executeCommandC(cmd, args...)
+	c.Assert(err, IsNil)
+	c.Assert(output, NotNil)
+
+	//etcd delschema
+	args = []string{"-u", pdAddr, "etcd", "delschema", "DDLID"}
+	_, output, err = executeCommandC(cmd, args...)
+	c.Assert(err, IsNil)
+	c.Assert(output, NotNil)
 
 }
 

--- a/tests/cmd/pdctl_test.go
+++ b/tests/cmd/pdctl_test.go
@@ -1169,7 +1169,7 @@ func (s *cmdTestSuite) TestEtcd(c *C) {
 
 	//etcd ddlinfo
 	args := []string{"-u", pdAddr, "etcd", "ddlinfo"}
-	_, output, err := executeCommandC(cmd, args...)
+	_, output, err = executeCommandC(cmd, args...)
 	//	fmt.Printf("\n\n\n\n\n\n\n\n\n*******************\n\n")
 	//	fmt.Println(string(output))
 	//	fmt.Printf("\n\n*******************\n\n\n\n\n\n\n\n\n")

--- a/tests/cmd/pdctl_test.go
+++ b/tests/cmd/pdctl_test.go
@@ -1155,6 +1155,36 @@ func (s *cmdTestSuite) TestHot(c *C) {
 	c.Assert(hotStores.BytesWriteStats[1], Equals, bytesWritten/10)
 }
 
+func (s *cmdTestSuite) TestEtcd(c *C) {
+	c.Parallel()
+
+	cluster, err := tests.NewTestCluster(1)
+	c.Assert(err, IsNil)
+	err = cluster.RunInitialServers()
+	c.Assert(err, IsNil)
+	cluster.WaitLeader()
+	pdAddr := cluster.GetConfig().GetClientURLs()
+	cmd := initCommand()
+	defer cluster.Destroy()
+
+	//etcd ddlinfo
+	args := []string{"-u", pdAddr, "etcd", "ddlinfo"}
+	_, output, err := executeCommandC(cmd, args...)
+	//	fmt.Printf("\n\n\n\n\n\n\n\n\n*******************\n\n")
+	//	fmt.Println(string(output))
+	//	fmt.Printf("\n\n*******************\n\n\n\n\n\n\n\n\n")
+	c.Assert(err, IsNil)
+	c.Assert(output, NotNil)
+
+	//	args = []string{"-u", pdAddr, "etcd", "delowner"}
+	//	_, output, err = executeCommandC(cmd, args...)
+	//	fmt.Printf("\n\n\n\n\n\n\n\n\n*******************\n\n")
+	//	fmt.Println(string(output))
+	//	fmt.Println(err)
+	//	fmt.Printf("\n\n*******************\n\n\n\n\n\n\n\n\n")
+
+}
+
 func initCommand() *cobra.Command {
 	commandFlags := pdctl.CommandFlags{}
 	rootCmd := &cobra.Command{}
@@ -1178,6 +1208,7 @@ func initCommand() *cobra.Command {
 		command.NewTableNamespaceCommand(),
 		command.NewHealthCommand(),
 		command.NewLogCommand(),
+		command.NewEtcdCommand(),
 	)
 	return rootCmd
 }

--- a/tools/pd-ctl/pdctl/command/etcd.go
+++ b/tools/pd-ctl/pdctl/command/etcd.go
@@ -1,0 +1,107 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+
+	"github.com/spf13/cobra"
+)
+
+// It is for query with --prefix
+type rangeQuery struct {
+	Key       string `json:"key"`
+	Range_end string `json:"range_end"`
+}
+
+var (
+	rangeQueryPrefix = "v3/kv/range"
+	//rangeDeletePrefix = "v3/kv/deleterange"
+)
+
+func base64Encode(str string) string {
+	return base64.StdEncoding.EncodeToString([]byte(str))
+}
+
+func base64Decode(str string) (string, error) {
+	data, err := base64.StdEncoding.DecodeString(str)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+var (
+	rangeQueryDDLInfo = &rangeQuery{
+		Key:       base64Encode("/tidb/ddl"),
+		Range_end: base64Encode("/tidb/ddm"),
+	}
+)
+
+// NewEtcdCommand return a etcd subcommand of rootCmd
+func NewEtcdCommand() *cobra.Command {
+	m := &cobra.Command{
+		Use:   "etcd",
+		Short: "control the info about etcd by grpc_gateway",
+	}
+	m.AddCommand(NewShowDDLInfoCommand())
+	return m
+}
+
+func NewShowDDLInfoCommand() *cobra.Command {
+	m := &cobra.Command{
+		Use:   "ddlinfo",
+		Short: "Show All Information about DDL",
+		Run:   showDDLInfoCommandFunc,
+	}
+	return m
+}
+
+func showDDLInfoCommandFunc(cmd *cobra.Command, args []string) {
+	reqData, _ := json.Marshal(rangeQueryDDLInfo)
+	req, err := getRequest(cmd, rangeQueryPrefix, http.MethodPost, "application/json",
+		bytes.NewBuffer(reqData))
+	if err != nil {
+		cmd.Printf("Failed to show DDLInfo: %v\n", err)
+		return
+	}
+	res, err := dail(req)
+	if err != nil {
+		cmd.Printf("Failed to show DDLInfo: %v\n", err)
+		return
+	}
+
+	// format JSON
+	var t interface{}
+	_ = json.Unmarshal([]byte(res), &t)
+	for _, v := range t.(map[string]interface{}) {
+		for kk, vv := range v.(map[string]interface{}) {
+			if kk == "key" || kk == "value" {
+				vv, err = base64Decode(vv.(string))
+				if err != nil {
+					cmd.Printf("Failed to show DDLInfo: %v\n", err)
+					return
+				}
+			}
+
+		}
+	}
+	resByte, _ := json.MarshalIndent(&t, "", "\t")
+	res = string(resByte)
+
+	cmd.Println(res)
+}

--- a/tools/pd-ctl/pdctl/command/etcd.go
+++ b/tools/pd-ctl/pdctl/command/etcd.go
@@ -22,10 +22,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// It is for operator with --prefix
 type parameter struct {
-	Key       string `json:"key"`
-	Range_end string `json:"range_end"`
+	// It is parameter for api_grpc_gateway
+	Key      string `json:"key"`
+	RangeEnd string `json:"range_end"`
 }
 
 var (
@@ -57,6 +57,7 @@ func formatJSON(str string) (string, error) {
 				if err != nil {
 					return "", err
 				}
+				v.(map[string]interface{})[kk] = vv
 			}
 
 		}
@@ -84,6 +85,7 @@ func NewEtcdCommand() *cobra.Command {
 	return m
 }
 
+// NewShowDDLInfoCommand return a show ddl information subcommand of EtcdCommand
 func NewShowDDLInfoCommand() *cobra.Command {
 	m := &cobra.Command{
 		Use:   "ddlinfo",
@@ -93,6 +95,7 @@ func NewShowDDLInfoCommand() *cobra.Command {
 	return m
 }
 
+// NewDelOwnerCampaign return a delete owner campaign subcommand of EtcdCommand
 func NewDelOwnerCampaign() *cobra.Command {
 	m := &cobra.Command{
 		Use:   "delowner",
@@ -102,6 +105,7 @@ func NewDelOwnerCampaign() *cobra.Command {
 	return m
 }
 
+// NewDelSchemaVersion return a delete schema version subcommand of EtcdCommand
 func NewDelSchemaVersion() *cobra.Command {
 	m := &cobra.Command{
 		Use:   "delschema",
@@ -113,8 +117,8 @@ func NewDelSchemaVersion() *cobra.Command {
 
 func showDDLInfoCommandFunc(cmd *cobra.Command, args []string) {
 	var rangeQueryDDLInfo = &parameter{
-		Key:       base64Encode("/tidb/ddl"),
-		Range_end: base64Encode("/tidb/ddm"),
+		Key:      base64Encode("/tidb/ddl"),
+		RangeEnd: base64Encode("/tidb/ddm"),
 	}
 
 	reqData, _ := json.Marshal(rangeQueryDDLInfo)

--- a/tools/pd-ctl/pdctl/command/etcd.go
+++ b/tools/pd-ctl/pdctl/command/etcd.go
@@ -61,7 +61,7 @@ func formatJSON(str string) (string, error) {
 			if kk == "key" || kk == "value" {
 				vv, err = base64Decode(vv)
 				if err != nil {
-					return "", nil
+					return "", err
 				}
 				jsn.Kvs[k][kk] = vv
 			}

--- a/tools/pd-ctl/pdctl/command/etcd.go
+++ b/tools/pd-ctl/pdctl/command/etcd.go
@@ -48,24 +48,30 @@ func base64Decode(str string) (string, error) {
 }
 
 func formatJSON(str string) (string, error) {
-	var t interface{}
-	err := json.Unmarshal([]byte(str), &t)
-	for _, v := range t.(map[string]interface{}) {
-		for kk, vv := range v.(map[string]interface{}) {
-			if kk == "key" || kk == "value" {
-				vv, err = base64Decode(vv.(string))
-				if err != nil {
-					return "", err
-				}
-				v.(map[string]interface{})[kk] = vv
-			}
+	var jsn struct {
+		Count  string              `json:"count"`
+		Header map[string]string   `json:"header"`
+		Kvs    []map[string]string `json:"kvs"`
+	}
 
+	err := json.Unmarshal([]byte(str), &jsn)
+
+	for k, v := range jsn.Kvs {
+		for kk, vv := range v {
+			if kk == "key" || kk == "lease" {
+				vv, err = base64Decode(vv)
+				if err != nil {
+					return "", nil
+				}
+				jsn.Kvs[k][kk] = vv
+			}
 		}
 	}
+
 	if err != nil {
 		return "", err
 	}
-	resByte, err := json.MarshalIndent(&t, "", "\t")
+	resByte, err := json.MarshalIndent(&jsn, "", "\t")
 	if err != nil {
 		return "", err
 	}

--- a/tools/pd-ctl/pdctl/command/etcd.go
+++ b/tools/pd-ctl/pdctl/command/etcd.go
@@ -127,7 +127,11 @@ func showDDLInfoCommandFunc(cmd *cobra.Command, args []string) {
 		RangeEnd: base64Encode("/tidb/ddm"),
 	}
 
-	reqData, _ := json.Marshal(rangeQueryDDLInfo)
+	reqData, err := json.Marshal(rangeQueryDDLInfo)
+	if err != nil {
+		cmd.Printf("Failed to show DDLInfo: %v\n", err)
+		return
+	}
 	req, err := getRequest(cmd, rangeQueryPrefix, http.MethodPost, "application/json",
 		bytes.NewBuffer(reqData))
 	if err != nil {
@@ -161,7 +165,12 @@ func delOwnerCampaign(cmd *cobra.Command, args []string) {
 		Key: base64Encode(delOwnerCampaignPrefix + leaseID),
 	}
 
-	reqData, _ := json.Marshal(para)
+	reqData, err := json.Marshal(para)
+
+	if err != nil {
+		cmd.Printf("Failed to delete owner campaign : %v\n", err)
+		return
+	}
 	req, err := getRequest(cmd, rangeDelPrefix, http.MethodPost, "application/json",
 		bytes.NewBuffer(reqData))
 	if err != nil {
@@ -194,7 +203,11 @@ func delSchemaVersion(cmd *cobra.Command, args []string) {
 		Key: base64Encode(delSchemaVersionPrefix + leaseID),
 	}
 
-	reqData, _ := json.Marshal(para)
+	reqData, err := json.Marshal(para)
+	if err != nil {
+		cmd.Printf("Failed to delete owner campaign : %v\n", err)
+		return
+	}
 	req, err := getRequest(cmd, rangeDelPrefix, http.MethodPost, "application/json",
 		bytes.NewBuffer(reqData))
 	if err != nil {

--- a/tools/pd-ctl/pdctl/command/etcd.go
+++ b/tools/pd-ctl/pdctl/command/etcd.go
@@ -1,4 +1,4 @@
-// Copyright 2016 PingCAP, Inc.
+// Copyright 2019 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// It is for query with --prefix
+// It is for operator with --prefix
 type parameter struct {
 	Key       string `json:"key"`
 	Range_end string `json:"range_end"`
@@ -72,13 +72,6 @@ func formatJSON(str string) (string, error) {
 	return res, nil
 }
 
-var (
-	rangeQueryDDLInfo = &parameter{
-		Key:       base64Encode("/tidb/ddl"),
-		Range_end: base64Encode("/tidb/ddm"),
-	}
-)
-
 // NewEtcdCommand return a etcd subcommand of rootCmd
 func NewEtcdCommand() *cobra.Command {
 	m := &cobra.Command{
@@ -119,6 +112,11 @@ func NewDelSchemaVersion() *cobra.Command {
 }
 
 func showDDLInfoCommandFunc(cmd *cobra.Command, args []string) {
+	var rangeQueryDDLInfo = &parameter{
+		Key:       base64Encode("/tidb/ddl"),
+		Range_end: base64Encode("/tidb/ddm"),
+	}
+
 	reqData, _ := json.Marshal(rangeQueryDDLInfo)
 	req, err := getRequest(cmd, rangeQueryPrefix, http.MethodPost, "application/json",
 		bytes.NewBuffer(reqData))

--- a/tools/pd-ctl/pdctl/command/etcd.go
+++ b/tools/pd-ctl/pdctl/command/etcd.go
@@ -32,7 +32,7 @@ var (
 	rangeQueryPrefix       = "v3/kv/range"
 	rangeDelPrefix         = "v3/kv/deleterange"
 	delOwnerCampaignPrefix = "/tidb/ddl/fg/owner/"
-	delSchemaVersionPrefix = "/tidb/ddl/all_schema_bersions/DDL_ID"
+	delSchemaVersionPrefix = "/tidb/ddl/all_schema_bersions/DDL_ID/"
 )
 
 func base64Encode(str string) string {
@@ -144,12 +144,12 @@ func delOwnerCampaign(cmd *cobra.Command, args []string) {
 	req, err := getRequest(cmd, rangeDelPrefix, http.MethodPost, "application/json",
 		bytes.NewBuffer(reqData))
 	if err != nil {
-		cmd.Printf("Failed to show DDLInfo: %v\n", err)
+		cmd.Printf("Failed to delete owner campaign : %v\n", err)
 		return
 	}
 	res, err := dail(req)
 	if err != nil {
-		cmd.Printf("Failed to show DDLInfo: %v\n", err)
+		cmd.Printf("Failed to delete owner campaign : %v\n", err)
 		return
 	}
 
@@ -171,19 +171,19 @@ func delSchemaVersion(cmd *cobra.Command, args []string) {
 	leaseID := args[0]
 
 	var para = &parameter{
-		Key: leaseID,
+		Key: base64Encode(delSchemaVersionPrefix + leaseID),
 	}
 
 	reqData, _ := json.Marshal(para)
-	req, err := getRequest(cmd, delSchemaVersionPrefix, http.MethodPost, "application/json",
+	req, err := getRequest(cmd, rangeDelPrefix, http.MethodPost, "application/json",
 		bytes.NewBuffer(reqData))
 	if err != nil {
-		cmd.Printf("Failed to show DDLInfo: %v\n", err)
+		cmd.Printf("Failed to delete schema version: %v\n", err)
 		return
 	}
 	res, err := dail(req)
 	if err != nil {
-		cmd.Printf("Failed to show DDLInfo: %v\n", err)
+		cmd.Printf("Failed to delete schema version: %v\n", err)
 		return
 	}
 

--- a/tools/pd-ctl/pdctl/command/etcd.go
+++ b/tools/pd-ctl/pdctl/command/etcd.go
@@ -58,7 +58,7 @@ func formatJSON(str string) (string, error) {
 
 	for k, v := range jsn.Kvs {
 		for kk, vv := range v {
-			if kk == "key" || kk == "lease" {
+			if kk == "key" || kk == "value" {
 				vv, err = base64Decode(vv)
 				if err != nil {
 					return "", nil

--- a/tools/pd-ctl/pdctl/command/etcd_test.go
+++ b/tools/pd-ctl/pdctl/command/etcd_test.go
@@ -1,0 +1,34 @@
+package command
+
+import (
+	"testing"
+
+	. "github.com/pingcap/check"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&EtcdCtl{})
+
+type EtcdCtl struct{}
+
+func (s *EtcdCtl) TestBase64Encode(c *C) {
+	c.Parallel()
+	expected := "SGVsbG8sV29ybGQ="
+	obtained := base64Encode("Hello,World")
+	c.Assert(obtained, Equals, expected)
+}
+
+func (s *EtcdCtl) TestBase64Decode(c *C) {
+	c.Parallel()
+	expected := "Hello,World"
+	obtained, err := base64Decode("SGVsbG8sV29ybGQ=")
+	c.Assert(err, IsNil)
+	c.Assert(obtained, Equals, expected)
+	obtained, err = base64Decode("ThisIsNotBase64")
+	c.Assert(obtained, Equals, "")
+	c.Assert(err, ErrorMatches, "*illegal.*")
+
+}

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -62,6 +62,7 @@ func Start(args []string) {
 		command.NewTableNamespaceCommand(),
 		command.NewHealthCommand(),
 		command.NewLogCommand(),
+		command.NewEtcdCommand(),
 	)
 
 	rootCmd.SetArgs(args)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

Add API to evict invalid owner in etcd manually.
- [x] Show all information like `ETCDCTL_API=3 etcdctl --endpoints={PD address} get /tidb/ddl  --prefix`
- [x] delete owner campaign like ` ETCDCTL_API=3 ./etcdctl --endpoints={PD address} del /tidb/ddl/fg/owner/Lease_ID`
- [x] delete schema version like `ETCDCTL_API=3 ./etcdctl --endpoints={PD address} del /tidb/ddl/all_schema_versions/DDL_ID`
- [ ] Add Unit Tests

### What is changed and how it works?

Add new function in pd-ctl.

### Check List <!--REMOVE the items that are not applicable-->


Related changes

 - Need to update the documentation

