### PR TITLE
config: check scheduler's name from config file

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/pd/pkg/metricutil"
 	"github.com/pingcap/pd/pkg/typeutil"
 	"github.com/pingcap/pd/server/namespace"
+	"github.com/pingcap/pd/server/schedule"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -620,6 +621,11 @@ func (c *ScheduleConfig) validate() error {
 	}
 	if c.LowSpaceRatio <= c.HighSpaceRatio {
 		return errors.New("low-space-ratio should be larger than high-space-ratio")
+	}
+	for _, scheduleConfig := range c.Schedulers {
+		if !schedule.IsSchedulerRegistered(scheduleConfig.Type) {
+			return errors.Errorf("create func of %v is not registered, maybe misspelled", scheduleConfig.Type)
+		}
 	}
 	return nil
 }

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -133,6 +133,34 @@ type = "random-merge"
 	err = cfg.Adjust(&meta)
 	c.Assert(err, NotNil)
 
+	// Check misspelled schedulers name
+	cfgData = `
+name = ""
+lease = 0
+
+[[schedule.schedulers]]
+type = "random-merge-schedulers"
+`
+	cfg = NewConfig()
+	meta, err = toml.Decode(cfgData, &cfg)
+	c.Assert(err, IsNil)
+	err = cfg.Adjust(&meta)
+	c.Assert(err, NotNil)
+
+	// Check correct schedulers name
+	cfgData = `
+name = ""
+lease = 0
+
+[[schedule.schedulers]]
+type = "random-merge"
+`
+	cfg = NewConfig()
+	meta, err = toml.Decode(cfgData, &cfg)
+	c.Assert(err, IsNil)
+	err = cfg.Adjust(&meta)
+	c.Assert(err, IsNil)
+
 	cfgData = `
 [metric]
 interval = "35s"

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -203,7 +203,8 @@ func (c *coordinator) run() {
 		}
 		s, err := schedule.CreateScheduler(schedulerCfg.Type, c.opController, schedulerCfg.Args...)
 		if err != nil {
-			log.Fatal("can not create scheduler", zap.String("scheduler-type", schedulerCfg.Type), zap.Error(err))
+			log.Error("can not create scheduler", zap.String("scheduler-type", schedulerCfg.Type), zap.Error(err))
+			continue
 		}
 		log.Info("create scheduler", zap.String("scheduler-name", s.GetName()))
 		if err = c.addScheduler(s, schedulerCfg.Args...); err != nil {

--- a/server/schedule/scheduler.go
+++ b/server/schedule/scheduler.go
@@ -82,6 +82,12 @@ func RegisterScheduler(name string, createFn CreateSchedulerFunc) {
 	schedulerMap[name] = createFn
 }
 
+// IsSchedulerRegistered check where the named scheduler type is registered.
+func IsSchedulerRegistered(name string) bool {
+	_, ok := schedulerMap[name]
+	return ok
+}
+
 // CreateScheduler creates a scheduler with registered creator func.
 func CreateScheduler(name string, opController *OperatorController, args ...string) (Scheduler, error) {
 	fn, ok := schedulerMap[name]

--- a/server/testutil.go
+++ b/server/testutil.go
@@ -30,6 +30,8 @@ import (
 
 	// Register namespace classifiers.
 	_ "github.com/pingcap/pd/table"
+	// Register schedulers
+	_ "github.com/pingcap/pd/server/schedulers"
 )
 
 // CleanupFunc closes test pd server(s) and deletes any files left behind.


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

Check scheduler's name from configFile to prevent misspelled cases.

Related issue: https://github.com/pingcap/pd/issues/1443
### What is changed and how it works?

Checking happens in scheduleConfigs validation stage.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

