### PR TITLE
server: update new split region info for scattering region

### DIFF
--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -601,6 +601,11 @@ func (s *Server) ScatterRegion(ctx context.Context, request *pdpb.ScatterRegionR
 			return nil, errors.Errorf("region %d not found", request.GetRegionId())
 		}
 		region = core.NewRegionInfo(request.GetRegion(), request.GetLeader())
+		// PD may have not received any heartbeat from the new split region,
+		// So scatter region requests take the new split region info.
+		if err := cluster.cachedCluster.handleRegionHeartbeat(region); err != nil {
+			return nil, err
+		}
 	}
 	cluster.RLock()
 	defer cluster.RUnlock()


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Before uploading KV pairs to TiKV, importer will first "split" the the region appropriate size not overlapping with existing data, and then use "scatter" to locate the target store. However, "split" returning does not mean the region ID is known to PD due to heartbeat not yet received. If we call "scatter" before the split regions are ready, the "scatter" operation will silently fail, which causes importer to upload to same store again and again and causing imbalance.

Another fix way of https://github.com/tikv/tikv/pull/4352

### What is changed and how it works?
Actually, the scatter region request will take the new split region info, so update the region info when receiving scatter requests and find no region.

### Check List <!--REMOVE the items that are not applicable-->
 - No code

