### PR TITLE
*: fix CI and switch to golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,14 +74,15 @@ retool-setup:
 
 check: retool-setup check-all
 
+static: export GO111MODULE=on
 static:
 	@ # Not running vet and fmt through metalinter becauase it ends up looking at vendor
 	gofmt -s -l $$($(PACKAGE_DIRECTORIES)) 2>&1 | $(GOCHECKER)
 	./scripts/retool do govet --shadow $$($(PACKAGE_DIRECTORIES)) 2>&1 | $(GOCHECKER)
 
-	CGO_ENABLED=0 ./scripts/retool do gometalinter.v2 --disable-all --deadline 120s \
+	CGO_ENABLED=0 ./scripts/retool do golangci-lint run --disable-all --deadline 120s \
 	  --enable misspell \
-	  --enable megacheck \
+	  --enable staticcheck \
 	  --enable ineffassign \
 	  $$($(PACKAGE_DIRECTORIES))
 

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -234,7 +234,7 @@ func (c *coordinator) stop() {
 	c.cancel()
 }
 
-// Hack to retrive info from scheduler.
+// Hack to retrieve info from scheduler.
 // TODO: remove it.
 type hasHotStatus interface {
 	GetHotReadStatus() *core.StoreHotRegionInfos

--- a/tools.json
+++ b/tools.json
@@ -1,44 +1,12 @@
 {
   "Tools": [
     {
-      "Repository": "honnef.co/go/tools/cmd/megacheck",
-      "Commit": "ae8f1f9103cc7cdcb6b573bfa8c94c820663f391"
-    },
-    {
-      "Repository": "gopkg.in/alecthomas/gometalinter.v2",
-      "Commit": "46cc1ea3778b247666c2949669a3333c532fa9c6"
-    },
-    {
-      "Repository": "github.com/kisielk/errcheck",
-      "Commit": "55d8f507faff4d6eddd0c41a3e713e2567fca4e5"
-    },
-    {
-      "Repository": "github.com/cockroachdb/returncheck",
-      "Commit": "e91bb28baf9de4a530d3ae7f041953b23dcce9be"
-    },
-    {
       "Repository": "github.com/mgechev/revive",
       "Commit": "7773f47324c2bf1c8f7a5500aff2b6c01d3ed73b"
     },
     {
-      "Repository": "github.com/gordonklaus/ineffassign",
-      "Commit": "7bae11eba15a3285c75e388f77eb6357a2d73ee2"
-    },
-    {
       "Repository": "github.com/dnephin/govet",
       "Commit": "4a96d43e39d340b63daa8bc5576985aa599885f6"
-    },
-    {
-      "Repository": "github.com/client9/misspell/cmd/misspell",
-      "Commit": "7888c6b6ce89353cd98e196bce3c3f9e4cdf31f6"
-    },
-    {
-      "Repository": "github.com/securego/gosec",
-      "Commit": "5fb530cda357c16175f2c049577d2030de735b28"
-    },
-    {
-      "Repository": "github.com/securego/gosec/cmd/gosec",
-      "Commit": "5fb530cda357c16175f2c049577d2030de735b28"
     },
     {
       "Repository": "github.com/pingcap/gofail",
@@ -47,6 +15,10 @@
     {
       "Repository": "github.com/go-playground/overalls",
       "Commit": "22ec1a223b7c9a2e56355bd500b539cba3784238"
+    },
+    {
+      "Repository": "github.com/golangci/golangci-lint/cmd/golangci-lint",
+      "Commit": "901cf25e20f86b7e9dc6f73eaba5afbd0cbdc257"
     }
   ],
   "RetoolVersion": "1.3.7"


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Currently, our CI is not stable. And also `gometalinter` and `megacheck` are deprecated.

### What is changed and how it works?
This PR fixes CI by adding `export GO111MODULE=on` and switches to `golangci-lint`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test