### PR TITLE
api: fix GetHotStores

### DIFF
--- a/server/api/hot_status.go
+++ b/server/api/hot_status.go
@@ -52,7 +52,7 @@ func (h *hotStatusHandler) GetHotStores(w http.ResponseWriter, r *http.Request) 
 	bytesWriteStats := h.GetHotBytesWriteStores()
 	bytesReadStats := h.GetHotBytesReadStores()
 	keysWriteStats := h.GetHotKeysWriteStores()
-	keysReadStats := h.GetHotKeysWriteStores()
+	keysReadStats := h.GetHotKeysReadStores()
 
 	stats := HotStoreStats{
 		BytesWriteStats: bytesWriteStats,

--- a/server/schedule/mockcluster.go
+++ b/server/schedule/mockcluster.go
@@ -329,7 +329,7 @@ func (mc *MockCluster) UpdateStorageWrittenBytes(storeID uint64, bytesWritten ui
 func (mc *MockCluster) UpdateStorageReadBytes(storeID uint64, bytesRead uint64) {
 	store := mc.GetStore(storeID)
 	newStats := proto.Clone(store.GetStoreStats()).(*pdpb.StoreStats)
-	newStats.BytesWritten = bytesRead
+	newStats.BytesRead = bytesRead
 	now := time.Now().Second()
 	interval := &pdpb.TimeInterval{StartTimestamp: uint64(now - storeHeartBeatReportInterval), EndTimestamp: uint64(now)}
 	newStats.Interval = interval

--- a/tests/cmd/pdctl_test.go
+++ b/tests/cmd/pdctl_test.go
@@ -1136,11 +1136,17 @@ func (s *cmdTestSuite) TestHot(c *C) {
 
 	ss, err := leaderServer.GetStore(1)
 	c.Assert(err, IsNil)
-	bytesWritten := uint64(8 * 1024 * 1024)
 	now := time.Now().Second()
 	interval := &pdpb.TimeInterval{StartTimestamp: uint64(now - 10), EndTimestamp: uint64(now)}
 	newStats := proto.Clone(ss.GetStoreStats()).(*pdpb.StoreStats)
+	bytesWritten := uint64(8 * 1024 * 1024)
+	bytesRead := uint64(16 * 1024 * 1024)
+	keysWritten := uint64(2000)
+	keysRead := uint64(4000)
 	newStats.BytesWritten = bytesWritten
+	newStats.BytesRead = bytesRead
+	newStats.KeysWritten = keysWritten
+	newStats.KeysRead = keysRead
 	newStats.Interval = interval
 	newStore := ss.Clone(core.SetStoreStats(newStats))
 	newStore.GetRollingStoreStats().Observe(newStore.GetStoreStats())
@@ -1163,6 +1169,9 @@ func (s *cmdTestSuite) TestHot(c *C) {
 	hotStores := api.HotStoreStats{}
 	c.Assert(json.Unmarshal(output, &hotStores), IsNil)
 	c.Assert(hotStores.BytesWriteStats[1], Equals, bytesWritten/10)
+	c.Assert(hotStores.BytesReadStats[1], Equals, bytesRead/10)
+	c.Assert(hotStores.KeysWriteStats[1], Equals, keysWritten/10)
+	c.Assert(hotStores.KeysReadStats[1], Equals, keysRead/10)
 }
 
 func initCommand() *cobra.Command {


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Currently, `GetHotStores` will return the same value for `KeysRead` and `KeysWritten`.

### What is changed and how it works?
This PR fixes this problem and improves the test.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test