### PR TITLE
server: improve region heartbeat

### DIFF
--- a/table/codec.go
+++ b/table/codec.go
@@ -53,13 +53,24 @@ func (k Key) TableID() int64 {
 	return tableID
 }
 
-// IsMeta returns if the key is a meta key.
-func (k Key) IsMeta() bool {
+// MetaOrTable checks if the key is a meta key or table key.
+// If the key is a meta key, it returns true and 0.
+// If the key is a table key, it returns false and table ID.
+// Otherwise, it returns false and 0.
+func (k Key) MetaOrTable() (bool, int64) {
 	_, key, err := DecodeBytes(k)
 	if err != nil {
-		return false
+		return false, 0
 	}
-	return bytes.HasPrefix(key, metaPrefix)
+	if bytes.HasPrefix(key, metaPrefix) {
+		return true, 0
+	}
+	if bytes.HasPrefix(key, tablePrefix) {
+		key = key[len(tablePrefix):]
+		_, tableID, _ := DecodeInt(key)
+		return false, tableID
+	}
+	return false, 0
 }
 
 var pads = make([]byte, encGroupSize)

--- a/table/namespace_classifier.go
+++ b/table/namespace_classifier.go
@@ -144,8 +144,7 @@ func (c *tableNamespaceClassifier) GetRegionNamespace(regionInfo *core.RegionInf
 	c.RLock()
 	defer c.RUnlock()
 
-	isMeta := Key(regionInfo.GetStartKey()).IsMeta()
-	tableID := Key(regionInfo.GetStartKey()).TableID()
+	isMeta, tableID := Key(regionInfo.GetStartKey()).MetaOrTable()
 	if tableID == 0 && !isMeta {
 		return namespace.DefaultNamespace
 	}

--- a/table/namespace_classifier_test.go
+++ b/table/namespace_classifier_test.go
@@ -121,8 +121,9 @@ func (s *testTableNamespaceSuite) TestTableNameSpaceGetRegionNamespace(c *C) {
 		if !t.endcoded {
 			startKey, endKey = EncodeBytes(startKey), EncodeBytes(endKey)
 		}
-		c.Assert(startKey.TableID(), Equals, t.tableID)
-		c.Assert(startKey.IsMeta(), Equals, t.isMeta)
+		isMeta, tableID := startKey.MetaOrTable()
+		c.Assert(tableID, Equals, t.tableID)
+		c.Assert(isMeta, Equals, t.isMeta)
 
 		region := core.NewRegionInfo(&metapb.Region{
 			StartKey: startKey,


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
For now, both `GetBytesReadRate` and `GetBytesWriteRate` use a read lock, and `GetRegionNamespace` decodes the same key twice.

### What is changed and how it works?
This PR replaces `GetBytesReadRate` and `GetBytesWriteRate` with `GetBytesRate` to reduce lock contention and replace `IsMeta` with `MetaOrTable` to reduce one decoding.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test