### PR TITLE
schedule: fix the operator step print

### DIFF
--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -183,7 +183,7 @@ func (oc *OperatorController) GetOperators() []*Operator {
 
 // SendScheduleCommand sends a command to the region.
 func (oc *OperatorController) SendScheduleCommand(region *core.RegionInfo, step OperatorStep) {
-	log.Info("send schedule command", zap.Uint64("region-id", region.GetID()), zap.Reflect("step", step))
+	log.Info("send schedule command", zap.Uint64("region-id", region.GetID()), zap.Stringer("step", step))
 	switch st := step.(type) {
 	case TransferLeader:
 		cmd := &pdpb.RegionHeartbeatResponse{


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Cannot understand the log, like:
```
[2019/04/02 15:29:20.333 +08:00] [INFO] [operator_test.go:206] [testing] [step="{\"ToStore\":1,\"PeerID\":1}"]
[2019/04/02 15:29:20.333 +08:00] [INFO] [operator_test.go:206] [testing] [step="{\"FromStore\":3,\"ToStore\":1}"]
[2019/04/02 15:29:20.333 +08:00] [INFO] [operator_test.go:206] [testing] [step="{\"FromStore\":3}"]
```

### What is changed and how it works?
use the `String` function to format output. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test
before:
```
[2019/04/02 15:29:20.333 +08:00] [INFO] [operator_test.go:206] [testing] [step="{\"ToStore\":1,\"PeerID\":1}"]
[2019/04/02 15:29:20.333 +08:00] [INFO] [operator_test.go:206] [testing] [step="{\"FromStore\":3,\"ToStore\":1}"]
[2019/04/02 15:29:20.333 +08:00] [INFO] [operator_test.go:206] [testing] [step="{\"FromStore\":3}"]
```
after:
```
[2019/04/02 15:29:48.472 +08:00] [INFO] [operator_test.go:206] [testing] [step="add peer 1 on store 1"]
[2019/04/02 15:29:48.473 +08:00] [INFO] [operator_test.go:206] [testing] [step="transfer leader from store 3 to store 1"]
[2019/04/02 15:29:48.473 +08:00] [INFO] [operator_test.go:206] [testing] [step="remove peer on store 3"]
```