### PR TITLE
server: add tso handle time metrics

### DIFF
--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -73,6 +73,7 @@ func (s *Server) Tso(stream pdpb.PD_TsoServer) error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		start := time.Now()
 		if err = s.validateRequest(request.GetHeader()); err != nil {
 			return err
 		}
@@ -89,6 +90,7 @@ func (s *Server) Tso(stream pdpb.PD_TsoServer) error {
 		if err := stream.Send(response); err != nil {
 			return errors.WithStack(err)
 		}
+		tsoHandleDuration.Observe(time.Since(start).Seconds())
 	}
 }
 

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -162,6 +162,15 @@ var (
 			Name:      "status",
 			Help:      "Status of the scheduling configurations.",
 		}, []string{"type", "namespace"})
+
+	tsoHandleDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "pd",
+			Subsystem: "server",
+			Name:      "handle_tso_duration_seconds",
+			Help:      "Bucketed histogram of processing time (s) of handled tso requests.",
+			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 13),
+		})
 )
 
 func init() {
@@ -182,4 +191,5 @@ func init() {
 	prometheus.MustRegister(patrolCheckRegionsHistogram)
 	prometheus.MustRegister(placementStatusGauge)
 	prometheus.MustRegister(configStatusGauge)
+	prometheus.MustRegister(tsoHandleDuration)
 }


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
When pd-client reports slow tso, we don't know if it takes too much time for server to handle the request.

### What is changed and how it works?
Add metrics.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integration test

Related changes
 - Need to cherry-pick to the release branch
 - Need to update the `tidb-ansible` repository
