### PR TITLE
makefile: tidy checks only module files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ lint:
 tidy:
 	@echo "go mod tidy"
 	GO111MODULE=on go mod tidy
-	git diff --quiet
+	git diff --quiet go.mod go.sum
 
 travis_coverage: export GO111MODULE=on
 travis_coverage:


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
When `make test` and there are some unstaged changes, the `tidy` check will fail.

### What is changed and how it works?
`tidy` checkes only module files (go.mod and go.sum)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)
