### PR TITLE
util: add a timeout for HTTP client

### DIFF
--- a/server/util.go
+++ b/server/util.go
@@ -35,6 +35,7 @@ import (
 const (
 	requestTimeout  = etcdutil.DefaultRequestTimeout
 	slowRequestTime = etcdutil.DefaultSlowRequestTime
+	clientTimeout   = 30 * time.Second
 )
 
 // Version information.
@@ -47,6 +48,7 @@ var (
 
 // DialClient used to dail http request.
 var DialClient = &http.Client{
+	Timeout: clientTimeout,
 	Transport: &http.Transport{
 		DisableKeepAlives: true,
 	},
@@ -271,10 +273,13 @@ func InitHTTPClient(svr *Server) error {
 		return err
 	}
 
-	DialClient = &http.Client{Transport: &http.Transport{
-		TLSClientConfig:   tlsConfig,
-		DisableKeepAlives: true,
-	}}
+	DialClient = &http.Client{
+		Timeout: clientTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig:   tlsConfig,
+			DisableKeepAlives: true,
+		},
+	}
 	return nil
 }
 

--- a/tools/pd-ctl/pdctl/command/global.go
+++ b/tools/pd-ctl/pdctl/command/global.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -30,7 +31,7 @@ import (
 )
 
 var (
-	dialClient = &http.Client{}
+	dialClient = &http.Client{Timeout: 30 * time.Second}
 
 	pingPrefix = "pd/ping"
 )
@@ -47,9 +48,12 @@ func InitHTTPSClient(CAPath, CertPath, KeyPath string) error {
 		return errors.WithStack(err)
 	}
 
-	dialClient = &http.Client{Transport: &http.Transport{
-		TLSClientConfig: tlsConfig,
-	}}
+	dialClient = &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
 
 	return nil
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
To avoid the potential hanging, it's better to add a timeout for HTTP clients.

### What is changed and how it works?
This PR adds a timeout for these clients.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
