### PR TITLE
docker: add jq and cache dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,29 @@ RUN apk add --no-cache \
     make \
     git
 
-COPY . /go/src/github.com/pingcap/pd
+# Install jq for pd-ctl
+RUN cd / && \
+    wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O jq && \
+    chmod +x jq
+
+RUN mkdir -p /go/src/github.com/pingcap/pd
 WORKDIR /go/src/github.com/pingcap/pd
+
+# Cache dependencies
+COPY go.mod .
+COPY go.sum .
+
+RUN GO111MODULE=on go mod download
+
+COPY . .
 
 RUN make
 
 FROM alpine:3.5
 
 COPY --from=builder /go/src/github.com/pingcap/pd/bin/pd-server /pd-server
+COPY --from=builder /go/src/github.com/pingcap/pd/bin/pd-ctl /pd-ctl
+COPY --from=builder /jq /usr/local/bin/jq
 
 EXPOSE 2379 2380
 


### PR DESCRIPTION
### What problem does this PR solve? 

+ Add pd-ctl in Docker
+ Add jq support for pd-ctl in Docker
+ Cache dependencies to avoid build them every time


### Check List 

Tests 

 - No code

Code changes

No

Side effects

No

Related changes

No need
