### PR TITLE
log: do not add stack to error log

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -35,6 +35,7 @@ import (
 	"go.etcd.io/etcd/embed"
 	"go.etcd.io/etcd/pkg/transport"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // Config is the pd server configuration.
@@ -791,7 +792,7 @@ func ParseUrls(s string) ([]url.URL, error) {
 
 // SetupLogger setup the logger.
 func (c *Config) SetupLogger() error {
-	lg, p, err := log.InitLogger(&c.Log)
+	lg, p, err := log.InitLogger(&c.Log, zap.AddStacktrace(zapcore.FatalLevel))
 	if err != nil {
 		return err
 	}

--- a/server/region_syncer/history_buffer.go
+++ b/server/region_syncer/history_buffer.go
@@ -134,7 +134,7 @@ func (h *historyBuffer) get(index uint64) *core.RegionInfo {
 func (h *historyBuffer) reload() {
 	v, err := h.kv.Load(historyKey)
 	if err != nil {
-		log.Warn("load history index failed", zap.Error(err))
+		log.Warn("load history index failed", zap.String("error", err.Error()))
 	}
 	if v != "" {
 		h.index, err = strconv.ParseUint(v, 10, 64)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
close https://github.com/pingcap/pd/issues/1523
```
[2019/04/29 04:25:37.846 +00:00] [ERROR] [leader.go:80] ["no etcd leader, check leader later"] [stack="github.com/pingcap/log.Error\n\t/go/pkg/mod/github.com/pingcap/log@v0.0.0-20190214045112-b37da76f67a7/global.go:42\ngithub.com/pingcap/pd/server.(*Server).leaderLoop\n\t/go/src/github.com/pingcap/pd/server/leader.go:80"][2019/04/29 04:25:38.046 +00:00] [ERROR] [leader.go:80] ["no etcd leader, check leader later"] [stack="github.com/pingcap/log.Error\n\t/go/pkg/mod/github.com/pingcap/log@v0.0.0-20190214045112-b37da76f67a7/global.go:42\ngithub.com/pingcap/pd/server.(*Server).leaderLoop\n\t/go/src/github.com/pingcap/pd/server/leader.go:80"]
```
The  stack trace of error level is not required, we can add a field if we need it.
### What is changed and how it works?
change the stack enable level.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)
