### PR TITLE
server: set timeout for MoveLeader

### DIFF
--- a/server/leader.go
+++ b/server/leader.go
@@ -159,7 +159,7 @@ func getLeaderAddr(leader *pdpb.Member) string {
 func (s *Server) MoveEtcdLeader(ctx context.Context, old, new uint64) error {
 	moveCtx, cancel := context.WithTimeout(ctx, moveLeaderTimeout)
 	defer cancel()
-	return errors.WithStack(s.etcd.Server.MoveLeader(moveCtx, old, new))
+	return errors.Trace(s.etcd.Server.MoveLeader(moveCtx, old, new))
 }
 
 // getLeader gets server leader from etcd.
@@ -354,7 +354,7 @@ func (s *Server) ResignLeader(nextLeader string) error {
 	}
 	nextLeaderID := leaderIDs[rand.Intn(len(leaderIDs))]
 	log.Infof("%s ready to resign leader, next leader: %v", s.Name(), nextLeaderID)
-	err = s.MoveEtcdLeader(s.serverLoopCtx, s.ID(), nextLeaderID)
+	err = s.MoveEtcdLeader(s.leaderLoopCtx, s.ID(), nextLeaderID)
 	return errors.Trace(err)
 }
 


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
When multiple PDs calls `MoveLeader`, one will succeed and others will block in `MoveLeader` function.

### What is changed and how it works?
Add timeout when calling `MoveLeader`.
Cherry-pick #1533 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integration test
