### PR TITLE
metrics: fix operator timeout metrics

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -601,7 +601,7 @@ func (c *RaftCluster) checkOperators() {
 			log.Info("operator timeout",
 				zap.Uint64("region-id", op.RegionID()),
 				zap.Stringer("operator", op))
-			opController.RemoveOperator(op)
+			opController.RemoveTimeoutOperator(op)
 		}
 	}
 }

--- a/server/schedule/operator.go
+++ b/server/schedule/operator.go
@@ -370,7 +370,6 @@ func (o *Operator) IsTimeout() bool {
 		timeout = time.Since(o.createTime) > LeaderOperatorWaitTime
 	}
 	if timeout {
-		operatorCounter.WithLabelValues(o.Desc(), "timeout").Inc()
 		return true
 	}
 	return false

--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -93,7 +93,7 @@ func (oc *OperatorController) Dispatch(region *core.RegionInfo, source string) {
 			oc.RemoveOperator(op)
 		} else if timeout {
 			log.Info("operator timeout", zap.Uint64("region-id", region.GetID()), zap.Reflect("operator", op))
-			oc.RemoveOperator(op)
+			oc.RemoveTimeoutOperator(op)
 			oc.opRecords.Put(op, pdpb.OperatorStatus_TIMEOUT)
 		}
 	}
@@ -235,6 +235,14 @@ func (oc *OperatorController) addOperatorLocked(op *Operator) bool {
 func (oc *OperatorController) RemoveOperator(op *Operator) {
 	oc.Lock()
 	defer oc.Unlock()
+	oc.removeOperatorLocked(op)
+}
+
+// RemoveTimeoutOperator removes a operator which is timeout from the running operators.
+func (oc *OperatorController) RemoveTimeoutOperator(op *Operator) {
+	oc.Lock()
+	defer oc.Unlock()
+	operatorCounter.WithLabelValues(op.Desc(), "timeout").Inc()
 	oc.removeOperatorLocked(op)
 }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Currently, the metrics of the timeout operator is updated in `IsTimeout`, which will be calculated multiple times since there are many functions call it.

### What is changed and how it works?
Add a new function `RemoveTimeoutOperator` to update this metrics.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
