### PR TITLE
schedule: move all NewOperator into operator

### DIFF
--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -158,11 +158,7 @@ func (c *coordinator) checkRegion(region *core.RegionInfo) bool {
 		if region.GetPendingLearner(p.GetId()) != nil {
 			continue
 		}
-		step := schedule.PromoteLearner{
-			ToStore: p.GetStoreId(),
-			PeerID:  p.GetId(),
-		}
-		op := schedule.NewOperator("promote-learner", region.GetID(), region.GetRegionEpoch(), schedule.OpRegion, step)
+		op := schedule.CreatePromoteLearnerOperator("promote-learner", region, p)
 		if opController.AddOperator(op) {
 			return true
 		}

--- a/server/handler.go
+++ b/server/handler.go
@@ -16,12 +16,10 @@ package server
 import (
 	"bytes"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/pingcap/errcode"
 	"github.com/pingcap/kvproto/pkg/metapb"
-	"github.com/pingcap/kvproto/pkg/pdpb"
 	log "github.com/pingcap/log"
 	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/server/schedule"
@@ -398,13 +396,13 @@ func (h *Handler) AddTransferLeaderOperator(regionID uint64, storeID uint64) err
 	if region == nil {
 		return ErrRegionNotFound(regionID)
 	}
+
 	newLeader := region.GetStoreVoter(storeID)
 	if newLeader == nil {
 		return errors.Errorf("region has no voter in store %v", storeID)
 	}
 
-	step := schedule.TransferLeader{FromStore: region.GetLeader().GetStoreId(), ToStore: newLeader.GetStoreId()}
-	op := schedule.NewOperator("admin-transfer-leader", regionID, region.GetRegionEpoch(), schedule.OpAdmin|schedule.OpLeader, step)
+	op := schedule.CreateTransferLeaderOperator("admin-transfer-leader", region, region.GetLeader().GetStoreId(), newLeader.GetStoreId(), schedule.OpAdmin)
 	if ok := c.opController.AddOperator(op); !ok {
 		return errors.WithStack(ErrAddOperator)
 	}
@@ -423,9 +421,6 @@ func (h *Handler) AddTransferRegionOperator(regionID uint64, storeIDs map[uint64
 		return ErrRegionNotFound(regionID)
 	}
 
-	var steps []schedule.OperatorStep
-
-	// Add missing peers.
 	for id := range storeIDs {
 		store := c.cluster.GetStore(id)
 		if store == nil {
@@ -437,29 +432,12 @@ func (h *Handler) AddTransferRegionOperator(regionID uint64, storeIDs map[uint64
 		if store.IsTombstone() {
 			return errcode.Op("operator.add").AddTo(core.StoreTombstonedErr{StoreID: id})
 		}
-		peer, err := c.cluster.AllocPeer(id)
-		if err != nil {
-			return err
-		}
-		if c.cluster.IsRaftLearnerEnabled() {
-			steps = append(steps,
-				schedule.AddLearner{ToStore: id, PeerID: peer.Id},
-				schedule.PromoteLearner{ToStore: id, PeerID: peer.Id},
-			)
-		} else {
-			steps = append(steps, schedule.AddPeer{ToStore: id, PeerID: peer.Id})
-		}
 	}
 
-	// Remove redundant peers.
-	for _, peer := range region.GetPeers() {
-		if _, ok := storeIDs[peer.GetStoreId()]; ok {
-			continue
-		}
-		steps = append(steps, schedule.RemovePeer{FromStore: peer.GetStoreId()})
+	op, err := schedule.CreateMoveRegionOperator("admin-move-region", c.cluster, region, schedule.OpAdmin, storeIDs)
+	if err != nil {
+		return err
 	}
-
-	op := schedule.NewOperator("admin-move-region", regionID, region.GetRegionEpoch(), schedule.OpAdmin|schedule.OpRegion, steps...)
 	if ok := c.opController.AddOperator(op); !ok {
 		return errors.WithStack(ErrAddOperator)
 	}
@@ -545,18 +523,7 @@ func (h *Handler) AddAddPeerOperator(regionID uint64, toStoreID uint64) error {
 		return err
 	}
 
-	var steps []schedule.OperatorStep
-	if c.cluster.IsRaftLearnerEnabled() {
-		steps = []schedule.OperatorStep{
-			schedule.AddLearner{ToStore: toStoreID, PeerID: newPeer.GetId()},
-			schedule.PromoteLearner{ToStore: toStoreID, PeerID: newPeer.GetId()},
-		}
-	} else {
-		steps = []schedule.OperatorStep{
-			schedule.AddPeer{ToStore: toStoreID, PeerID: newPeer.GetId()},
-		}
-	}
-	op := schedule.NewOperator("admin-add-peer", regionID, region.GetRegionEpoch(), schedule.OpAdmin|schedule.OpRegion, steps...)
+	op := schedule.CreateAddPeerOperator("admin-add-peer", c.cluster, region, newPeer.GetId(), toStoreID, schedule.OpAdmin)
 	if ok := c.opController.AddOperator(op); !ok {
 		return errors.WithStack(ErrAddOperator)
 	}
@@ -579,10 +546,7 @@ func (h *Handler) AddAddLearnerOperator(regionID uint64, toStoreID uint64) error
 		return err
 	}
 
-	steps := []schedule.OperatorStep{
-		schedule.AddLearner{ToStore: toStoreID, PeerID: newPeer.GetId()},
-	}
-	op := schedule.NewOperator("admin-add-peer", regionID, region.GetRegionEpoch(), schedule.OpAdmin|schedule.OpRegion, steps...)
+	op := schedule.CreateAddLearnerOperator("admin-add-learner", c.cluster, region, newPeer.GetId(), toStoreID, schedule.OpAdmin)
 	if ok := c.opController.AddOperator(op); !ok {
 		return errors.WithStack(ErrAddOperator)
 	}
@@ -670,12 +634,7 @@ func (h *Handler) AddSplitRegionOperator(regionID uint64, policy string) error {
 		return ErrRegionNotFound(regionID)
 	}
 
-	step := schedule.SplitRegion{
-		StartKey: region.GetStartKey(),
-		EndKey:   region.GetEndKey(),
-		Policy:   pdpb.CheckPolicy(pdpb.CheckPolicy_value[strings.ToUpper(policy)]),
-	}
-	op := schedule.NewOperator("admin-split-region", regionID, region.GetRegionEpoch(), schedule.OpAdmin, step)
+	op := schedule.CreateSplitRegionOperator("admin-split-region", region, schedule.OpAdmin, policy)
 	if ok := c.opController.AddOperator(op); !ok {
 		return errors.WithStack(ErrAddOperator)
 	}

--- a/server/handler.go
+++ b/server/handler.go
@@ -421,13 +421,14 @@ func (h *Handler) AddTransferRegionOperator(regionID uint64, storeIDs map[uint64
 		return ErrRegionNotFound(regionID)
 	}
 
+	if len(storeIDs) > c.cluster.GetMaxReplicas() {
+		return errors.Errorf("the number of stores is %v, beyond the max replicas", len(storeIDs))
+	}
+
 	for id := range storeIDs {
 		store := c.cluster.GetStore(id)
 		if store == nil {
 			return core.NewStoreNotFoundErr(id)
-		}
-		if region.GetStorePeer(id) != nil {
-			continue
 		}
 		if store.IsTombstone() {
 			return errcode.Op("operator.add").AddTo(core.StoreTombstonedErr{StoreID: id})

--- a/server/schedule/merge_checker.go
+++ b/server/schedule/merge_checker.go
@@ -109,12 +109,12 @@ func (m *MergeChecker) Check(region *core.RegionInfo) []*Operator {
 		return nil
 	}
 
-	checkerCounter.WithLabelValues("merge_checker", "new_operator").Inc()
 	log.Debug("try to merge region", zap.Reflect("from", core.HexRegionMeta(region.GetMeta())), zap.Reflect("to", core.HexRegionMeta(target.GetMeta())))
 	ops, err := CreateMergeRegionOperator("merge-region", m.cluster, region, target, OpMerge)
 	if err != nil {
 		return nil
 	}
+	checkerCounter.WithLabelValues("merge_checker", "new_operator").Inc()
 	return ops
 }
 

--- a/server/schedule/operator.go
+++ b/server/schedule/operator.go
@@ -509,8 +509,8 @@ func CreateAddPeerOperator(desc string, cluster Cluster, region *core.RegionInfo
 
 // CreateAddLearnerOperator creates an operator that adds a new learner.
 func CreateAddLearnerOperator(desc string, cluster Cluster, region *core.RegionInfo, peerID uint64, toStoreID uint64, kind OperatorKind) *Operator {
-	steps := []OperatorStep{AddLearner{ToStore: toStoreID, PeerID: peerID}}
-	return NewOperator(desc, region.GetID(), region.GetRegionEpoch(), kind|OpRegion, steps...)
+	step := AddLearner{ToStore: toStoreID, PeerID: peerID}
+	return NewOperator(desc, region.GetID(), region.GetRegionEpoch(), kind|OpRegion, step)
 }
 
 // CreatePromoteLearnerOperator creates an operator that promotes a learner.
@@ -565,8 +565,8 @@ func CreateAddLightPeerSteps(newStore uint64, peerID uint64, cluster Cluster) []
 
 // CreateTransferLeaderOperator creates an operator that transfers the leader from a source store to a target store.
 func CreateTransferLeaderOperator(desc string, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64, kind OperatorKind) *Operator {
-	steps := TransferLeader{FromStore: sourceStoreID, ToStore: targetStoreID}
-	return NewOperator(desc, region.GetID(), region.GetRegionEpoch(), kind|OpLeader, steps)
+	step := TransferLeader{FromStore: sourceStoreID, ToStore: targetStoreID}
+	return NewOperator(desc, region.GetID(), region.GetRegionEpoch(), kind|OpLeader, step)
 }
 
 // CreateMoveRegionOperator creates an operator that moves a region to specified stores.

--- a/server/schedule/operator.go
+++ b/server/schedule/operator.go
@@ -17,7 +17,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math/rand"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -499,6 +501,27 @@ func (o *Operator) History() []OperatorHistory {
 	return histories
 }
 
+// CreateAddPeerOperator creates an operator that adds a new peer.
+func CreateAddPeerOperator(desc string, cluster Cluster, region *core.RegionInfo, peerID uint64, toStoreID uint64, kind OperatorKind) *Operator {
+	steps := CreateAddPeerSteps(toStoreID, peerID, cluster)
+	return NewOperator(desc, region.GetID(), region.GetRegionEpoch(), kind|OpRegion, steps...)
+}
+
+// CreateAddLearnerOperator creates an operator that adds a new learner.
+func CreateAddLearnerOperator(desc string, cluster Cluster, region *core.RegionInfo, peerID uint64, toStoreID uint64, kind OperatorKind) *Operator {
+	steps := []OperatorStep{AddLearner{ToStore: toStoreID, PeerID: peerID}}
+	return NewOperator(desc, region.GetID(), region.GetRegionEpoch(), kind|OpRegion, steps...)
+}
+
+// CreatePromoteLearnerOperator creates an operator that promotes a learner.
+func CreatePromoteLearnerOperator(desc string, region *core.RegionInfo, peer *metapb.Peer) *Operator {
+	step := PromoteLearner{
+		ToStore: peer.GetStoreId(),
+		PeerID:  peer.GetId(),
+	}
+	return NewOperator(desc, region.GetID(), region.GetRegionEpoch(), OpRegion, step)
+}
+
 // CreateRemovePeerOperator creates an operator that removes a peer from region.
 func CreateRemovePeerOperator(desc string, cluster Cluster, kind OperatorKind, region *core.RegionInfo, storeID uint64) (*Operator, error) {
 	removeKind, steps, err := removePeerSteps(cluster, region, storeID, getRegionFollowerIDs(region))
@@ -540,6 +563,41 @@ func CreateAddLightPeerSteps(newStore uint64, peerID uint64, cluster Cluster) []
 	return st
 }
 
+// CreateTransferLeaderOperator creates an operator that transfers the leader from a source store to a target store.
+func CreateTransferLeaderOperator(desc string, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64, kind OperatorKind) *Operator {
+	steps := TransferLeader{FromStore: sourceStoreID, ToStore: targetStoreID}
+	return NewOperator(desc, region.GetID(), region.GetRegionEpoch(), kind|OpLeader, steps)
+}
+
+// CreateMoveRegionOperator creates an operator that moves a region to specified stores.
+func CreateMoveRegionOperator(desc string, cluster Cluster, region *core.RegionInfo, kind OperatorKind, storeIDs map[uint64]struct{}) (*Operator, error) {
+	var steps []OperatorStep
+	// Add missing peers.
+	for id := range storeIDs {
+		peer, err := cluster.AllocPeer(id)
+		if err != nil {
+			return nil, err
+		}
+		if cluster.IsRaftLearnerEnabled() {
+			steps = append(steps,
+				AddLearner{ToStore: id, PeerID: peer.Id},
+				PromoteLearner{ToStore: id, PeerID: peer.Id},
+			)
+		} else {
+			steps = append(steps, AddPeer{ToStore: id, PeerID: peer.Id})
+		}
+	}
+
+	// Remove redundant peers.
+	for _, peer := range region.GetPeers() {
+		if _, ok := storeIDs[peer.GetStoreId()]; ok {
+			continue
+		}
+		steps = append(steps, RemovePeer{FromStore: peer.GetStoreId()})
+	}
+	return NewOperator(desc, region.GetID(), region.GetRegionEpoch(), kind|OpRegion, steps...), nil
+}
+
 // CreateMovePeerOperator creates an operator that replaces an old peer with a new peer.
 func CreateMovePeerOperator(desc string, cluster Cluster, region *core.RegionInfo, kind OperatorKind, oldStore, newStore uint64, peerID uint64) (*Operator, error) {
 	removeKind, steps, err := removePeerSteps(cluster, region, oldStore, append(getRegionFollowerIDs(region), newStore))
@@ -549,6 +607,27 @@ func CreateMovePeerOperator(desc string, cluster Cluster, region *core.RegionInf
 	st := CreateAddPeerSteps(newStore, peerID, cluster)
 	steps = append(st, steps...)
 	return NewOperator(desc, region.GetID(), region.GetRegionEpoch(), removeKind|kind|OpRegion, steps...), nil
+}
+
+// CreateMoveLeaderOperator creates an operator that replaces an old leader with a new leader.
+func CreateMoveLeaderOperator(desc string, cluster Cluster, region *core.RegionInfo, kind OperatorKind, oldStore, newStore uint64, peerID uint64) (*Operator, error) {
+	removeKind, steps, err := removePeerSteps(cluster, region, oldStore, []uint64{newStore})
+	if err != nil {
+		return nil, err
+	}
+	st := CreateAddPeerSteps(newStore, peerID, cluster)
+	steps = append(st, steps...)
+	return NewOperator(desc, region.GetID(), region.GetRegionEpoch(), removeKind|kind|OpLeader|OpRegion, steps...), nil
+}
+
+// CreateSplitRegionOperator creates an operator that splits a region.
+func CreateSplitRegionOperator(desc string, region *core.RegionInfo, kind OperatorKind, policy string) *Operator {
+	step := SplitRegion{
+		StartKey: region.GetStartKey(),
+		EndKey:   region.GetEndKey(),
+		Policy:   pdpb.CheckPolicy(pdpb.CheckPolicy_value[strings.ToUpper(policy)]),
+	}
+	return NewOperator(desc, region.GetID(), region.GetRegionEpoch(), kind, step)
 }
 
 func getRegionFollowerIDs(region *core.RegionInfo) []uint64 {
@@ -723,6 +802,76 @@ func getIntersectionStores(a []*metapb.Peer, b []*metapb.Peer) map[uint64]struct
 	}
 
 	return intersection
+}
+
+// CreateScatterRegionOperator creates an operator that scatters the specified region.
+func CreateScatterRegionOperator(desc string, cluster Cluster, origin *core.RegionInfo, replacedPeers, targetPeers []*metapb.Peer) *Operator {
+	// Randomly pick a leader
+	i := rand.Intn(len(targetPeers))
+	targetLeaderPeer := targetPeers[i]
+	originLeaderStoreID := origin.GetLeader().GetStoreId()
+
+	originStoreIDs := origin.GetStoreIds()
+	steps := make([]OperatorStep, 0, len(targetPeers)*3+1)
+	// deferSteps will append to the end of the steps
+	deferSteps := make([]OperatorStep, 0, 5)
+	var kind OperatorKind
+	sameLeader := targetLeaderPeer.GetStoreId() == originLeaderStoreID
+	// No need to do anything
+	if sameLeader {
+		isSame := true
+		for _, peer := range targetPeers {
+			if _, ok := originStoreIDs[peer.GetStoreId()]; !ok {
+				isSame = false
+				break
+			}
+		}
+		if isSame {
+			return nil
+		}
+	}
+
+	// Creates the first step
+	if _, ok := originStoreIDs[targetLeaderPeer.GetStoreId()]; !ok {
+		st := CreateAddLightPeerSteps(targetLeaderPeer.GetStoreId(), targetLeaderPeer.GetId(), cluster)
+		steps = append(steps, st...)
+		// Do not transfer leader to the newly added peer
+		// Ref: https://github.com/tikv/tikv/issues/3819
+		deferSteps = append(deferSteps, TransferLeader{FromStore: originLeaderStoreID, ToStore: targetLeaderPeer.GetStoreId()})
+		deferSteps = append(deferSteps, RemovePeer{FromStore: replacedPeers[i].GetStoreId()})
+		kind |= OpLeader
+		kind |= OpRegion
+	} else {
+		if !sameLeader {
+			steps = append(steps, TransferLeader{FromStore: originLeaderStoreID, ToStore: targetLeaderPeer.GetStoreId()})
+			kind |= OpLeader
+		}
+	}
+
+	// For the other steps
+	for j, peer := range targetPeers {
+		if peer.GetId() == targetLeaderPeer.GetId() {
+			continue
+		}
+		if _, ok := originStoreIDs[peer.GetStoreId()]; ok {
+			continue
+		}
+		if replacedPeers[j].GetStoreId() == originLeaderStoreID {
+			st := CreateAddLightPeerSteps(peer.GetStoreId(), peer.GetId(), cluster)
+			st = append(st, RemovePeer{FromStore: replacedPeers[j].GetStoreId()})
+			deferSteps = append(deferSteps, st...)
+			kind |= OpRegion | OpLeader
+			continue
+		}
+		st := CreateAddLightPeerSteps(peer.GetStoreId(), peer.GetId(), cluster)
+		steps = append(steps, st...)
+		steps = append(steps, RemovePeer{FromStore: replacedPeers[j].GetStoreId()})
+		kind |= OpRegion
+	}
+
+	steps = append(steps, deferSteps...)
+	op := NewOperator(desc, origin.GetID(), origin.GetRegionEpoch(), kind, steps...)
+	return op
 }
 
 // CheckOperatorValid checks if the operator is valid.

--- a/server/schedule/operator.go
+++ b/server/schedule/operator.go
@@ -625,6 +625,7 @@ func CreateMoveLeaderOperator(desc string, cluster Cluster, region *core.RegionI
 		return nil, err
 	}
 	st := CreateAddPeerSteps(newStore, peerID, cluster)
+	st = append(st, TransferLeader{ToStore: newStore, FromStore: oldStore})
 	steps = append(st, steps...)
 	return NewOperator(desc, region.GetID(), region.GetRegionEpoch(), removeKind|kind|OpLeader|OpRegion, steps...), nil
 }

--- a/server/schedule/replica_checker.go
+++ b/server/schedule/replica_checker.go
@@ -70,19 +70,8 @@ func (r *ReplicaChecker) Check(region *core.RegionInfo) *Operator {
 			checkerCounter.WithLabelValues("replica_checker", "no_target_store").Inc()
 			return nil
 		}
-		var steps []OperatorStep
-		if r.cluster.IsRaftLearnerEnabled() {
-			steps = []OperatorStep{
-				AddLearner{ToStore: newPeer.GetStoreId(), PeerID: newPeer.GetId()},
-				PromoteLearner{ToStore: newPeer.GetStoreId(), PeerID: newPeer.GetId()},
-			}
-		} else {
-			steps = []OperatorStep{
-				AddPeer{ToStore: newPeer.GetStoreId(), PeerID: newPeer.GetId()},
-			}
-		}
 		checkerCounter.WithLabelValues("replica_checker", "new_operator").Inc()
-		return NewOperator("make-up-replica", region.GetID(), region.GetRegionEpoch(), OpReplica|OpRegion, steps...)
+		return CreateAddPeerOperator("make-up-replica", r.cluster, region, newPeer.GetId(), newPeer.GetStoreId(), OpReplica)
 	}
 
 	// when add learner peer, the number of peer will exceed max replicas for a while,

--- a/server/schedulers/adjacent_region.go
+++ b/server/schedulers/adjacent_region.go
@@ -269,8 +269,7 @@ func (l *balanceAdjacentRegionScheduler) disperseLeader(cluster schedule.Cluster
 	if target == nil {
 		return nil
 	}
-	step := schedule.TransferLeader{FromStore: before.GetLeader().GetStoreId(), ToStore: target.GetID()}
-	op := schedule.NewOperator("balance-adjacent-leader", before.GetID(), before.GetRegionEpoch(), schedule.OpAdjacent|schedule.OpLeader, step)
+	op := schedule.CreateTransferLeaderOperator("balance-adjacent-leader", before, before.GetLeader().GetStoreId(), target.GetID(), schedule.OpAdjacent)
 	op.SetPriorityLevel(core.LowPriority)
 	schedulerCounter.WithLabelValues(l.GetName(), "adjacent_leader").Inc()
 	return op

--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -192,7 +192,6 @@ func (l *balanceLeaderScheduler) createOperator(region *core.RegionInfo, source,
 	targetLabel := strconv.FormatUint(targetID, 10)
 	balanceLeaderCounter.WithLabelValues("move_leader", source.GetAddress()+"-out", sourceLabel).Inc()
 	balanceLeaderCounter.WithLabelValues("move_leader", target.GetAddress()+"-in", targetLabel).Inc()
-	step := schedule.TransferLeader{FromStore: region.GetLeader().GetStoreId(), ToStore: targetID}
-	op := schedule.NewOperator("balance-leader", regionID, region.GetRegionEpoch(), schedule.OpBalance|schedule.OpLeader, step)
+	op := schedule.CreateTransferLeaderOperator("balance-leader", region, region.GetLeader().GetStoreId(), targetID, schedule.OpBalance)
 	return []*schedule.Operator{op}
 }

--- a/server/schedulers/evict_leader.go
+++ b/server/schedulers/evict_leader.go
@@ -90,8 +90,7 @@ func (s *evictLeaderScheduler) Schedule(cluster schedule.Cluster) []*schedule.Op
 		return nil
 	}
 	schedulerCounter.WithLabelValues(s.GetName(), "new_operator").Inc()
-	step := schedule.TransferLeader{FromStore: region.GetLeader().GetStoreId(), ToStore: target.GetID()}
-	op := schedule.NewOperator("evict-leader", region.GetID(), region.GetRegionEpoch(), schedule.OpLeader, step)
+	op := schedule.CreateTransferLeaderOperator("evict-leader", region, region.GetLeader().GetStoreId(), target.GetID(), schedule.OpLeader)
 	op.SetPriorityLevel(core.HighPriority)
 	return []*schedule.Operator{op}
 }

--- a/server/schedulers/grant_leader.go
+++ b/server/schedulers/grant_leader.go
@@ -80,8 +80,7 @@ func (s *grantLeaderScheduler) Schedule(cluster schedule.Cluster) []*schedule.Op
 		return nil
 	}
 	schedulerCounter.WithLabelValues(s.GetName(), "new_operator").Inc()
-	step := schedule.TransferLeader{FromStore: region.GetLeader().GetStoreId(), ToStore: s.storeID}
-	op := schedule.NewOperator("grant-leader", region.GetID(), region.GetRegionEpoch(), schedule.OpLeader, step)
+	op := schedule.CreateTransferLeaderOperator("grant-leader", region, region.GetLeader().GetStoreId(), s.storeID, schedule.OpLeader)
 	op.SetPriorityLevel(core.HighPriority)
 	return []*schedule.Operator{op}
 }

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -161,8 +161,7 @@ func (h *balanceHotRegionsScheduler) balanceHotReadRegions(cluster schedule.Clus
 	srcRegion, newLeader := h.balanceByLeader(cluster, h.stats.readStatAsLeader)
 	if srcRegion != nil {
 		schedulerCounter.WithLabelValues(h.GetName(), "move_leader").Inc()
-		step := schedule.TransferLeader{FromStore: srcRegion.GetLeader().GetStoreId(), ToStore: newLeader.GetStoreId()}
-		op := schedule.NewOperator("transfer-hot-read-leader", srcRegion.GetID(), srcRegion.GetRegionEpoch(), schedule.OpHotRegion|schedule.OpLeader, step)
+		op := schedule.CreateTransferLeaderOperator("transfer-hot-read-leader", srcRegion, srcRegion.GetLeader().GetStoreId(), newLeader.GetStoreId(), schedule.OpHotRegion)
 		op.SetPriorityLevel(core.HighPriority)
 		return []*schedule.Operator{op}
 	}
@@ -207,8 +206,7 @@ func (h *balanceHotRegionsScheduler) balanceHotWriteRegions(cluster schedule.Clu
 			srcRegion, newLeader := h.balanceByLeader(cluster, h.stats.writeStatAsLeader)
 			if srcRegion != nil {
 				schedulerCounter.WithLabelValues(h.GetName(), "move_leader").Inc()
-				step := schedule.TransferLeader{FromStore: srcRegion.GetLeader().GetStoreId(), ToStore: newLeader.GetStoreId()}
-				op := schedule.NewOperator("transfer-hot-write-leader", srcRegion.GetID(), srcRegion.GetRegionEpoch(), schedule.OpHotRegion|schedule.OpLeader, step)
+				op := schedule.CreateTransferLeaderOperator("transfer-hot-write-leader", srcRegion, srcRegion.GetLeader().GetStoreId(), newLeader.GetStoreId(), schedule.OpHotRegion)
 				op.SetPriorityLevel(core.HighPriority)
 				return []*schedule.Operator{op}
 			}

--- a/server/schedulers/label.go
+++ b/server/schedulers/label.go
@@ -89,8 +89,7 @@ func (s *labelScheduler) Schedule(cluster schedule.Cluster) []*schedule.Operator
 			}
 
 			schedulerCounter.WithLabelValues(s.GetName(), "new_operator").Inc()
-			step := schedule.TransferLeader{FromStore: id, ToStore: target.GetID()}
-			op := schedule.NewOperator("label-reject-leader", region.GetID(), region.GetRegionEpoch(), schedule.OpLeader, step)
+			op := schedule.CreateTransferLeaderOperator("label-reject-leader", region, id, target.GetID(), schedule.OpLeader)
 			return []*schedule.Operator{op}
 		}
 	}

--- a/server/schedulers/random_merge.go
+++ b/server/schedulers/random_merge.go
@@ -80,10 +80,10 @@ func (s *randomMergeScheduler) Schedule(cluster schedule.Cluster) []*schedule.Op
 		return nil
 	}
 
-	schedulerCounter.WithLabelValues(s.GetName(), "new_operator").Inc()
 	ops, err := schedule.CreateMergeRegionOperator("random-merge", cluster, region, target, schedule.OpAdmin)
 	if err != nil {
 		return nil
 	}
+	schedulerCounter.WithLabelValues(s.GetName(), "new_operator").Inc()
 	return ops
 }

--- a/server/schedulers/shuffle_leader.go
+++ b/server/schedulers/shuffle_leader.go
@@ -71,8 +71,7 @@ func (s *shuffleLeaderScheduler) Schedule(cluster schedule.Cluster) []*schedule.
 		return nil
 	}
 	schedulerCounter.WithLabelValues(s.GetName(), "new_operator").Inc()
-	step := schedule.TransferLeader{FromStore: region.GetLeader().GetStoreId(), ToStore: targetStore.GetID()}
-	op := schedule.NewOperator("shuffle-leader", region.GetID(), region.GetRegionEpoch(), schedule.OpAdmin|schedule.OpLeader, step)
+	op := schedule.CreateTransferLeaderOperator("shuffle-leader", region, region.GetLeader().GetId(), targetStore.GetID(), schedule.OpAdmin)
 	op.SetPriorityLevel(core.HighPriority)
 	return []*schedule.Operator{op}
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
We have a lot of operators right now, and these operators are created through API, schedulers and checkers. We use `NewOperator` everywhere and each of them needs `steps` as the parameters, which is complex.

### What is changed and how it works?
Since we already have some functions like `CreateMovePeerOperator`. This PR abstracts more functions to create corresponding operators and makes the code unified.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test