### PR TITLE
*: use staticcheck instead of megacheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ static:
 
 	CGO_ENABLED=0 ./hack/retool do gometalinter.v2 --disable-all --deadline 120s \
 	  --enable misspell \
-	  --enable megacheck \
+	  --enable staticcheck \
 	  --enable ineffassign \
 	  $$($(PACKAGE_DIRECTORIES))
 

--- a/hack/retool-install.sh
+++ b/hack/retool-install.sh
@@ -14,7 +14,7 @@ which retool >/dev/null || go get github.com/twitchtv/retool
 ./hack/retool add github.com/client9/misspell/cmd/misspell v0.3.4
 # checks correctness
 ./hack/retool add github.com/gordonklaus/ineffassign 7bae11eba15a3285c75e388f77eb6357a2d73ee2
-./hack/retool add honnef.co/go/tools/cmd/megacheck master
+./hack/retool add honnef.co/go/tools/cmd/staticcheck master
 ./hack/retool add github.com/dnephin/govet 4a96d43e39d340b63daa8bc5576985aa599885f6
 # slow checks
 ./hack/retool add github.com/kisielk/errcheck v1.1.0

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -934,6 +934,8 @@ func (s *testBalanceHotWriteRegionSchedulerSuite) TestBalance(c *C) {
 	hb.Schedule(tc, schedule.NewOpInfluence(nil, tc))
 }
 
+var _ = Suite(&testBalanceHotReadRegionSchedulerSuite{})
+
 type testBalanceHotReadRegionSchedulerSuite struct{}
 
 func (s *testBalanceHotReadRegionSchedulerSuite) TestBalance(c *C) {

--- a/tools.json
+++ b/tools.json
@@ -1,8 +1,8 @@
 {
   "Tools": [
     {
-      "Repository": "honnef.co/go/tools/cmd/megacheck",
-      "Commit": "3ac6a802416d2efd6654491fe47f693e56d8eb4e"
+      "Repository": "honnef.co/go/tools/cmd/staticcheck",
+      "Commit": "5a4a2f4a438d01ba03c591f88ef312005a05063b"
     },
     {
       "Repository": "gopkg.in/alecthomas/gometalinter.v2",


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
The CI of `release-2.1` branch has been broken since `megacheck` is deprecated.

### What is changed and how it works?
This PR fixes this problem by using `staticcheck` and also fixes a lint problem.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
