### PR TITLE
pdctl: support to delete a store by its address

### DIFF
--- a/tests/pdctl/store/store_test.go
+++ b/tests/pdctl/store/store_test.go
@@ -56,8 +56,14 @@ func (s *storeTestSuite) TestStore(c *C) {
 			Version: "2.0.0",
 		},
 		{
-			Id:      2,
+			Id:      3,
 			Address: "tikv3",
+			State:   metapb.StoreState_Up,
+			Version: "2.0.0",
+		},
+		{
+			Id:      2,
+			Address: "tikv2",
 			State:   metapb.StoreState_Tombstone,
 			Version: "2.0.0",
 		},
@@ -77,7 +83,7 @@ func (s *storeTestSuite) TestStore(c *C) {
 	c.Assert(err, IsNil)
 	storesInfo := new(api.StoresInfo)
 	c.Assert(json.Unmarshal(output, &storesInfo), IsNil)
-	pdctl.CheckStoresInfo(c, storesInfo.Stores, stores[:1])
+	pdctl.CheckStoresInfo(c, storesInfo.Stores, stores[:2])
 
 	// store <store_id> command
 	args = []string{"-u", pdAddr, "store", "1"}
@@ -119,6 +125,17 @@ func (s *storeTestSuite) TestStore(c *C) {
 	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
 	c.Assert(err, IsNil)
 	args = []string{"-u", pdAddr, "store", "1"}
+	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	c.Assert(err, IsNil)
+	c.Assert(json.Unmarshal(output, &storeInfo), IsNil)
+	c.Assert(storeInfo.Store.State, Equals, metapb.StoreState_Offline)
+
+	// store delete addr <address>
+	args = []string{"-u", pdAddr, "store", "delete", "addr", "tikv3"}
+	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	c.Assert(string(output), Equals, "Success!\n")
+	c.Assert(err, IsNil)
+	args = []string{"-u", pdAddr, "store", "3"}
 	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
 	c.Assert(err, IsNil)
 	c.Assert(json.Unmarshal(output, &storeInfo), IsNil)

--- a/tools/pd-ctl/pdctl/command/store_command.go
+++ b/tools/pd-ctl/pdctl/command/store_command.go
@@ -221,6 +221,7 @@ func deleteStoreCommandByAddrFunc(cmd *cobra.Command, args []string) {
 	}{}
 	if err = json.Unmarshal([]byte(r), &storeInfo); err != nil {
 		cmd.Printf("Failed to parse store info: %s\n", err)
+		return
 	}
 
 	// filter by the addr

--- a/tools/pd-ctl/pdctl/command/store_command.go
+++ b/tools/pd-ctl/pdctl/command/store_command.go
@@ -228,6 +228,7 @@ func deleteStoreCommandByAddrFunc(cmd *cobra.Command, args []string) {
 	for _, store := range storeInfo.Stores {
 		if store.Store.Address == addr {
 			id = store.Store.ID
+			break
 		}
 	}
 

--- a/tools/pd-ctl/pdctl/command/store_command.go
+++ b/tools/pd-ctl/pdctl/command/store_command.go
@@ -16,7 +16,6 @@ package command
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"path"
 	"strconv"
@@ -200,10 +199,7 @@ func deleteStoreCommandByAddrFunc(cmd *cobra.Command, args []string) {
 		return
 	}
 	addr := args[0]
-	if _, _, err := net.SplitHostPort(addr); err != nil {
-		cmd.Printf("invalid address: %v\n", err)
-		return
-	}
+
 	// fetch all the stores
 	r, err := doRequest(cmd, storesPrefix, http.MethodGet)
 	if err != nil {


### PR DESCRIPTION
closes #1517

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

https://github.com/pingcap/pd/issues/1517
Support removing a TiKV store by its address.

### What is changed and how it works?

Extend the `delete` command

```
store delete addr <address>
```
There are two HTTP requests issued in this command, first to fetch all the stores, finding the ID by its address and second to delete the store by the ID.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below) 
 - Integration test

