### PR TITLE
set detached as default mode for pd-ctl

### DIFF
--- a/tools/pd-ctl/README.md
+++ b/tools/pd-ctl/README.md
@@ -40,6 +40,11 @@ Use TLS to encrypt:
 + Default address: http://127.0.0.1:2379
 + Environment variable: PD_ADDR
 
+### \-\-detach,-d
+
++ Use single command line mode (not entering readline)
++ Default: true
+
 ### \-\-interact,-i
 
 + Use interactive mode (entering readline)

--- a/tools/pd-ctl/README.md
+++ b/tools/pd-ctl/README.md
@@ -13,11 +13,11 @@ pd-ctl is a command line tool for PD, pd-ctl obtains the state information of th
 
 Single-command mode:
 
-    ./pd-ctl store -d -u http://127.0.0.1:2379
+    ./pd-ctl store -u http://127.0.0.1:2379
 
 Interactive mode:
 
-    ./pd-ctl -u http://127.0.0.1:2379
+    ./pd-ctl -i -u http://127.0.0.1:2379
 
 Use environment variables:
 
@@ -40,9 +40,9 @@ Use TLS to encrypt:
 + Default address: http://127.0.0.1:2379
 + Environment variable: PD_ADDR
 
-### \-\-detach,-d
+### \-\-interact,-i
 
-+ Use single command line mode (not entering readline)
++ Use interactive mode (entering readline)
 + Default: false
 
 ### --cacert

--- a/tools/pd-ctl/main.go
+++ b/tools/pd-ctl/main.go
@@ -31,6 +31,7 @@ import (
 
 var (
 	url      string
+	detach   bool
 	interact bool
 	version  bool
 	caPath   string
@@ -40,6 +41,7 @@ var (
 
 func init() {
 	flag.StringVarP(&url, "pd", "u", "http://127.0.0.1:2379", "The pd address")
+	flag.BoolVarP(&detach, "detach", "d", true, "Run pdctl without readline")
 	flag.BoolVarP(&interact, "interact", "i", false, "Run pdctl with readline")
 	flag.BoolVarP(&version, "version", "V", false, "print version information and exit")
 	flag.StringVar(&caPath, "cacert", "", "path of file that contains list of trusted SSL CAs.")
@@ -80,7 +82,7 @@ func main() {
 	var input []string
 	stat, _ := os.Stdin.Stat()
 	if (stat.Mode() & os.ModeCharDevice) == 0 {
-		interact = false
+		detach = true
 		b, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
 			fmt.Println(err)

--- a/tools/pd-ctl/main.go
+++ b/tools/pd-ctl/main.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	url      string
-	detach   bool
+	interact bool
 	version  bool
 	caPath   string
 	certPath string
@@ -40,7 +40,7 @@ var (
 
 func init() {
 	flag.StringVarP(&url, "pd", "u", "http://127.0.0.1:2379", "The pd address")
-	flag.BoolVarP(&detach, "detach", "d", false, "Run pdctl without readline")
+	flag.BoolVarP(&interact, "interact", "i", false, "Run pdctl with readline")
 	flag.BoolVarP(&version, "version", "V", false, "print version information and exit")
 	flag.StringVar(&caPath, "cacert", "", "path of file that contains list of trusted SSL CAs.")
 	flag.StringVar(&certPath, "cert", "", "path of file that contains X509 certificate in PEM format.")
@@ -80,7 +80,7 @@ func main() {
 	var input []string
 	stat, _ := os.Stdin.Stat()
 	if (stat.Mode() & os.ModeCharDevice) == 0 {
-		detach = true
+		interact = false
 		b, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
 			fmt.Println(err)
@@ -88,11 +88,11 @@ func main() {
 		}
 		input = strings.Split(strings.TrimSpace(string(b[:])), " ")
 	}
-	if detach {
-		pdctl.Start(append(os.Args[1:], input...))
+	if interact {
+		loop()
 		return
 	}
-	loop()
+	pdctl.Start(append(os.Args[1:], input...))
 }
 
 func loop() {

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -67,11 +67,14 @@ func Start(args []string) {
 
 	rootCmd.SetArgs(args)
 	rootCmd.SilenceErrors = true
-	if err := rootCmd.ParseFlags(args); err != nil {
-		rootCmd.Println(err)
-	}
 	rootCmd.SetUsageTemplate(command.UsageTemplate)
 	rootCmd.SetOutput(os.Stdout)
+
+	if err := rootCmd.ParseFlags(args); err != nil {
+		rootCmd.Println(err)
+		rootCmd.Println(rootCmd.UsageString())
+		return
+	}
 
 	if len(commandFlags.CAPath) != 0 {
 		if err := command.InitHTTPSClient(commandFlags.CAPath, commandFlags.CertPath, commandFlags.KeyPath); err != nil {


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
solve issue [1518](https://github.com/pingcap/pd/issues/1518)

`./pd-ctl` to use detached mode by default
`./pd-ctl -i` to use interactive mode

### What is changed and how it works?

modify the flag parameter

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has configuration change

Side effects

Related changes

 - Need to update the documentation
 - Need to be included in the release notes
