### PR TITLE
makefile: add the capability to build binarys separately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,20 +35,19 @@ dev: build check test
 
 ci: build check basic-test
 
-build: export GO111MODULE=on
 build: pd-server pd-ctl pd-tso-bench pd-recover
-pd-server:
+pd-server: export GO111MODULE=on
 ifeq ("$(WITH_RACE)", "1")
 	CGO_ENABLED=1 go build -race -ldflags '$(LDFLAGS)' -o bin/pd-server cmd/pd-server/main.go
 else
 	CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o bin/pd-server cmd/pd-server/main.go
 endif
 
-pd-ctl:
+pd-ctl: export GO111MODULE=on
 	CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o bin/pd-ctl tools/pd-ctl/main.go
-pd-tso-bench:
+pd-tso-bench: export GO111MODULE=on
 	CGO_ENABLED=0 go build -o bin/pd-tso-bench tools/pd-tso-bench/main.go
-pd-recover:
+pd-recover: export GO111MODULE=on
 	CGO_ENABLED=0 go build -o bin/pd-recover tools/pd-recover/main.go
 
 test: retool-setup

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ ci: build check basic-test
 
 build: pd-server pd-ctl pd-tso-bench pd-recover
 pd-server: export GO111MODULE=on
+pd-server:
 ifeq ("$(WITH_RACE)", "1")
 	CGO_ENABLED=1 go build -race -ldflags '$(LDFLAGS)' -o bin/pd-server cmd/pd-server/main.go
 else
@@ -44,10 +45,13 @@ else
 endif
 
 pd-ctl: export GO111MODULE=on
+pd-ctl:
 	CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o bin/pd-ctl tools/pd-ctl/main.go
 pd-tso-bench: export GO111MODULE=on
+pd-tso-bench:
 	CGO_ENABLED=0 go build -o bin/pd-tso-bench tools/pd-tso-bench/main.go
 pd-recover: export GO111MODULE=on
+pd-recover:
 	CGO_ENABLED=0 go build -o bin/pd-recover tools/pd-recover/main.go
 
 test: retool-setup

--- a/Makefile
+++ b/Makefile
@@ -36,14 +36,19 @@ dev: build check test
 ci: build check basic-test
 
 build: export GO111MODULE=on
-build:
+build: pd-server pd-ctl pd-tso-bench pd-recover
+pd-server:
 ifeq ("$(WITH_RACE)", "1")
 	CGO_ENABLED=1 go build -race -ldflags '$(LDFLAGS)' -o bin/pd-server cmd/pd-server/main.go
 else
 	CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o bin/pd-server cmd/pd-server/main.go
 endif
+
+pd-ctl:
 	CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o bin/pd-ctl tools/pd-ctl/main.go
+pd-tso-bench:
 	CGO_ENABLED=0 go build -o bin/pd-tso-bench tools/pd-tso-bench/main.go
+pd-recover:
 	CGO_ENABLED=0 go build -o bin/pd-recover tools/pd-recover/main.go
 
 test: retool-setup


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

Improve the `Makefile` to build binaries separately. The most time we want to build is the `pd-server` when in a modify-test-modify workflow.

### What is changed and how it works?

* `make` keeps the original behavior
* `make pd-server` builds the pd-server only
* `make pd-ctl` builds the pd-ctl only
* `make pd-tso-bench` builds the pd-tso-bench only
* `make pd-recover` builds the pd-recover only

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

