### PR TITLE
server: use a different timeout for http clients

### DIFF
--- a/server/api/redirector.go
+++ b/server/api/redirector.go
@@ -79,7 +79,7 @@ type customReverseProxies struct {
 
 func newCustomReverseProxies(urls []url.URL) *customReverseProxies {
 	p := &customReverseProxies{
-		client: server.DialClient,
+		client: dialClient,
 	}
 
 	p.urls = append(p.urls, urls...)

--- a/server/api/util.go
+++ b/server/api/util.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"time"
 
 	"github.com/pingcap/errcode"
 	log "github.com/pingcap/log"
@@ -28,11 +27,8 @@ import (
 	"github.com/unrolled/render"
 )
 
-const clientTimeout = 30 * time.Second
-
 // dialClient used to dail http request.
 var dialClient = &http.Client{
-	Timeout: clientTimeout,
 	Transport: &http.Transport{
 		DisableKeepAlives: true,
 	},

--- a/server/server.go
+++ b/server/server.go
@@ -838,7 +838,7 @@ func (s *Server) CheckHealth(members []*pdpb.Member) map[uint64]*pdpb.Member {
 	unhealthMembers := make(map[uint64]*pdpb.Member)
 	for _, member := range members {
 		for _, cURL := range member.ClientUrls {
-			resp, err := DialClient.Get(fmt.Sprintf("%s%s", cURL, healthURL))
+			resp, err := dialClient.Get(fmt.Sprintf("%s%s", cURL, healthURL))
 			if resp != nil {
 				resp.Body.Close()
 			}

--- a/server/util.go
+++ b/server/util.go
@@ -35,7 +35,7 @@ import (
 const (
 	requestTimeout  = etcdutil.DefaultRequestTimeout
 	slowRequestTime = etcdutil.DefaultSlowRequestTime
-	clientTimeout   = 30 * time.Second
+	clientTimeout   = 3 * time.Second
 )
 
 // Version information.
@@ -46,8 +46,8 @@ var (
 	PDGitBranch      = "None"
 )
 
-// DialClient used to dail http request.
-var DialClient = &http.Client{
+// dialClient used to dail http request.
+var dialClient = &http.Client{
 	Timeout: clientTimeout,
 	Transport: &http.Transport{
 		DisableKeepAlives: true,
@@ -274,7 +274,7 @@ func InitHTTPClient(svr *Server) error {
 		return err
 	}
 
-	DialClient = &http.Client{
+	dialClient = &http.Client{
 		Timeout: clientTimeout,
 		Transport: &http.Transport{
 			TLSClientConfig:   tlsConfig,

--- a/tools/pd-ctl/pdctl/command/global.go
+++ b/tools/pd-ctl/pdctl/command/global.go
@@ -32,7 +32,6 @@ import (
 
 var (
 	dialClient = &http.Client{Timeout: 30 * time.Second}
-
 	pingPrefix = "pd/ping"
 )
 

--- a/tools/pd-ctl/pdctl/command/global.go
+++ b/tools/pd-ctl/pdctl/command/global.go
@@ -23,7 +23,6 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -31,7 +30,7 @@ import (
 )
 
 var (
-	dialClient = &http.Client{Timeout: 30 * time.Second}
+	dialClient = &http.Client{}
 	pingPrefix = "pd/ping"
 )
 
@@ -48,7 +47,6 @@ func InitHTTPSClient(CAPath, CertPath, KeyPath string) error {
 	}
 
 	dialClient = &http.Client{
-		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		},


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
To solve the problem like #1569, we add a timeout for the HTTP client in #1515, but it still needs to spend a long time to wait for the goroutine to exit.

### What is changed and how it works?
This PR uses clients with a different timeout respectively for `server`, `api` and `pd-ctl`. And it changes the timeout of the client in `server` to 3 seconds.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test