### PR TITLE
server: use a different timeout for http clients (#1574)

### DIFF
--- a/server/api/redirector.go
+++ b/server/api/redirector.go
@@ -77,7 +77,7 @@ type customReverseProxies struct {
 
 func newCustomReverseProxies(urls []url.URL) *customReverseProxies {
 	p := &customReverseProxies{
-		client: server.DialClient,
+		client: dialClient,
 	}
 
 	p.urls = append(p.urls, urls...)

--- a/server/api/util.go
+++ b/server/api/util.go
@@ -21,12 +21,18 @@ import (
 	"net/http"
 
 	"github.com/pingcap/pd/pkg/apiutil"
-	"github.com/pingcap/pd/pkg/error_code"
-	"github.com/pingcap/pd/server"
+	errcode "github.com/pingcap/pd/pkg/error_code"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/unrolled/render"
 )
+
+// dialClient used to dail http request.
+var dialClient = &http.Client{
+	Transport: &http.Transport{
+		DisableKeepAlives: true,
+	},
+}
 
 // Respond to the client about the given error, integrating with errcode.ErrorCode.
 //
@@ -81,7 +87,7 @@ func readJSON(r io.ReadCloser, data interface{}) error {
 }
 
 func postJSON(url string, data []byte) error {
-	resp, err := server.DialClient.Post(url, "application/json", bytes.NewBuffer(data))
+	resp, err := dialClient.Post(url, "application/json", bytes.NewBuffer(data))
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -101,7 +107,7 @@ func doDelete(url string) error {
 	if err != nil {
 		return err
 	}
-	res, err := server.DialClient.Do(req)
+	res, err := dialClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -110,7 +116,7 @@ func doDelete(url string) error {
 }
 
 func doGet(url string) (*http.Response, error) {
-	resp, err := server.DialClient.Get(url)
+	resp, err := dialClient.Get(url)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -714,7 +714,7 @@ func (s *Server) CheckHealth(members []*pdpb.Member) map[uint64]*pdpb.Member {
 	unhealthMembers := make(map[uint64]*pdpb.Member)
 	for _, member := range members {
 		for _, cURL := range member.ClientUrls {
-			resp, err := DialClient.Get(fmt.Sprintf("%s%s", cURL, healthURL))
+			resp, err := dialClient.Get(fmt.Sprintf("%s%s", cURL, healthURL))
 			if resp != nil {
 				resp.Body.Close()
 			}

--- a/server/util.go
+++ b/server/util.go
@@ -34,6 +34,7 @@ import (
 const (
 	requestTimeout  = etcdutil.DefaultRequestTimeout
 	slowRequestTime = etcdutil.DefaultSlowRequestTime
+	clientTimeout   = 3 * time.Second
 )
 
 // Version information.
@@ -44,8 +45,9 @@ var (
 	PDGitBranch      = "None"
 )
 
-// DialClient used to dail http request.
-var DialClient = &http.Client{
+// dialClient used to dail http request.
+var dialClient = &http.Client{
+	Timeout: clientTimeout,
 	Transport: &http.Transport{
 		DisableKeepAlives: true,
 	},
@@ -264,10 +266,13 @@ func InitHTTPClient(svr *Server) error {
 		return err
 	}
 
-	DialClient = &http.Client{Transport: &http.Transport{
-		TLSClientConfig:   tlsConfig,
-		DisableKeepAlives: true,
-	}}
+	dialClient = &http.Client{
+		Timeout: clientTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig:   tlsConfig,
+			DisableKeepAlives: true,
+		},
+	}
 	return nil
 }
 

--- a/tools/pd-ctl/pdctl/command/global.go
+++ b/tools/pd-ctl/pdctl/command/global.go
@@ -30,7 +30,6 @@ import (
 
 var (
 	dialClient = &http.Client{}
-
 	pingPrefix = "pd/ping"
 )
 
@@ -46,9 +45,11 @@ func InitHTTPSClient(CAPath, CertPath, KeyPath string) error {
 		return errors.WithStack(err)
 	}
 
-	dialClient = &http.Client{Transport: &http.Transport{
-		TLSClientConfig: tlsConfig,
-	}}
+	dialClient = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
 
 	return nil
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
cherry-pick #1574.

### What is changed and how it works?
This PR uses clients with a different timeout respectively for `server`, `api` and `pd-ctl`. And it changes the timeout of the client in `server` to 3 seconds.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
