### PR TITLE
server: use a different timeout for http clients (#1574)

### DIFF
--- a/pdctl/command/global.go
+++ b/pdctl/command/global.go
@@ -29,8 +29,7 @@ import (
 )
 
 var (
-	dialClient = &http.Client{}
-
+	dialClient     = &http.Client{}
 	pingPrefix     = "pd/ping"
 	errInvalidAddr = errors.New("Invalid pd address, Cannot get connect to it")
 )
@@ -47,9 +46,11 @@ func InitHTTPSClient(CAPath, CertPath, KeyPath string) error {
 		return errors.Trace(err)
 	}
 
-	dialClient = &http.Client{Transport: &http.Transport{
-		TLSClientConfig: tlsConfig,
-	}}
+	dialClient = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
 
 	return nil
 }

--- a/server/api/redirector.go
+++ b/server/api/redirector.go
@@ -77,7 +77,7 @@ type customReverseProxies struct {
 
 func newCustomReverseProxies(urls []url.URL) *customReverseProxies {
 	p := &customReverseProxies{
-		client: server.DialClient,
+		client: dialClient,
 	}
 
 	p.urls = append(p.urls, urls...)

--- a/server/api/util.go
+++ b/server/api/util.go
@@ -21,8 +21,14 @@ import (
 	"net/http"
 
 	"github.com/juju/errors"
-	"github.com/pingcap/pd/server"
 )
+
+// dialClient used to dail http request.
+var dialClient = &http.Client{
+	Transport: &http.Transport{
+		DisableKeepAlives: true,
+	},
+}
 
 func readJSON(r io.ReadCloser, data interface{}) error {
 	defer r.Close()
@@ -40,7 +46,7 @@ func readJSON(r io.ReadCloser, data interface{}) error {
 }
 
 func postJSON(url string, data []byte) error {
-	resp, err := server.DialClient.Post(url, "application/json", bytes.NewBuffer(data))
+	resp, err := dialClient.Post(url, "application/json", bytes.NewBuffer(data))
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -60,7 +66,7 @@ func doDelete(url string) error {
 	if err != nil {
 		return err
 	}
-	res, err := server.DialClient.Do(req)
+	res, err := dialClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -69,7 +75,7 @@ func doDelete(url string) error {
 }
 
 func doGet(url string) (*http.Response, error) {
-	resp, err := server.DialClient.Get(url)
+	resp, err := dialClient.Get(url)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -648,7 +648,7 @@ func (s *Server) CheckHealth(members []*pdpb.Member) map[uint64]*pdpb.Member {
 	unhealthMembers := make(map[uint64]*pdpb.Member)
 	for _, member := range members {
 		for _, cURL := range member.ClientUrls {
-			resp, err := DialClient.Get(fmt.Sprintf("%s%s", cURL, healthURL))
+			resp, err := dialClient.Get(fmt.Sprintf("%s%s", cURL, healthURL))
 			if resp != nil {
 				resp.Body.Close()
 			}

--- a/server/util.go
+++ b/server/util.go
@@ -39,7 +39,8 @@ const (
 	defaultLogMaxAge     = 28 // days
 	defaultLogLevel      = log.InfoLevel
 
-	logDirMode = 0755
+	logDirMode    = 0755
+	clientTimeout = 3 * time.Second
 )
 
 // Version information.
@@ -50,8 +51,9 @@ var (
 	PDGitBranch      = "None"
 )
 
-// DialClient used to dail http request.
-var DialClient = &http.Client{
+// dialClient used to dail http request.
+var dialClient = &http.Client{
+	Timeout: clientTimeout,
 	Transport: &http.Transport{
 		DisableKeepAlives: true,
 	},
@@ -265,9 +267,12 @@ func InitHTTPClient(svr *Server) error {
 		return errors.Trace(err)
 	}
 
-	DialClient = &http.Client{Transport: &http.Transport{
-		TLSClientConfig:   tlsConfig,
-		DisableKeepAlives: true,
-	}}
+	dialClient = &http.Client{
+		Timeout: clientTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig:   tlsConfig,
+			DisableKeepAlives: true,
+		},
+	}
 	return nil
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
cherry-pick #1574.

### What is changed and how it works?
This PR uses clients with a different timeout respectively for `server`, `api` and `pd-ctl`. And it changes the timeout of the client in `server` to 3 seconds.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
