### PR TITLE
config: warn undefined config item

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -67,7 +67,7 @@ leader-schedule-limit = 4
 region-schedule-limit = 1024
 replica-schedule-limit = 1024
 merge-schedule-limit = 8
-# tolerant-size-ratio = 0.0
+#tolerant-size-ratio = 5.0
 
 # customized schedulers, the format is as below
 # if empty, it will use balance-leader, balance-region, hot-region as default
@@ -83,7 +83,8 @@ max-replicas = 3
 # For example, ["zone", "rack"] means that we should place replicas to
 # different zones first, then to different racks if we don't have enough zones.
 location-labels = []
-# strictly-match-label = false
+# Strictly checks if the label of TiKV is matched with LocaltionLabels.
+#strictly-match-label = false
 
 [label-property]
 # Do not assign region leaders to stores that have these tags.

--- a/conf/config.toml
+++ b/conf/config.toml
@@ -83,7 +83,7 @@ max-replicas = 3
 # For example, ["zone", "rack"] means that we should place replicas to
 # different zones first, then to different racks if we don't have enough zones.
 location-labels = []
-# Strictly checks if the label of TiKV is matched with localtion labels.
+# Strictly checks if the label of TiKV is matched with location labels.
 #strictly-match-label = false
 
 [label-property]

--- a/conf/config.toml
+++ b/conf/config.toml
@@ -83,7 +83,7 @@ max-replicas = 3
 # For example, ["zone", "rack"] means that we should place replicas to
 # different zones first, then to different racks if we don't have enough zones.
 location-labels = []
-# Strictly checks if the label of TiKV is matched with LocaltionLabels.
+# Strictly checks if the label of TiKV is matched with localtion labels.
 #strictly-match-label = false
 
 [label-property]

--- a/conf/config.toml
+++ b/conf/config.toml
@@ -67,7 +67,7 @@ leader-schedule-limit = 4
 region-schedule-limit = 1024
 replica-schedule-limit = 1024
 merge-schedule-limit = 8
-tolerant-size-ratio = 0
+# tolerant-size-ratio = 0.0
 
 # customized schedulers, the format is as below
 # if empty, it will use balance-leader, balance-region, hot-region as default
@@ -83,6 +83,7 @@ max-replicas = 3
 # For example, ["zone", "rack"] means that we should place replicas to
 # different zones first, then to different racks if we don't have enough zones.
 location-labels = []
+# strictly-match-label = false
 
 [label-property]
 # Do not assign region leaders to stores that have these tags.

--- a/server/config.go
+++ b/server/config.go
@@ -350,7 +350,7 @@ func (m *configMetaData) CheckUndecoded() error {
 func (c *Config) Adjust(meta *toml.MetaData) error {
 	configMetaData := newConfigMetadata(meta)
 	if err := configMetaData.CheckUndecoded(); err != nil {
-		return err
+		c.WarningMsgs = append(c.WarningMsgs, err.Error())
 	}
 
 	if c.Name == "" {

--- a/server/config.go
+++ b/server/config.go
@@ -682,7 +682,7 @@ type ReplicationConfig struct {
 	// For example, ["zone", "rack"] means that we should place replicas to
 	// different zones first, then to different racks if we don't have enough zones.
 	LocationLabels typeutil.StringSlice `toml:"location-labels,omitempty" json:"location-labels"`
-	// StrictlyMatchLabel strictly checks if the label of TiKV is matched with LocaltionLabels.
+	// StrictlyMatchLabel strictly checks if the label of TiKV is matched with LocationLabels.
 	StrictlyMatchLabel bool `toml:"strictly-match-label,omitempty" json:"strictly-match-label,string"`
 }
 

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -131,7 +132,8 @@ type = "random-merge"
 	meta, err = toml.Decode(cfgData, &cfg)
 	c.Assert(err, IsNil)
 	err = cfg.Adjust(&meta)
-	c.Assert(err, NotNil)
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(cfg.WarningMsgs[0], "Config contains undefined item"), IsTrue)
 
 	// Check misspelled schedulers name
 	cfgData = `


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Now, the undefined config item will let PD exit. This makes the new configuration item incompatible with the old configuration template.

### What is changed and how it works?
Only log it with `warn` level.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)
 
![image](https://user-images.githubusercontent.com/6428910/59264979-f53dac00-8c76-11e9-985f-b57459f84776.png)
