### PR TITLE
schedule: fix store maybe always overloaded

### DIFF
--- a/server/cluster_info.go
+++ b/server/cluster_info.go
@@ -240,18 +240,11 @@ func (c *clusterInfo) UnblockStore(storeID uint64) {
 	c.core.UnblockStore(storeID)
 }
 
-// SetStoreOverload stops balancer from selecting the store.
-func (c *clusterInfo) SetStoreOverload(storeID uint64) {
+// AttachOverloadStatus attaches the overload status to a store.
+func (c *clusterInfo) AttachOverloadStatus(storeID uint64, f func() bool) {
 	c.Lock()
 	defer c.Unlock()
-	c.core.SetStoreOverload(storeID)
-}
-
-// ResetStoreOverload allows balancer to select the store.
-func (c *clusterInfo) ResetStoreOverload(storeID uint64) {
-	c.Lock()
-	defer c.Unlock()
-	c.core.ResetStoreOverload(storeID)
+	c.core.AttachOverloadStatus(storeID, f)
 }
 
 // GetStores returns all stores in the cluster.

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -32,8 +32,8 @@ import (
 	"github.com/pingcap/pd/server/schedulers"
 )
 
-func newTestOperator(regionID uint64, regionEpoch *metapb.RegionEpoch, kind schedule.OperatorKind) *schedule.Operator {
-	return schedule.NewOperator("test", regionID, regionEpoch, kind)
+func newTestOperator(regionID uint64, regionEpoch *metapb.RegionEpoch, kind schedule.OperatorKind, steps ...schedule.OperatorStep) *schedule.Operator {
+	return schedule.NewOperator("test", regionID, regionEpoch, kind, steps...)
 }
 
 func newTestScheduleConfig() (*ScheduleConfig, *scheduleOption, error) {
@@ -763,6 +763,65 @@ func (s *testOperatorControllerSuite) TestOperatorCount(c *C) {
 	oc.AddOperator(op2)
 	c.Assert(oc.OperatorCount(schedule.OpRegion), Equals, uint64(2)) // 1:region 2:region
 	c.Assert(oc.OperatorCount(schedule.OpLeader), Equals, uint64(0))
+}
+
+func (s *testOperatorControllerSuite) TestStoreOverloaded(c *C) {
+	_, opt, err := newTestScheduleConfig()
+	c.Assert(err, IsNil)
+	tc := newTestClusterInfo(opt)
+	hbStreams := getHeartBeatStreams(c, tc)
+	defer hbStreams.Close()
+	oc := schedule.NewOperatorController(tc.clusterInfo, hbStreams)
+	lb, err := schedule.CreateScheduler("balance-region", oc)
+	c.Assert(err, IsNil)
+
+	c.Assert(tc.addRegionStore(4, 40), IsNil)
+	c.Assert(tc.addRegionStore(3, 40), IsNil)
+	c.Assert(tc.addRegionStore(2, 40), IsNil)
+	c.Assert(tc.addRegionStore(1, 10), IsNil)
+	c.Assert(tc.addLeaderRegion(1, 2, 3, 4), IsNil)
+	op1 := lb.Schedule(tc)[0]
+	c.Assert(op1, NotNil)
+	c.Assert(oc.AddOperator(op1), IsTrue)
+	op2 := lb.Schedule(tc)[0]
+	c.Assert(op2, NotNil)
+	c.Assert(oc.AddOperator(op2), IsFalse)
+	for i := 0; i < 10; i++ {
+		c.Assert(lb.Schedule(tc), IsNil)
+	}
+	oc.RemoveOperator(op1)
+	time.Sleep(1 * time.Second)
+	for i := 0; i < 100; i++ {
+		c.Assert(lb.Schedule(tc), NotNil)
+	}
+}
+
+func (s *testOperatorControllerSuite) TestStoreOverloadedWithReplace(c *C) {
+	_, opt, err := newTestScheduleConfig()
+	c.Assert(err, IsNil)
+	tc := newTestClusterInfo(opt)
+	hbStreams := getHeartBeatStreams(c, tc)
+	defer hbStreams.Close()
+	oc := schedule.NewOperatorController(tc.clusterInfo, hbStreams)
+	lb, err := schedule.CreateScheduler("balance-region", oc)
+	c.Assert(err, IsNil)
+
+	c.Assert(tc.addRegionStore(4, 40), IsNil)
+	c.Assert(tc.addRegionStore(3, 40), IsNil)
+	c.Assert(tc.addRegionStore(2, 40), IsNil)
+	c.Assert(tc.addRegionStore(1, 10), IsNil)
+	c.Assert(tc.addLeaderRegion(1, 2, 3, 4), IsNil)
+	c.Assert(tc.addLeaderRegion(2, 1, 3, 4), IsNil)
+	op1 := newTestOperator(1, tc.GetRegion(1).GetRegionEpoch(), schedule.OpRegion, schedule.AddPeer{ToStore: 1, PeerID: 1})
+	c.Assert(oc.AddOperator(op1), IsTrue)
+	op2 := newTestOperator(1, tc.GetRegion(1).GetRegionEpoch(), schedule.OpRegion, schedule.AddPeer{ToStore: 2, PeerID: 2})
+	op2.SetPriorityLevel(core.HighPriority)
+	c.Assert(oc.AddOperator(op2), IsTrue)
+	op3 := newTestOperator(1, tc.GetRegion(2).GetRegionEpoch(), schedule.OpRegion, schedule.AddPeer{ToStore: 1, PeerID: 3})
+	c.Assert(oc.AddOperator(op3), IsFalse)
+	c.Assert(lb.Schedule(tc), IsNil)
+	time.Sleep(1 * time.Second)
+	c.Assert(lb.Schedule(tc), NotNil)
 }
 
 var _ = Suite(&testScheduleControllerSuite{})

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -783,9 +783,6 @@ func (s *testOperatorControllerSuite) TestStoreOverloaded(c *C) {
 	op1 := lb.Schedule(tc)[0]
 	c.Assert(op1, NotNil)
 	c.Assert(oc.AddOperator(op1), IsTrue)
-	op2 := lb.Schedule(tc)[0]
-	c.Assert(op2, NotNil)
-	c.Assert(oc.AddOperator(op2), IsFalse)
 	for i := 0; i < 10; i++ {
 		c.Assert(lb.Schedule(tc), IsNil)
 	}

--- a/server/core/basic_cluster.go
+++ b/server/core/basic_cluster.go
@@ -84,14 +84,9 @@ func (bc *BasicCluster) UnblockStore(storeID uint64) {
 	bc.Stores.UnblockStore(storeID)
 }
 
-// SetStoreOverload stops balancer from selecting the store.
-func (bc *BasicCluster) SetStoreOverload(storeID uint64) {
-	bc.Stores.SetStoreOverload(storeID)
-}
-
-// ResetStoreOverload allows balancer to select the store.
-func (bc *BasicCluster) ResetStoreOverload(storeID uint64) {
-	bc.Stores.ResetStoreOverload(storeID)
+// AttachOverloadStatus attaches the overload status to a store.
+func (bc *BasicCluster) AttachOverloadStatus(storeID uint64, f func() bool) {
+	bc.Stores.AttachOverloadStatus(storeID, f)
 }
 
 // RandFollowerRegion returns a random region that has a follower on the store.

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -40,7 +40,7 @@ type StoreInfo struct {
 	lastHeartbeatTS  time.Time
 	leaderWeight     float64
 	regionWeight     float64
-	overloaded       bool
+	overloaded       func() bool
 }
 
 // NewStoreInfo creates StoreInfo with meta data.
@@ -87,7 +87,10 @@ func (s *StoreInfo) IsBlocked() bool {
 
 // IsOverloaded returns if the store is overloaded.
 func (s *StoreInfo) IsOverloaded() bool {
-	return s.overloaded
+	if s.overloaded == nil {
+		return false
+	}
+	return s.overloaded()
 }
 
 // IsUp checks if the store's state is Up.
@@ -520,24 +523,11 @@ func (s *StoresInfo) UnblockStore(storeID uint64) {
 	s.stores[storeID] = store.Clone(SetStoreUnBlock())
 }
 
-// SetStoreOverload set a StoreInfo with storeID overload.
-func (s *StoresInfo) SetStoreOverload(storeID uint64) {
-	store, ok := s.stores[storeID]
-	if !ok {
-		log.Fatal("store is overloaded, but it is not found",
-			zap.Uint64("store-id", storeID))
+// AttachOverloadStatus attaches the overload status to a store.
+func (s *StoresInfo) AttachOverloadStatus(storeID uint64, f func() bool) {
+	if store, ok := s.stores[storeID]; ok {
+		s.stores[storeID] = store.Clone(SetOverloadStatus(f))
 	}
-	s.stores[storeID] = store.Clone(SetStoreOverload())
-}
-
-// ResetStoreOverload reset a StoreInfo with storeID overload.
-func (s *StoresInfo) ResetStoreOverload(storeID uint64) {
-	store, ok := s.stores[storeID]
-	if !ok {
-		log.Fatal("store is not overloaded anymore, but it is not found",
-			zap.Uint64("store-id", storeID))
-	}
-	s.stores[storeID] = store.Clone(ResetStoreOverload())
 }
 
 // GetStores gets a complete set of StoreInfo.

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -93,11 +93,6 @@ func (s *StoreInfo) IsOverloaded() bool {
 	return s.overloaded()
 }
 
-// IsAttached returns if the store is attached with the overloaded status.
-func (s *StoreInfo) IsAttached() bool {
-	return s.overloaded != nil
-}
-
 // IsUp checks if the store's state is Up.
 func (s *StoreInfo) IsUp() bool {
 	return s.GetState() == metapb.StoreState_Up

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -93,6 +93,11 @@ func (s *StoreInfo) IsOverloaded() bool {
 	return s.overloaded()
 }
 
+// IsAttached returns if the store is attached with the overloaded status.
+func (s *StoreInfo) IsAttached() bool {
+	return s.overloaded != nil
+}
+
 // IsUp checks if the store's state is Up.
 func (s *StoreInfo) IsUp() bool {
 	return s.GetState() == metapb.StoreState_Up

--- a/server/core/store_option.go
+++ b/server/core/store_option.go
@@ -65,20 +65,6 @@ func SetStoreUnBlock() StoreCreateOption {
 	}
 }
 
-// SetStoreOverload stops balancer from selecting the store.
-func SetStoreOverload() StoreCreateOption {
-	return func(store *StoreInfo) {
-		store.overloaded = true
-	}
-}
-
-// ResetStoreOverload allows balancer to select the store.
-func ResetStoreOverload() StoreCreateOption {
-	return func(store *StoreInfo) {
-		store.overloaded = false
-	}
-}
-
 // SetLeaderCount sets the leader count for the store.
 func SetLeaderCount(leaderCount int) StoreCreateOption {
 	return func(store *StoreInfo) {
@@ -139,5 +125,12 @@ func SetLastHeartbeatTS(lastHeartbeatTS time.Time) StoreCreateOption {
 func SetStoreStats(stats *pdpb.StoreStats) StoreCreateOption {
 	return func(store *StoreInfo) {
 		store.stats = stats
+	}
+}
+
+// SetOverloadStatus sets the overload status for the store.
+func SetOverloadStatus(f func() bool) StoreCreateOption {
+	return func(store *StoreInfo) {
+		store.overloaded = f
 	}
 }

--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -629,6 +629,8 @@ func (oc *OperatorController) exceedStoreLimit(ops ...*Operator) bool {
 		storeLimit.WithLabelValues(strconv.FormatUint(storeID, 10), "available").Set(float64(available) / float64(RegionInfluence))
 		if available < stepCost {
 			oc.cluster.AttachOverloadStatus(storeID, func() bool {
+				oc.RLock()
+				defer oc.RUnlock()
 				return oc.storesLimit[storeID].Available() < RegionInfluence
 			})
 			return true

--- a/server/schedule/scheduler.go
+++ b/server/schedule/scheduler.go
@@ -44,8 +44,7 @@ type Cluster interface {
 	BlockStore(id uint64) error
 	UnblockStore(id uint64)
 
-	SetStoreOverload(id uint64)
-	ResetStoreOverload(id uint64)
+	AttachOverloadStatus(id uint64, f func() bool)
 
 	IsRegionHot(id uint64) bool
 	RegionWriteStats() []*statistics.RegionStat


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
There are some cases which will cause the PD cannot generate operator since the store could be always overloaded and be filtered in the end.

### What is changed and how it works?
This PR fixes this problem by removing reset logic.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release notes
