### PR TITLE
pdctl: config show command add replication config

### DIFF
--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -172,7 +172,7 @@ func (s *configTestSuite) TestConfig(c *C) {
 	c.Assert(err, IsNil)
 	cfg = server.Config{}
 	c.Assert(json.Unmarshal(output, &cfg), IsNil)
-	c.Assert(cfg.Schedule, Equals, svr.GetScheduleConfig())
+	c.Assert(&cfg.Schedule, Equals, svr.GetScheduleConfig())
 	scheduleCfg = cfg.Schedule
 	c.Assert(scheduleCfg.LeaderScheduleLimit, Equals, svr.GetScheduleConfig().LeaderScheduleLimit)
 	c.Assert(scheduleCfg.HotRegionScheduleLimit, Equals, svr.GetScheduleConfig().HotRegionScheduleLimit)

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	   http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -170,8 +170,10 @@ func (s *configTestSuite) TestConfig(c *C) {
 	args2 = []string{"-u", pdAddr, "config", "show"}
 	_, output, err = pdctl.ExecuteCommandC(cmd, args2...)
 	c.Assert(err, IsNil)
-	scheduleCfg = server.ScheduleConfig{}
-	c.Assert(json.Unmarshal(output, &scheduleCfg), IsNil)
+	cfg = server.Config{}
+	c.Assert(json.Unmarshal(output, &cfg), IsNil)
+	c.Assert(cfg.Schedule, Equals, svr.GetScheduleConfig())
+	scheduleCfg = cfg.Schedule
 	c.Assert(scheduleCfg.LeaderScheduleLimit, Equals, svr.GetScheduleConfig().LeaderScheduleLimit)
 	c.Assert(scheduleCfg.HotRegionScheduleLimit, Equals, svr.GetScheduleConfig().HotRegionScheduleLimit)
 	c.Assert(scheduleCfg.HotRegionCacheHitsThreshold, Equals, svr.GetScheduleConfig().HotRegionCacheHitsThreshold)

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -62,6 +62,7 @@ func (s *configTestSuite) TestConfig(c *C) {
 	args := []string{"-u", pdAddr, "config", "show"}
 	_, output, err := pdctl.ExecuteCommandC(cmd, args...)
 	c.Assert(err, IsNil)
+	scheduleCfg := server.ScheduleConfig{}
 	cfg := make(map[string]interface{})
 	c.Assert(json.Unmarshal(output, &cfg), IsNil)
 	c.Assert(cfg["schedule"], DeepEquals, svr.GetScheduleConfig())

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -63,10 +63,10 @@ func (s *configTestSuite) TestConfig(c *C) {
 	_, output, err := pdctl.ExecuteCommandC(cmd, args...)
 	c.Assert(err, IsNil)
 	scheduleCfg := server.ScheduleConfig{}
-	cfg := make(map[string]interface{})
+	cfg := server.Config{}
 	c.Assert(json.Unmarshal(output, &cfg), IsNil)
-	c.Assert(cfg["schedule"], DeepEquals, svr.GetScheduleConfig())
-	c.Assert(cfg["replication"], DeepEquals, svr.GetReplicationConfig())
+	c.Assert(&cfg.Schedule, DeepEquals, svr.GetScheduleConfig())
+	c.Assert(&cfg.Replication, DeepEquals, svr.GetReplicationConfig())
 
 	// config show replication
 	args = []string{"-u", pdAddr, "config", "show", "replication"}

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -172,7 +172,6 @@ func (s *configTestSuite) TestConfig(c *C) {
 	c.Assert(err, IsNil)
 	cfg = server.Config{}
 	c.Assert(json.Unmarshal(output, &cfg), IsNil)
-	c.Assert(&cfg.Schedule, Equals, svr.GetScheduleConfig())
 	scheduleCfg = cfg.Schedule
 	c.Assert(scheduleCfg.LeaderScheduleLimit, Equals, svr.GetScheduleConfig().LeaderScheduleLimit)
 	c.Assert(scheduleCfg.HotRegionScheduleLimit, Equals, svr.GetScheduleConfig().HotRegionScheduleLimit)

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -62,9 +62,10 @@ func (s *configTestSuite) TestConfig(c *C) {
 	args := []string{"-u", pdAddr, "config", "show"}
 	_, output, err := pdctl.ExecuteCommandC(cmd, args...)
 	c.Assert(err, IsNil)
-	scheduleCfg := server.ScheduleConfig{}
-	c.Assert(json.Unmarshal(output, &scheduleCfg), IsNil)
-	c.Assert(&scheduleCfg, DeepEquals, svr.GetScheduleConfig())
+	cfg := make(map[string]interface{})
+	c.Assert(json.Unmarshal(output, &cfg), IsNil)
+	c.Assert(cfg["schedule"], DeepEquals, svr.GetScheduleConfig())
+	c.Assert(cfg["replication"], DeepEquals, svr.GetReplicationConfig())
 
 	// config show replication
 	args = []string{"-u", pdAddr, "config", "show", "replication"}

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -185,7 +185,8 @@ func (s *configTestSuite) TestConfig(c *C) {
 	args2 = []string{"-u", pdAddr, "config", "show"}
 	_, output, err = pdctl.ExecuteCommandC(cmd, args2...)
 	c.Assert(err, IsNil)
-	scheduleCfg = server.ScheduleConfig{}
-	c.Assert(json.Unmarshal(output, &scheduleCfg), IsNil)
+	cfg = server.Config{}
+	c.Assert(json.Unmarshal(output, &cfg), IsNil)
+	scheduleCfg = cfg.Schedule
 	c.Assert(scheduleCfg.DisableLearner, Equals, svr.GetScheduleConfig().DisableLearner)
 }

--- a/tools/pd-ctl/README.md
+++ b/tools/pd-ctl/README.md
@@ -93,43 +93,61 @@ Use this command to view or modify the configuration information.
 Usage:
 
 ```bash
->> config show                                // Display the config information of the scheduler
+>> config show                                // Display the config information of the replication and schedule
 {
-  "max-snapshot-count": 3,
-  "max-pending-peer-count": 16,
-  "max-merge-region-size": 50,
-  "max-merge-region-rows": 200000,
-  "split-merge-interval": "1h",
-  "patrol-region-interval": "100ms",
-  "max-store-down-time": "1h0m0s",
-  "leader-schedule-limit": 4,
-  "region-schedule-limit": 4,
-  "replica-schedule-limit":8,
-  "merge-schedule-limit": 8,
-  "tolerant-size-ratio": 5,
-  "low-space-ratio": 0.8,
-  "high-space-ratio": 0.6,
-  "disable-raft-learner": "false",
-  "disable-remove-down-replica": "false",
-  "disable-replace-offline-replica": "false",
-  "disable-make-up-replica": "false",
-  "disable-remove-extra-replica": "false",
-  "disable-location-replacement": "false",
-  "disable-namespace-relocation": "false",
-  "schedulers-v2": [
-    {
-      "type": "balance-region",
-      "args": null
-    },
-    {
-      "type": "balance-leader",
-      "args": null
-    },
-    {
-      "type": "hot-region",
-      "args": null
-    }
-  ]
+  "replication": {
+    "location-labels": "",
+    "max-replicas": 3,
+    "strictly-match-label": "true"
+  },
+  "schedule": {
+    "disable-location-replacement": "false",
+    "disable-make-up-replica": "false",
+    "disable-namespace-relocation": "false",
+    "disable-raft-learner": "false",
+    "disable-remove-down-replica": "false",
+    "disable-remove-extra-replica": "false",
+    "disable-replace-offline-replica": "false",
+    "high-space-ratio": 0.6,
+    "hot-region-cache-hits-threshold": 3,
+    "hot-region-schedule-limit": 2,
+    "leader-schedule-limit": 4,
+    "low-space-ratio": 0.8,
+    "max-merge-region-keys": 200000,
+    "max-merge-region-size": 20,
+    "max-pending-peer-count": 16,
+    "max-snapshot-count": 3,
+    "max-store-down-time": "30m0s",
+    "merge-schedule-limit": 8,
+    "patrol-region-interval": "100ms",
+    "region-schedule-limit": 4,
+    "replica-schedule-limit": 8,
+    "schedulers-v2": [
+      {
+        "args": null,
+        "disable": false,
+        "type": "balance-region"
+      },
+      {
+        "args": null,
+        "disable": false,
+        "type": "balance-leader"
+      },
+      {
+        "args": null,
+        "disable": false,
+        "type": "hot-region"
+      },
+      {
+        "args": null,
+        "disable": false,
+        "type": "label"
+      }
+    ],
+    "split-merge-interval": "1h0m0s",
+    "store-balance-rate": 1,
+    "tolerant-size-ratio": 5
+  }
 }
 >> config show all                            // Display all config information
 >> config show namespace ts1                  // Display the config information of the namespace named ts1


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

[#1580](https://github.com/pingcap/pd/issues/1580)  `pd-ctl config show` command add replication config

### What is changed and how it works?

get data from api `pd/api/v1/config` to get schedule and replicate config

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to update the documentation
