### PR TITLE
feature(label): tolerate backslash in the label name

### DIFF
--- a/server/util.go
+++ b/server/util.go
@@ -287,7 +287,7 @@ func InitHTTPClient(svr *Server) error {
 const matchRule = "^[A-Za-z0-9]([-A-Za-z0-9_./]*[A-Za-z0-9])?$"
 
 // ValidateLabelString checks the legality of the label string.
-// The valid label consist of alphanumeric characters, '-', '_', '/' or '.',
+// The valid label consists of alphanumeric characters, '-', '_', '.' or '/',
 // and must start and end with an alphanumeric character.
 func ValidateLabelString(s string) error {
 	isValid, _ := regexp.MatchString(matchRule, s)

--- a/server/util.go
+++ b/server/util.go
@@ -284,10 +284,10 @@ func InitHTTPClient(svr *Server) error {
 	return nil
 }
 
-const matchRule = "^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$"
+const matchRule = "^[A-Za-z0-9]([-A-Za-z0-9_./]*[A-Za-z0-9])?$"
 
 // ValidateLabelString checks the legality of the label string.
-// The valid label consist of alphanumeric characters, '-', '_' or '.',
+// The valid label consist of alphanumeric characters, '-', '_', '/' or '.',
 // and must start and end with an alphanumeric character.
 func ValidateLabelString(s string) error {
 	isValid, _ := regexp.MatchString(matchRule, s)

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -68,6 +68,9 @@ func (s *testUtilSuite) TestVerifyLabels(c *C) {
 		{"www.pingcap.com", false},
 		{"h_127.0.0.1", false},
 		{"a", false},
+		{"a/b", false},
+		{"ab/", true},
+		{"/ab", true},
 	}
 	for _, t := range tests {
 		c.Assert(ValidateLabelString(t.label) != nil, Equals, t.hasErr)


### PR DESCRIPTION
Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

Closes #1588

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

tolerate backslash in the label name.

### What is changed and how it works?

relax the rules to check the validation of a label.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

