### PR TITLE
config: add a option about gRPC gateway

### DIFF
--- a/server/api/etcd_api_test.go
+++ b/server/api/etcd_api_test.go
@@ -1,0 +1,51 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testEtcdAPISuite{})
+
+type testEtcdAPISuite struct {
+	hc *http.Client
+}
+
+func (s *testEtcdAPISuite) SetUpSuite(c *C) {
+	s.hc = newHTTPClient()
+}
+
+func (s *testEtcdAPISuite) TestGRPCGateway(c *C) {
+	svr, clean := mustNewServer(c)
+	defer clean()
+
+	addr := svr.GetConfig().ClientUrls + "/v3/kv/put"
+	putKey := map[string]string{"key": "Zm9v", "value": "YmFy"}
+	v, _ := json.Marshal(putKey)
+	err := postJSON(addr, v)
+	c.Assert(err, IsNil)
+	addr = svr.GetConfig().ClientUrls + "/v3/kv/range"
+	getKey := map[string]string{"key": "Zm9v"}
+	v, _ = json.Marshal(getKey)
+	err = postJSON(addr, v, func(res []byte) bool {
+		c.Assert(strings.Contains(string(res), "Zm9v"), IsTrue)
+		return true
+	})
+	c.Assert(err, IsNil)
+}

--- a/server/config.go
+++ b/server/config.go
@@ -49,9 +49,10 @@ type Config struct {
 	AdvertiseClientUrls string `toml:"advertise-client-urls" json:"advertise-client-urls"`
 	AdvertisePeerUrls   string `toml:"advertise-peer-urls" json:"advertise-peer-urls"`
 
-	Name            string `toml:"name" json:"name"`
-	DataDir         string `toml:"data-dir" json:"data-dir"`
-	ForceNewCluster bool   `json:"force-new-cluster"`
+	Name              string `toml:"name" json:"name"`
+	DataDir           string `toml:"data-dir" json:"data-dir"`
+	ForceNewCluster   bool   `json:"force-new-cluster"`
+	EnableGRPCGateway bool   `json:"enable-grpc-gateway"`
 
 	InitialCluster      string `toml:"initial-cluster" json:"initial-cluster"`
 	InitialClusterState string `toml:"initial-cluster-state" json:"initial-cluster-state"`
@@ -199,6 +200,7 @@ const (
 
 	defaultUseRegionStorage   = true
 	defaultStrictlyMatchLabel = false
+	defaultEnableGRPCGateway  = true
 )
 
 func adjustString(v *string, defValue string) {
@@ -426,6 +428,9 @@ func (c *Config) Adjust(meta *toml.MetaData) error {
 
 	if !configMetaData.IsDefined("enable-prevote") {
 		c.PreVote = true
+	}
+	if !configMetaData.IsDefined("enable-grpc-gateway") {
+		c.EnableGRPCGateway = defaultEnableGRPCGateway
 	}
 	return nil
 }
@@ -871,6 +876,7 @@ func (c *Config) genEmbedEtcdConfig() (*embed.Config, error) {
 	cfg.PeerTLSInfo.KeyFile = c.Security.KeyPath
 	cfg.ForceNewCluster = c.ForceNewCluster
 	cfg.ZapLoggerBuilder = embed.NewZapCoreLoggerBuilder(c.logger, c.logger.Core(), c.logProps.Syncer)
+	cfg.EnableGRPCGateway = c.EnableGRPCGateway
 	cfg.Logger = "zap"
 	var err error
 


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
After upgrade the `etcd`, the [gRPC gateway](https://github.com/etcd-io/etcd/blob/master/Documentation/dev-guide/api_grpc_gateway.md) does not enable in default(https://github.com/etcd-io/etcd/pull/10392). Our `tidb-ctl` use it. Now, add a config to enable it.

### What is changed and how it works?
add a configurable item.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 