### PR TITLE
config: fix cannot set `two-way-merge` via pdctl

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -464,7 +464,7 @@ type ScheduleConfig struct {
 	// SplitMergeInterval is the minimum interval time to permit merge after split.
 	SplitMergeInterval typeutil.Duration `toml:"split-merge-interval,omitempty" json:"split-merge-interval"`
 	// EnableTwoWayMerge is the option to enable two way merge
-	EnableTwoWayMerge bool `toml:"enable-two-way-merge,omitempty" json:"enable-two-way-merge"`
+	EnableTwoWayMerge bool `toml:"enable-two-way-merge,omitempty" json:"enable-two-way-merge,string"`
 	// PatrolRegionInterval is the interval for scanning region during patrol.
 	PatrolRegionInterval typeutil.Duration `toml:"patrol-region-interval,omitempty" json:"patrol-region-interval"`
 	// MaxStoreDownTime is the max duration after which
@@ -543,6 +543,7 @@ func (c *ScheduleConfig) clone() *ScheduleConfig {
 		RegionScheduleLimit:          c.RegionScheduleLimit,
 		ReplicaScheduleLimit:         c.ReplicaScheduleLimit,
 		MergeScheduleLimit:           c.MergeScheduleLimit,
+		EnableTwoWayMerge:            c.EnableTwoWayMerge,
 		HotRegionScheduleLimit:       c.HotRegionScheduleLimit,
 		HotRegionCacheHitsThreshold:  c.HotRegionCacheHitsThreshold,
 		StoreBalanceRate:             c.StoreBalanceRate,
@@ -574,6 +575,7 @@ const (
 	defaultRegionScheduleLimit    = 64
 	defaultReplicaScheduleLimit   = 64
 	defaultMergeScheduleLimit     = 8
+	defaultEnableTwoWayMerge      = true
 	defaultHotRegionScheduleLimit = 2
 	defaultStoreBalanceRate       = 15
 	defaultTolerantSizeRatio      = 0
@@ -624,6 +626,9 @@ func (c *ScheduleConfig) adjust(meta *configMetaData) error {
 	}
 	if !meta.IsDefined("scheduler-max-waiting-operator") {
 		adjustUint64(&c.SchedulerMaxWaitingOperator, defaultSchedulerMaxWaitingOperator)
+	}
+	if !meta.IsDefined("enable-two-way-merge") {
+		c.EnableTwoWayMerge = defaultEnableTwoWayMerge
 	}
 	adjustFloat64(&c.StoreBalanceRate, defaultStoreBalanceRate)
 	adjustFloat64(&c.LowSpaceRatio, defaultLowSpaceRatio)


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
./bin/pd-ctl config set enable-two-way-merge true
Failed to set config: [500] "json: cannot unmarshal string into Go struct field ScheduleConfig.enable-two-way-merge of type bool"


### What is changed and how it works?
support it

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test 
I do manual test and set sucess.
