### PR TITLE
scheduler: check replica for hot region 

### DIFF
--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -288,7 +288,13 @@ func (h *balanceHotRegionsScheduler) balanceByPeer(cluster schedule.Cluster, sto
 	for _, i := range h.r.Perm(storesStat[srcStoreID].RegionsStat.Len()) {
 		rs := storesStat[srcStoreID].RegionsStat[i]
 		srcRegion := cluster.GetRegion(rs.RegionID)
-		if srcRegion == nil || len(srcRegion.GetDownPeers()) != 0 || len(srcRegion.GetPendingPeers()) != 0 {
+		if srcRegion == nil || len(srcRegion.GetDownPeers()) != 0 || len(srcRegion.GetPendingPeers()) != 0 || len(srcRegion.GetLearners()) != 0 {
+			continue
+		}
+
+		if len(srcRegion.GetPeers()) != cluster.GetMaxReplicas() {
+			log.Debug("region has abnormal replica count", zap.String("scheduler", h.GetName()), zap.Uint64("region-id", srcRegion.GetID()))
+			schedulerCounter.WithLabelValues(h.GetName(), "abnormal_replica").Inc()
 			continue
 		}
 

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -288,7 +288,13 @@ func (h *balanceHotRegionsScheduler) balanceByPeer(cluster schedule.Cluster, sto
 	for _, i := range h.r.Perm(storesStat[srcStoreID].RegionsStat.Len()) {
 		rs := storesStat[srcStoreID].RegionsStat[i]
 		srcRegion := cluster.GetRegion(rs.RegionID)
-		if srcRegion == nil || len(srcRegion.GetDownPeers()) != 0 || len(srcRegion.GetPendingPeers()) != 0 || len(srcRegion.GetLearners()) != 0 {
+		if srcRegion == nil {
+			schedulerCounter.WithLabelValues(h.GetName(), "no_region").Inc()
+			continue
+		}
+
+		if isRegionUnhealthy(srcRegion) {
+			schedulerCounter.WithLabelValues(h.GetName(), "unhealthy_replica").Inc()
 			continue
 		}
 
@@ -351,7 +357,13 @@ func (h *balanceHotRegionsScheduler) balanceByLeader(cluster schedule.Cluster, s
 	for _, i := range h.r.Perm(storesStat[srcStoreID].RegionsStat.Len()) {
 		rs := storesStat[srcStoreID].RegionsStat[i]
 		srcRegion := cluster.GetRegion(rs.RegionID)
-		if srcRegion == nil || len(srcRegion.GetDownPeers()) != 0 || len(srcRegion.GetPendingPeers()) != 0 {
+		if srcRegion == nil {
+			schedulerCounter.WithLabelValues(h.GetName(), "no_region").Inc()
+			continue
+		}
+
+		if isRegionUnhealthy(srcRegion) {
+			schedulerCounter.WithLabelValues(h.GetName(), "unhealthy_replica").Inc()
 			continue
 		}
 

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -50,7 +50,7 @@ func minDuration(a, b time.Duration) time.Duration {
 }
 
 func isRegionUnhealthy(region *core.RegionInfo) bool {
-	return len(region.GetDownPeers()) != 0 || len(region.GetPendingPeers()) != 0 || len(region.GetLearners()) != 0
+	return len(region.GetDownPeers()) != 0 || len(region.GetLearners()) != 0
 }
 
 func shouldBalance(cluster schedule.Cluster, source, target *core.StoreInfo, region *core.RegionInfo, kind core.ResourceKind, opInfluence schedule.OpInfluence) bool {

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -49,6 +49,10 @@ func minDuration(a, b time.Duration) time.Duration {
 	return b
 }
 
+func isRegionUnhealthy(region *core.RegionInfo) bool {
+	return len(region.GetDownPeers()) != 0 || len(region.GetPendingPeers()) != 0 || len(region.GetLearners()) != 0
+}
+
 func shouldBalance(cluster schedule.Cluster, source, target *core.StoreInfo, region *core.RegionInfo, kind core.ResourceKind, opInfluence schedule.OpInfluence) bool {
 	// The reason we use max(regionSize, averageRegionSize) to check is:
 	// 1. prevent moving small regions between stores with close scores, leading to unnecessary balance.

--- a/server/schedulers/utils_test.go
+++ b/server/schedulers/utils_test.go
@@ -18,6 +18,9 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/pd/server/core"
 )
 
 func TestSchedulers(t *testing.T) {
@@ -44,4 +47,33 @@ func (s *testMinMaxSuite) TestMinDuration(c *C) {
 	c.Assert(minDuration(time.Minute, time.Second), Equals, time.Second)
 	c.Assert(minDuration(time.Second, time.Minute), Equals, time.Second)
 	c.Assert(minDuration(time.Second, time.Second), Equals, time.Second)
+}
+
+var _ = Suite(&testRegionUnhealthySuite{})
+
+type testRegionUnhealthySuite struct{}
+
+func (s *testRegionUnhealthySuite) TestIsRegionUnhealthy(c *C) {
+	peers := make([]*metapb.Peer, 0, 3)
+	for i := uint64(0); i < 2; i++ {
+		p := &metapb.Peer{
+			Id:      i,
+			StoreId: i,
+		}
+		peers = append(peers, p)
+	}
+	peers = append(peers, &metapb.Peer{
+		Id:        2,
+		StoreId:   2,
+		IsLearner: true,
+	})
+
+	r1 := core.NewRegionInfo(&metapb.Region{Peers: peers[:2]}, peers[0], core.WithDownPeers([]*pdpb.PeerStats{{Peer: peers[1]}}))
+	r2 := core.NewRegionInfo(&metapb.Region{Peers: peers[:2]}, peers[0], core.WithPendingPeers([]*metapb.Peer{peers[1]}))
+	r3 := core.NewRegionInfo(&metapb.Region{Peers: peers[:3]}, peers[0], core.WithLearners([]*metapb.Peer{peers[2]}))
+	r4 := core.NewRegionInfo(&metapb.Region{Peers: peers[:2]}, peers[0])
+	c.Assert(isRegionUnhealthy(r1), IsTrue)
+	c.Assert(isRegionUnhealthy(r2), IsTrue)
+	c.Assert(isRegionUnhealthy(r3), IsTrue)
+	c.Assert(isRegionUnhealthy(r4), IsFalse)
 }

--- a/server/schedulers/utils_test.go
+++ b/server/schedulers/utils_test.go
@@ -73,7 +73,7 @@ func (s *testRegionUnhealthySuite) TestIsRegionUnhealthy(c *C) {
 	r3 := core.NewRegionInfo(&metapb.Region{Peers: peers[:3]}, peers[0], core.WithLearners([]*metapb.Peer{peers[2]}))
 	r4 := core.NewRegionInfo(&metapb.Region{Peers: peers[:2]}, peers[0])
 	c.Assert(isRegionUnhealthy(r1), IsTrue)
-	c.Assert(isRegionUnhealthy(r2), IsTrue)
+	c.Assert(isRegionUnhealthy(r2), IsFalse)
 	c.Assert(isRegionUnhealthy(r3), IsTrue)
 	c.Assert(isRegionUnhealthy(r4), IsFalse)
 }


### PR DESCRIPTION
# What problem does this PR solve? <!--add the issue link with summary if it exists-->
We don't check the number of replicas when scheduling the hot region.

### What is changed and how it works?
This PR improves it by checking if it is lack of replicas or has learner peer, just like the balance region does.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release notes
