### PR TITLE
client: modify the tso_wait_duration metric

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -485,7 +485,7 @@ func (c *client) processTSORequests(stream pdpb.PD_TsoClient, requests []*tsoReq
 		c.finishTSORequest(requests, 0, 0, err)
 		return err
 	}
-	requestDuration.WithLabelValues("tso").Observe(time.Since(start).Seconds())
+	requestDurationTSO.Observe(time.Since(start).Seconds())
 	if resp.GetCount() != uint32(len(requests)) {
 		err = errors.WithStack(errTSOLength)
 		c.finishTSORequest(requests, 0, 0, err)
@@ -595,18 +595,20 @@ type TSFuture interface {
 func (req *tsoRequest) Wait() (physical int64, logical int64, err error) {
 	// If tso command duration is observed very high, the reason could be it
 	// takes too long for Wait() be called.
-	now := time.Now()
-	cmdDuration.WithLabelValues("tso_async_wait").Observe(now.Sub(req.start).Seconds())
+	start := time.Now()
+	cmdDurationTSOAsyncWait.Observe(start.Sub(req.start).Seconds())
 	select {
 	case err = <-req.done:
 		err = errors.WithStack(err)
 		defer tsoReqPool.Put(req)
 		if err != nil {
-			cmdFailedDuration.WithLabelValues("tso").Observe(time.Since(req.start).Seconds())
+			cmdFailDurationTSO.Observe(time.Since(req.start).Seconds())
 			return 0, 0, err
 		}
 		physical, logical = req.physical, req.logical
-		cmdDuration.WithLabelValues("wait").Observe(time.Since(now).Seconds())
+		now := time.Now()
+		cmdDurationWait.Observe(now.Sub(start).Seconds())
+		cmdDurationTSO.Observe(now.Sub(req.start).Seconds())
 		return
 	case <-req.ctx.Done():
 		return 0, 0, errors.WithStack(req.ctx.Err())
@@ -624,7 +626,7 @@ func (c *client) GetRegion(ctx context.Context, key []byte) (*metapb.Region, *me
 		defer span.Finish()
 	}
 	start := time.Now()
-	defer func() { cmdDuration.WithLabelValues("get_region").Observe(time.Since(start).Seconds()) }()
+	defer func() { cmdDurationGetRegion.Observe(time.Since(start).Seconds()) }()
 
 	ctx, cancel := context.WithTimeout(ctx, pdTimeout)
 	resp, err := c.leaderClient().GetRegion(ctx, &pdpb.GetRegionRequest{
@@ -634,7 +636,7 @@ func (c *client) GetRegion(ctx context.Context, key []byte) (*metapb.Region, *me
 	cancel()
 
 	if err != nil {
-		cmdFailedDuration.WithLabelValues("get_region").Observe(time.Since(start).Seconds())
+		cmdFailDurationGetRegion.Observe(time.Since(start).Seconds())
 		c.ScheduleCheckLeader()
 		return nil, nil, errors.WithStack(err)
 	}
@@ -647,7 +649,7 @@ func (c *client) GetPrevRegion(ctx context.Context, key []byte) (*metapb.Region,
 		defer span.Finish()
 	}
 	start := time.Now()
-	defer func() { cmdDuration.WithLabelValues("get_prev_region").Observe(time.Since(start).Seconds()) }()
+	defer func() { cmdDurationGetPrevRegion.Observe(time.Since(start).Seconds()) }()
 
 	ctx, cancel := context.WithTimeout(ctx, pdTimeout)
 	resp, err := c.leaderClient().GetPrevRegion(ctx, &pdpb.GetRegionRequest{
@@ -657,7 +659,7 @@ func (c *client) GetPrevRegion(ctx context.Context, key []byte) (*metapb.Region,
 	cancel()
 
 	if err != nil {
-		cmdFailedDuration.WithLabelValues("get_prev_region").Observe(time.Since(start).Seconds())
+		cmdFailDurationGetPrevRegion.Observe(time.Since(start).Seconds())
 		c.ScheduleCheckLeader()
 		return nil, nil, errors.WithStack(err)
 	}
@@ -670,7 +672,7 @@ func (c *client) GetRegionByID(ctx context.Context, regionID uint64) (*metapb.Re
 		defer span.Finish()
 	}
 	start := time.Now()
-	defer func() { cmdDuration.WithLabelValues("get_region_byid").Observe(time.Since(start).Seconds()) }()
+	defer func() { cmdDurationGetRegionByID.Observe(time.Since(start).Seconds()) }()
 
 	ctx, cancel := context.WithTimeout(ctx, pdTimeout)
 	resp, err := c.leaderClient().GetRegionByID(ctx, &pdpb.GetRegionByIDRequest{
@@ -680,7 +682,7 @@ func (c *client) GetRegionByID(ctx context.Context, regionID uint64) (*metapb.Re
 	cancel()
 
 	if err != nil {
-		cmdFailedDuration.WithLabelValues("get_region_byid").Observe(time.Since(start).Seconds())
+		cmdFailedDurationGetRegionByID.Observe(time.Since(start).Seconds())
 		c.ScheduleCheckLeader()
 		return nil, nil, errors.WithStack(err)
 	}
@@ -693,7 +695,7 @@ func (c *client) ScanRegions(ctx context.Context, key []byte, limit int) ([]*met
 		defer span.Finish()
 	}
 	start := time.Now()
-	defer cmdDuration.WithLabelValues("scan_regions").Observe(time.Since(start).Seconds())
+	defer cmdDurationScanRegions.Observe(time.Since(start).Seconds())
 	ctx, cancel := context.WithTimeout(ctx, pdTimeout)
 	resp, err := c.leaderClient().ScanRegions(ctx, &pdpb.ScanRegionsRequest{
 		Header:   c.requestHeader(),
@@ -702,7 +704,7 @@ func (c *client) ScanRegions(ctx context.Context, key []byte, limit int) ([]*met
 	})
 	cancel()
 	if err != nil {
-		cmdFailedDuration.WithLabelValues("scan_regions").Observe(time.Since(start).Seconds())
+		cmdFailedDurationScanRegions.Observe(time.Since(start).Seconds())
 		c.ScheduleCheckLeader()
 		return nil, nil, errors.WithStack(err)
 	}
@@ -715,7 +717,7 @@ func (c *client) GetStore(ctx context.Context, storeID uint64) (*metapb.Store, e
 		defer span.Finish()
 	}
 	start := time.Now()
-	defer func() { cmdDuration.WithLabelValues("get_store").Observe(time.Since(start).Seconds()) }()
+	defer func() { cmdDurationGetStore.Observe(time.Since(start).Seconds()) }()
 
 	ctx, cancel := context.WithTimeout(ctx, pdTimeout)
 	resp, err := c.leaderClient().GetStore(ctx, &pdpb.GetStoreRequest{
@@ -725,7 +727,7 @@ func (c *client) GetStore(ctx context.Context, storeID uint64) (*metapb.Store, e
 	cancel()
 
 	if err != nil {
-		cmdFailedDuration.WithLabelValues("get_store").Observe(time.Since(start).Seconds())
+		cmdFailedDurationGetStore.Observe(time.Since(start).Seconds())
 		c.ScheduleCheckLeader()
 		return nil, errors.WithStack(err)
 	}
@@ -751,7 +753,7 @@ func (c *client) GetAllStores(ctx context.Context, opts ...GetStoreOption) ([]*m
 		defer span.Finish()
 	}
 	start := time.Now()
-	defer func() { cmdDuration.WithLabelValues("get_all_stores").Observe(time.Since(start).Seconds()) }()
+	defer func() { cmdDurationGetAllStores.Observe(time.Since(start).Seconds()) }()
 
 	ctx, cancel := context.WithTimeout(ctx, pdTimeout)
 	resp, err := c.leaderClient().GetAllStores(ctx, &pdpb.GetAllStoresRequest{
@@ -761,7 +763,7 @@ func (c *client) GetAllStores(ctx context.Context, opts ...GetStoreOption) ([]*m
 	cancel()
 
 	if err != nil {
-		cmdFailedDuration.WithLabelValues("get_all_stores").Observe(time.Since(start).Seconds())
+		cmdFailedDurationGetAllStores.Observe(time.Since(start).Seconds())
 		c.ScheduleCheckLeader()
 		return nil, errors.WithStack(err)
 	}
@@ -775,7 +777,7 @@ func (c *client) UpdateGCSafePoint(ctx context.Context, safePoint uint64) (uint6
 		defer span.Finish()
 	}
 	start := time.Now()
-	defer func() { cmdDuration.WithLabelValues("update_gc_safe_point").Observe(time.Since(start).Seconds()) }()
+	defer func() { cmdDurationUpdateGCSafePoint.Observe(time.Since(start).Seconds()) }()
 
 	ctx, cancel := context.WithTimeout(ctx, pdTimeout)
 	resp, err := c.leaderClient().UpdateGCSafePoint(ctx, &pdpb.UpdateGCSafePointRequest{
@@ -785,7 +787,7 @@ func (c *client) UpdateGCSafePoint(ctx context.Context, safePoint uint64) (uint6
 	cancel()
 
 	if err != nil {
-		cmdFailedDuration.WithLabelValues("update_gc_safe_point").Observe(time.Since(start).Seconds())
+		cmdFailedDurationUpdateGCSafePoint.Observe(time.Since(start).Seconds())
 		c.ScheduleCheckLeader()
 		return 0, errors.WithStack(err)
 	}
@@ -798,7 +800,7 @@ func (c *client) ScatterRegion(ctx context.Context, regionID uint64) error {
 		defer span.Finish()
 	}
 	start := time.Now()
-	defer func() { cmdDuration.WithLabelValues("scatter_region").Observe(time.Since(start).Seconds()) }()
+	defer func() { cmdDurationScatterRegion.Observe(time.Since(start).Seconds()) }()
 
 	ctx, cancel := context.WithTimeout(ctx, pdTimeout)
 	resp, err := c.leaderClient().ScatterRegion(ctx, &pdpb.ScatterRegionRequest{
@@ -821,7 +823,7 @@ func (c *client) GetOperator(ctx context.Context, regionID uint64) (*pdpb.GetOpe
 		defer span.Finish()
 	}
 	start := time.Now()
-	defer func() { cmdDuration.WithLabelValues("get_operator").Observe(time.Since(start).Seconds()) }()
+	defer func() { cmdDurationGetOperator.Observe(time.Since(start).Seconds()) }()
 
 	ctx, cancel := context.WithTimeout(ctx, pdTimeout)
 	defer cancel()

--- a/client/client.go
+++ b/client/client.go
@@ -595,7 +595,8 @@ type TSFuture interface {
 func (req *tsoRequest) Wait() (physical int64, logical int64, err error) {
 	// If tso command duration is observed very high, the reason could be it
 	// takes too long for Wait() be called.
-	cmdDuration.WithLabelValues("tso_async_wait").Observe(time.Since(req.start).Seconds())
+	now := time.Now()
+	cmdDuration.WithLabelValues("tso_async_wait").Observe(now.Sub(req.start).Seconds())
 	select {
 	case err = <-req.done:
 		err = errors.WithStack(err)
@@ -605,7 +606,7 @@ func (req *tsoRequest) Wait() (physical int64, logical int64, err error) {
 			return 0, 0, err
 		}
 		physical, logical = req.physical, req.logical
-		cmdDuration.WithLabelValues("tso").Observe(time.Since(req.start).Seconds())
+		cmdDuration.WithLabelValues("wait").Observe(time.Since(now).Seconds())
 		return
 	case <-req.ctx.Done():
 		return 0, 0, errors.WithStack(req.ctx.Err())

--- a/client/metrics.go
+++ b/client/metrics.go
@@ -44,6 +44,32 @@ var (
 		}, []string{"type"})
 )
 
+var (
+	// WithLabelValues is a heavy operation, define variable to avoid call it every time.
+	cmdDurationWait              = cmdDuration.WithLabelValues("wait")
+	cmdDurationTSO               = cmdDuration.WithLabelValues("tso")
+	cmdDurationTSOAsyncWait      = cmdDuration.WithLabelValues("tso_async_wait")
+	cmdDurationGetRegion         = cmdDuration.WithLabelValues("get_region")
+	cmdDurationGetPrevRegion     = cmdDuration.WithLabelValues("get_prev_region")
+	cmdDurationGetRegionByID     = cmdDuration.WithLabelValues("get_region_byid")
+	cmdDurationScanRegions       = cmdDuration.WithLabelValues("scan_regions")
+	cmdDurationGetStore          = cmdDuration.WithLabelValues("get_store")
+	cmdDurationGetAllStores      = cmdDuration.WithLabelValues("get_all_stores")
+	cmdDurationUpdateGCSafePoint = cmdDuration.WithLabelValues("update_gc_safe_point")
+	cmdDurationScatterRegion     = cmdDuration.WithLabelValues("scatter_region")
+	cmdDurationGetOperator       = cmdDuration.WithLabelValues("get_operator")
+
+	cmdFailDurationGetRegion           = cmdFailedDuration.WithLabelValues("get_region")
+	cmdFailDurationTSO                 = cmdFailedDuration.WithLabelValues("tso")
+	cmdFailDurationGetPrevRegion       = cmdFailedDuration.WithLabelValues("get_prev_region")
+	cmdFailedDurationGetRegionByID     = cmdFailedDuration.WithLabelValues("get_region_byid")
+	cmdFailedDurationScanRegions       = cmdFailedDuration.WithLabelValues("scan_regions")
+	cmdFailedDurationGetStore          = cmdFailedDuration.WithLabelValues("get_store")
+	cmdFailedDurationGetAllStores      = cmdFailedDuration.WithLabelValues("get_all_stores")
+	cmdFailedDurationUpdateGCSafePoint = cmdFailedDuration.WithLabelValues("update_gc_safe_point")
+	requestDurationTSO                 = requestDuration.WithLabelValues("tso")
+)
+
 func init() {
 	prometheus.MustRegister(cmdDuration)
 	prometheus.MustRegister(cmdFailedDuration)


### PR DESCRIPTION


<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

The "PD TSO WAIT DURATION" here is very confusing:

![image](https://user-images.githubusercontent.com/1420062/60944122-878aab80-a31a-11e9-80ab-4fd71b2c10c3.png)

I'd like to change this to a real **wait** duration, that is, we wait on the channel to return the result.


### What is changed and how it works?

The meaning of this metric is that we **wait** for a tso future, maybe that time is quite small if the **wait** doesn't really happen.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)


Side effects

- Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch

PTAL @disksing @jackysp 