### PR TITLE
core: use hex format for region meta key

### DIFF
--- a/server/checker/merge_checker.go
+++ b/server/checker/merge_checker.go
@@ -114,7 +114,7 @@ func (m *MergeChecker) Check(region *core.RegionInfo) []*schedule.Operator {
 		return nil
 	}
 
-	log.Debug("try to merge region", zap.Reflect("from", core.HexRegionMeta(region.GetMeta())), zap.Reflect("to", core.HexRegionMeta(target.GetMeta())))
+	log.Debug("try to merge region", zap.Stringer("from", core.RegionToHexMeta(region.GetMeta())), zap.Stringer("to", core.RegionToHexMeta(target.GetMeta())))
 	ops, err := schedule.CreateMergeRegionOperator("merge-region", m.cluster, region, target, schedule.OpMerge)
 	if err != nil {
 		return nil

--- a/server/cluster_info.go
+++ b/server/cluster_info.go
@@ -532,7 +532,7 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 	if origin == nil {
 		log.Debug("insert new region",
 			zap.Uint64("region-id", region.GetID()),
-			zap.Reflect("meta-region", core.HexRegionMeta(region.GetMeta())),
+			zap.Stringer("meta-region", core.RegionToHexMeta(region.GetMeta())),
 		)
 		saveKV, saveCache, isNew = true, true, true
 	} else {
@@ -595,7 +595,7 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 			// after restart. Here we only log the error then go on updating cache.
 			log.Error("fail to save region to storage",
 				zap.Uint64("region-id", region.GetID()),
-				zap.Reflect("region-meta", core.HexRegionMeta(region.GetMeta())),
+				zap.Stringer("region-meta", core.RegionToHexMeta(region.GetMeta())),
 				zap.Error(err))
 		}
 		select {
@@ -620,7 +620,7 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 				if err := c.storage.DeleteRegion(item); err != nil {
 					log.Error("fail to delete region from storage",
 						zap.Uint64("region-id", item.GetId()),
-						zap.Reflect("region-meta", core.HexRegionMeta(item)),
+						zap.Stringer("region-meta", core.RegionToHexMeta(item)),
 						zap.Error(err))
 				}
 			}

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -822,14 +822,25 @@ func HexRegionKey(key []byte) []byte {
 
 // RegionToHexMeta converts a region meta's keys to hex format. Used for formating
 // region in logs.
-func RegionToHexMeta(meta *metapb.Region) HexRegionsMeta {
+func RegionToHexMeta(meta *metapb.Region) HexRegionMeta {
 	if meta == nil {
-		return nil
+		return HexRegionMeta{}
 	}
 	meta = proto.Clone(meta).(*metapb.Region)
 	meta.StartKey = HexRegionKey(meta.StartKey)
 	meta.EndKey = HexRegionKey(meta.EndKey)
-	return HexRegionsMeta([]*metapb.Region{meta})
+	return HexRegionMeta{meta}
+}
+
+// HexRegionMeta is a region meta in the hex format. Used for formating region in logs.
+type HexRegionMeta struct {
+	*metapb.Region
+}
+
+func (h HexRegionMeta) String() string {
+	var b strings.Builder
+	b.WriteString(proto.CompactTextString(h.Region))
+	return strings.TrimSpace(b.String())
 }
 
 // RegionsToHexMeta converts regions' meta keys to hex format. Used for formating
@@ -851,9 +862,9 @@ func RegionsToHexMeta(regions []*metapb.Region) HexRegionsMeta {
 type HexRegionsMeta []*metapb.Region
 
 func (h HexRegionsMeta) String() string {
-	var s string
-	for i := 0; i < len(h); i++ {
-		s += proto.CompactTextString(h[i])
+	var b strings.Builder
+	for _, r := range h {
+		b.WriteString(proto.CompactTextString(r))
 	}
-	return strings.TrimRight(s, " ")
+	return strings.TrimSpace(b.String())
 }

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -838,9 +838,7 @@ type HexRegionMeta struct {
 }
 
 func (h HexRegionMeta) String() string {
-	var b strings.Builder
-	b.WriteString(proto.CompactTextString(h.Region))
-	return strings.TrimSpace(b.String())
+	return strings.TrimSpace(proto.CompactTextString(h.Region))
 }
 
 // RegionsToHexMeta converts regions' meta keys to hex format. Used for formating

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -820,14 +820,40 @@ func HexRegionKey(key []byte) []byte {
 	return []byte(strings.ToUpper(hex.EncodeToString(key)))
 }
 
-// HexRegionMeta converts a region meta's keys to hex format. Used for formating
+// RegionToHexMeta converts a region meta's keys to hex format. Used for formating
 // region in logs.
-func HexRegionMeta(meta *metapb.Region) *metapb.Region {
+func RegionToHexMeta(meta *metapb.Region) HexRegionsMeta {
 	if meta == nil {
 		return nil
 	}
 	meta = proto.Clone(meta).(*metapb.Region)
 	meta.StartKey = HexRegionKey(meta.StartKey)
 	meta.EndKey = HexRegionKey(meta.EndKey)
-	return meta
+	return HexRegionsMeta([]*metapb.Region{meta})
+}
+
+// RegionsToHexMeta converts regions' meta keys to hex format. Used for formating
+// region in logs.
+func RegionsToHexMeta(regions []*metapb.Region) HexRegionsMeta {
+	hexRegionMetas := make([]*metapb.Region, len(regions))
+	for i, region := range regions {
+		meta := proto.Clone(region).(*metapb.Region)
+		meta.StartKey = HexRegionKey(meta.StartKey)
+		meta.EndKey = HexRegionKey(meta.EndKey)
+
+		hexRegionMetas[i] = meta
+	}
+	return HexRegionsMeta(hexRegionMetas)
+}
+
+// HexRegionsMeta is a slice of regions' meta in the hex format. Used for formating
+// region in logs.
+type HexRegionsMeta []*metapb.Region
+
+func (h HexRegionsMeta) String() string {
+	var s string
+	for i := 0; i < len(h); i++ {
+		s += proto.CompactTextString(h[i])
+	}
+	return strings.TrimRight(s, " ")
 }

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -118,7 +118,7 @@ func (*testRegionKey) TestRegionKey(c *C) {
 	for _, t := range testCase {
 		got, err := strconv.Unquote(t.key)
 		c.Assert(err, IsNil)
-		s := fmt.Sprintln(HexRegionMeta(&metapb.Region{StartKey: []byte(got)}))
+		s := fmt.Sprintln(RegionToHexMeta(&metapb.Region{StartKey: []byte(got)}))
 		c.Assert(strings.Contains(s, t.expect), IsTrue)
 
 		// start key changed

--- a/server/core/region_tree.go
+++ b/server/core/region_tree.go
@@ -92,8 +92,8 @@ func (t *regionTree) update(region *metapb.Region) []*metapb.Region {
 	for _, item := range overlaps {
 		log.Debug("overlapping region",
 			zap.Uint64("region-id", item.GetId()),
-			zap.Reflect("delete-region", HexRegionMeta(item)),
-			zap.Reflect("update-region", HexRegionMeta(region)))
+			zap.Stringer("delete-region", RegionToHexMeta(item)),
+			zap.Stringer("update-region", RegionToHexMeta(region)))
 		t.tree.Delete(&regionItem{item})
 	}
 

--- a/tools/regions-dump/main.go
+++ b/tools/regions-dump/main.go
@@ -115,7 +115,7 @@ func loadRegions(client *clientv3.Client, f *os.File) error {
 				return errors.WithStack(err)
 			}
 			nextID = region.GetId() + 1
-			fmt.Fprintln(w, core.HexRegionMeta(region))
+			fmt.Fprintln(w, core.RegionToHexMeta(region).Region)
 		}
 
 		if len(res) < rangeLimit {


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
When printing the log, the region meta key is not in hex format in many places. e.g.
```
[2019/07/10 08:36:24.581 +00:00] [INFO] [cluster_worker.go:207] ["region batch split, generate new regions"] [region-id=48898216] [origin="[{\"id\":48904284,\"start_key\":\"NzQ4MDAwMDAwMDAwMDAwNUZGMTc1RjcyODAwMDAwMDAwMEZGNDZDOUE1MDAwMDAwMDAwMEZB\",\"end_key\":\"NzQ4MDAwMDAwMDAwMDAwNUZGMTc1RjcyODAwMDAwMDAwMEZGNDhFQUE4MDAwMDAwMDAwMEZB\",\"region_epoch\":{\"conf_ver\":74,\"version\":1332},\"peers\":[{\"id\":48904285,\"store_id\":1723600},{\"id\":48904286,\"store_id\":14},{\"id\":48904287,\"store_id\":12}]}]"] [total=1]
```

### What is changed and how it works?
After this PR:
```
[2019/07/10 12:03:30.051 +00:00] [INFO] [cluster_worker.go:205] ["region batch split, generate new regions"] [region-id=179169] [origin="id:179249 start_key:\"7480000000000004FF0A00000000000000F8\" end_key:\"7480000000000004FF0B00000000000000F8\" region_epoch:<conf_ver:23 version:547 > peers:<id:179250 store_id:7 > peers:<id:179251 store_id:4 > peers:<id:179252 store_id:6 >"] [total=1]
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release notes
