### PR TITLE
api: stabilize redirector test

### DIFF
--- a/server/api/redirector_test.go
+++ b/server/api/redirector_test.go
@@ -38,9 +38,12 @@ func (s *testRedirectorSuite) TearDownSuite(c *C) {
 func (s *testRedirectorSuite) TestRedirect(c *C) {
 	leader := mustWaitLeader(c, s.servers)
 	header := mustRequestSuccess(c, leader)
+	header.Del("Date")
 	for _, svr := range s.servers {
 		if svr != leader {
-			c.Assert(header, DeepEquals, mustRequestSuccess(c, svr))
+			h := mustRequestSuccess(c, svr)
+			h.Del("Date")
+			c.Assert(header, DeepEquals, h)
 		}
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
There is a certain probability that the redirector test may be failed because there is a gap between two requests.

### What is changed and how it works?
This PR removes the `Date` comparison between two requests. It will make our CI more stable.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test