### PR TITLE
schedule: fix merge related operators in waiting operators

### DIFF
--- a/server/schedule/waiting_operator.go
+++ b/server/schedule/waiting_operator.go
@@ -90,7 +90,7 @@ func (b *RandBuckets) GetOperator() []*Operator {
 			var res []*Operator
 			res = append(res, bucket.ops[0])
 			// Merge operation has two operators, and thus it should be handled specifically.
-			if bucket.ops[0].Desc() == "merge-region" {
+			if bucket.ops[0].Kind()&OpMerge != 0 {
 				res = append(res, bucket.ops[1])
 				bucket.ops = bucket.ops[2:]
 			} else {

--- a/server/schedule/waiting_operator_test.go
+++ b/server/schedule/waiting_operator_test.go
@@ -58,9 +58,11 @@ func (s *testWaitingOperatorSuite) TestListOperator(c *C) {
 
 func (s *testWaitingOperatorSuite) TestRandomBucketsWithMergeRegion(c *C) {
 	rb := NewRandBuckets()
+	descs := []string{"merge-region", "admin-merge-region", "random-merge"}
 	for j := 0; j < 100; j++ {
 		// adds operators
-		op := NewOperator("merge-region", uint64(1), &metapb.RegionEpoch{}, OpRegion|OpMerge, []OperatorStep{
+		desc := descs[j%3]
+		op := NewOperator(desc, uint64(1), &metapb.RegionEpoch{}, OpRegion|OpMerge, []OperatorStep{
 			MergeRegion{
 				FromRegion: &metapb.Region{
 					Id:          1,
@@ -75,7 +77,7 @@ func (s *testWaitingOperatorSuite) TestRandomBucketsWithMergeRegion(c *C) {
 			},
 		}...)
 		rb.PutOperator(op)
-		op = NewOperator("merge-region", uint64(2), &metapb.RegionEpoch{}, OpRegion|OpMerge, []OperatorStep{
+		op = NewOperator(desc, uint64(2), &metapb.RegionEpoch{}, OpRegion|OpMerge, []OperatorStep{
 			MergeRegion{
 				FromRegion: &metapb.Region{
 					Id:          1,


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Currently, we only take `merge-region` into consideration. But `random-merge` and `admin-merge-region` also need to be considered.

### What is changed and how it works?
This PR uses `Kind()` instead of `Desc()` to decide if we need to get another operator.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test