### PR TITLE
server: use an individual package for join

### DIFF
--- a/cmd/pd-server/main.go
+++ b/cmd/pd-server/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/pd/server"
 	"github.com/pingcap/pd/server/api"
 	"github.com/pingcap/pd/server/config"
+	"github.com/pingcap/pd/server/join"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
@@ -81,7 +82,7 @@ func main() {
 
 	metricutil.Push(&cfg.Metric)
 
-	err = server.PrepareJoinCluster(cfg)
+	err = join.PrepareJoinCluster(cfg)
 	if err != nil {
 		log.Fatal("join meet error", zap.Error(err))
 	}

--- a/server/join/join.go
+++ b/server/join/join.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package join
 
 import (
 	"fmt"

--- a/server/join/join_test.go
+++ b/server/join/join_test.go
@@ -11,11 +11,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package join
 
 import (
+	"testing"
+
 	. "github.com/pingcap/check"
+	"github.com/pingcap/pd/server"
 )
+
+func TestJoin(t *testing.T) {
+	TestingT(t)
+}
 
 var _ = Suite(&testJoinServerSuite{})
 
@@ -23,7 +30,7 @@ type testJoinServerSuite struct{}
 
 // A PD joins itself.
 func (s *testJoinServerSuite) TestPDJoinsItself(c *C) {
-	cfg := NewTestSingleConfig(c)
+	cfg := server.NewTestSingleConfig(c)
 	cfg.Join = cfg.AdvertiseClientUrls
 	c.Assert(PrepareJoinCluster(cfg), NotNil)
 }

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/pd/server/config"
 	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/server/id"
+	"github.com/pingcap/pd/server/join"
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/clientv3"
 	"go.uber.org/zap"
@@ -61,7 +62,7 @@ func NewTestServer(cfg *config.Config) (*TestServer, error) {
 	zapLogOnce.Do(func() {
 		log.ReplaceGlobals(cfg.GetZapLogger(), cfg.GetZapLogProperties())
 	})
-	err = server.PrepareJoinCluster(cfg)
+	err = join.PrepareJoinCluster(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/server/join/join_fail/join_fail_test.go
+++ b/tests/server/join/join_fail/join_fail_test.go
@@ -27,15 +27,15 @@ func Test(t *testing.T) {
 	TestingT(t)
 }
 
-var _ = Suite(&serverTestSuite{})
+var _ = Suite(&joinTestSuite{})
 
-type serverTestSuite struct{}
+type joinTestSuite struct{}
 
-func (s *serverTestSuite) SetUpSuite(c *C) {
+func (s *joinTestSuite) SetUpSuite(c *C) {
 	server.EnableZap = true
 }
 
-func (s *serverTestSuite) TestFailedPDJoinInStep1(c *C) {
+func (s *joinTestSuite) TestFailedPDJoinInStep1(c *C) {
 	cluster, err := tests.NewTestCluster(1)
 	c.Assert(err, IsNil)
 	defer cluster.Destroy()
@@ -45,9 +45,9 @@ func (s *serverTestSuite) TestFailedPDJoinInStep1(c *C) {
 	cluster.WaitLeader()
 
 	// Join the second PD.
-	c.Assert(failpoint.Enable("github.com/pingcap/pd/server/add-member-failed", `return`), IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/pd/server/join/add-member-failed", `return`), IsNil)
 	_, err = cluster.Join()
 	c.Assert(err, NotNil)
 	c.Assert(strings.Contains(err.Error(), "join failed"), IsTrue)
-	c.Assert(failpoint.Disable("github.com/pingcap/pd/server/add-member-failed"), IsNil)
+	c.Assert(failpoint.Disable("github.com/pingcap/pd/server/join/add-member-failed"), IsNil)
 }

--- a/tests/server/join/join_test.go
+++ b/tests/server/join/join_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/pd/pkg/etcdutil"
 	"github.com/pingcap/pd/server"
+	"github.com/pingcap/pd/server/join"
 	"github.com/pingcap/pd/tests"
 )
 
@@ -30,15 +31,15 @@ func Test(t *testing.T) {
 	TestingT(t)
 }
 
-var _ = Suite(&serverTestSuite{})
+var _ = Suite(&joinTestSuite{})
 
-type serverTestSuite struct{}
+type joinTestSuite struct{}
 
-func (s *serverTestSuite) SetUpSuite(c *C) {
+func (s *joinTestSuite) SetUpSuite(c *C) {
 	server.EnableZap = true
 }
 
-func (s *serverTestSuite) TestSimpleJoin(c *C) {
+func (s *joinTestSuite) TestSimpleJoin(c *C) {
 	c.Parallel()
 
 	cluster, err := tests.NewTestCluster(1)
@@ -85,7 +86,7 @@ func (s *serverTestSuite) TestSimpleJoin(c *C) {
 
 // A failed PD tries to join the previous cluster but it has been deleted
 // during its downtime.
-func (s *serverTestSuite) TestFailedAndDeletedPDJoinsPreviousCluster(c *C) {
+func (s *joinTestSuite) TestFailedAndDeletedPDJoinsPreviousCluster(c *C) {
 	c.Parallel()
 
 	cluster, err := tests.NewTestCluster(3)
@@ -121,7 +122,7 @@ func (s *serverTestSuite) TestFailedAndDeletedPDJoinsPreviousCluster(c *C) {
 }
 
 // A deleted PD joins the previous cluster.
-func (s *serverTestSuite) TestDeletedPDJoinsPreviousCluster(c *C) {
+func (s *joinTestSuite) TestDeletedPDJoinsPreviousCluster(c *C) {
 	c.Parallel()
 
 	cluster, err := tests.NewTestCluster(3)
@@ -156,7 +157,7 @@ func (s *serverTestSuite) TestDeletedPDJoinsPreviousCluster(c *C) {
 	c.Assert(members.Members, HasLen, 2)
 }
 
-func (s *serverTestSuite) TestFailedPDJoinsPreviousCluster(c *C) {
+func (s *joinTestSuite) TestFailedPDJoinsPreviousCluster(c *C) {
 	c.Parallel()
 
 	cluster, err := tests.NewTestCluster(1)
@@ -176,5 +177,5 @@ func (s *serverTestSuite) TestFailedPDJoinsPreviousCluster(c *C) {
 	c.Assert(err, IsNil)
 	err = pd2.Destroy()
 	c.Assert(err, IsNil)
-	c.Assert(server.PrepareJoinCluster(pd2.GetConfig()), NotNil)
+	c.Assert(join.PrepareJoinCluster(pd2.GetConfig()), NotNil)
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Part of modularizing PD. It should be reviewed after #1657 is merged.

### What is changed and how it works?
This PR uses an individual package for `join`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test