### PR TITLE
server/schedule: remove unnecessary interfaces

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -44,7 +44,7 @@ type idAllocator struct {
 }
 
 func (i *idAllocator) alloc() uint64 {
-	id, _ := i.allocator.Alloc()
+	id, _ := i.allocator.AllocID()
 	return id
 }
 

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -384,7 +384,7 @@ func (mc *Cluster) newMockRegionInfo(regionID uint64, leaderID uint64, followerI
 		EndKey:   []byte(fmt.Sprintf("%20d", regionID+1)),
 	}
 	peerID, _ := mc.AllocID()
-	region.Peers = []*metapb.Peer{&metapb.Peer{StoreId: leaderID, Id: peerID}}
+	region.Peers = []*metapb.Peer{{StoreId: leaderID, Id: peerID}}
 	for _, id := range followerIds {
 		pID, _ := mc.AllocID()
 		region.Peers = append(region.Peers, &metapb.Peer{StoreId: id, Id: pID})

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -93,7 +93,7 @@ func (mc *Cluster) RandHotRegionFromStore(store uint64, kind statistics.FlowKind
 
 // AllocPeer allocs a new peer on a store.
 func (mc *Cluster) AllocPeer(storeID uint64) (*metapb.Peer, error) {
-	peerID, err := mc.Alloc()
+	peerID, err := mc.AllocID()
 	if err != nil {
 		log.Error("failed to alloc peer", zap.Error(err))
 		return nil, err
@@ -383,10 +383,10 @@ func (mc *Cluster) newMockRegionInfo(regionID uint64, leaderID uint64, followerI
 		StartKey: []byte(fmt.Sprintf("%20d", regionID)),
 		EndKey:   []byte(fmt.Sprintf("%20d", regionID+1)),
 	}
-	peerID, _ := mc.Alloc()
+	peerID, _ := mc.AllocID()
 	region.Peers = []*metapb.Peer{&metapb.Peer{StoreId: leaderID, Id: peerID}}
 	for _, id := range followerIds {
-		pID, _ := mc.Alloc()
+		pID, _ := mc.AllocID()
 		region.Peers = append(region.Peers, &metapb.Peer{StoreId: id, Id: pID})
 	}
 

--- a/pkg/mock/mockid/mockid.go
+++ b/pkg/mock/mockid/mockid.go
@@ -25,7 +25,7 @@ func NewIDAllocator() *IDAllocator {
 	return &IDAllocator{base: 0}
 }
 
-// Alloc returns a new id.
-func (alloc *IDAllocator) Alloc() (uint64, error) {
+// AllocID returns a new id.
+func (alloc *IDAllocator) AllocID() (uint64, error) {
 	return atomic.AddUint64(&alloc.base, 1), nil
 }

--- a/server/checker/merge_checker.go
+++ b/server/checker/merge_checker.go
@@ -116,7 +116,7 @@ func (m *MergeChecker) Check(region *core.RegionInfo) []*operator.Operator {
 	}
 
 	log.Debug("try to merge region", zap.Stringer("from", core.RegionToHexMeta(region.GetMeta())), zap.Stringer("to", core.RegionToHexMeta(target.GetMeta())))
-	ops, err := operator.CreateMergeRegionOperator("merge-region", m.cluster, region, target, operator.OpMerge)
+	ops, err := operator.CreateMergeRegionOperator("merge-region", m.cluster, m.cluster, region, target, operator.OpMerge)
 	if err != nil {
 		return nil
 	}

--- a/server/checker/namespace_checker.go
+++ b/server/checker/namespace_checker.go
@@ -96,7 +96,7 @@ func (n *NamespaceChecker) SelectBestPeerToRelocate(region *core.RegionInfo, tar
 		log.Debug("has no best store to relocate", zap.Uint64("region-id", region.GetID()))
 		return nil
 	}
-	id, err := n.cluster.Alloc()
+	id, err := n.cluster.AllocID()
 	if err != nil {
 		return nil
 	}

--- a/server/checker/namespace_checker.go
+++ b/server/checker/namespace_checker.go
@@ -76,7 +76,7 @@ func (n *NamespaceChecker) Check(region *core.RegionInfo) *operator.Operator {
 			checkerCounter.WithLabelValues("namespace_checker", "no_target_peer").Inc()
 			return nil
 		}
-		op, err := operator.CreateMovePeerOperator("make-namespace-relocation", n.cluster, region, operator.OpReplica, peer.GetStoreId(), newPeer.GetStoreId(), newPeer.GetId())
+		op, err := operator.CreateMovePeerOperator("make-namespace-relocation", n.cluster, n.cluster, region, operator.OpReplica, peer.GetStoreId(), newPeer.GetStoreId(), newPeer.GetId())
 		if err != nil {
 			checkerCounter.WithLabelValues("namespace_checker", "create_operator_fail").Inc()
 			return nil

--- a/server/checker/namespace_checker.go
+++ b/server/checker/namespace_checker.go
@@ -96,11 +96,11 @@ func (n *NamespaceChecker) SelectBestPeerToRelocate(region *core.RegionInfo, tar
 		log.Debug("has no best store to relocate", zap.Uint64("region-id", region.GetID()))
 		return nil
 	}
-	newPeer, err := n.cluster.AllocPeer(storeID)
+	id, err := n.cluster.Alloc()
 	if err != nil {
 		return nil
 	}
-	return newPeer
+	return &metapb.Peer{StoreId: storeID, Id: id}
 }
 
 // SelectBestStoreToRelocate randomly returns the store to relocate

--- a/server/checker/replica_checker.go
+++ b/server/checker/replica_checker.go
@@ -114,7 +114,7 @@ func (r *ReplicaChecker) selectBestPeerToAddReplica(region *core.RegionInfo, fil
 		log.Debug("no best store to add replica", zap.Uint64("region-id", region.GetID()))
 		return nil, 0
 	}
-	id, err := r.cluster.Alloc()
+	id, err := r.cluster.AllocID()
 	if err != nil {
 		return nil, 0
 	}
@@ -228,7 +228,7 @@ func (r *ReplicaChecker) checkBestReplacement(region *core.RegionInfo) *operator
 		checkerCounter.WithLabelValues("replica_checker", "not_better").Inc()
 		return nil
 	}
-	id, err := r.cluster.Alloc()
+	id, err := r.cluster.AllocID()
 	if err != nil {
 		return nil
 	}
@@ -272,7 +272,7 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, peer *metapb.Peer, sta
 		log.Debug("no best store to add replica", zap.Uint64("region-id", region.GetID()))
 		return nil
 	}
-	id, err := r.cluster.Alloc()
+	id, err := r.cluster.AllocID()
 	if err != nil {
 		return nil
 	}

--- a/server/checker/replica_checker.go
+++ b/server/checker/replica_checker.go
@@ -88,7 +88,7 @@ func (r *ReplicaChecker) Check(region *core.RegionInfo) *operator.Operator {
 			checkerCounter.WithLabelValues("replica_checker", "no_worst_peer").Inc()
 			return nil
 		}
-		op, err := operator.CreateRemovePeerOperator("remove-extra-replica", r.cluster, operator.OpReplica, region, oldPeer.GetStoreId())
+		op, err := operator.CreateRemovePeerOperator("remove-extra-replica", r.cluster, r.cluster, operator.OpReplica, region, oldPeer.GetStoreId())
 		if err != nil {
 			checkerCounter.WithLabelValues("replica_checker", "create_operator_fail").Inc()
 			return nil
@@ -232,7 +232,7 @@ func (r *ReplicaChecker) checkBestReplacement(region *core.RegionInfo) *operator
 	if err != nil {
 		return nil
 	}
-	op, err := operator.CreateMovePeerOperator("move-to-better-location", r.cluster, region, operator.OpReplica, oldPeer.GetStoreId(), storeID, id)
+	op, err := operator.CreateMovePeerOperator("move-to-better-location", r.cluster, r.cluster, region, operator.OpReplica, oldPeer.GetStoreId(), storeID, id)
 	if err != nil {
 		checkerCounter.WithLabelValues("replica_checker", "create_operator_fail").Inc()
 		return nil
@@ -245,7 +245,7 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, peer *metapb.Peer, sta
 	removeExtra := fmt.Sprintf("remove-extra-%s-replica", status)
 	// Check the number of replicas first.
 	if len(region.GetPeers()) > r.cluster.GetMaxReplicas() {
-		op, err := operator.CreateRemovePeerOperator(removeExtra, r.cluster, operator.OpReplica, region, peer.GetStoreId())
+		op, err := operator.CreateRemovePeerOperator(removeExtra, r.cluster, r.cluster, operator.OpReplica, region, peer.GetStoreId())
 		if err != nil {
 			checkerCounter.WithLabelValues("replica_checker", "create_operator_fail").Inc()
 			return nil
@@ -259,7 +259,7 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, peer *metapb.Peer, sta
 	// D then removes C, D will not be successfully added util C is normal again.
 	// So it's better to remove C directly.
 	if region.GetPendingPeer(peer.GetId()) != nil {
-		op, err := operator.CreateRemovePeerOperator(removePending, r.cluster, operator.OpReplica, region, peer.GetStoreId())
+		op, err := operator.CreateRemovePeerOperator(removePending, r.cluster, r.cluster, operator.OpReplica, region, peer.GetStoreId())
 		if err != nil {
 			checkerCounter.WithLabelValues("replica_checker", "create_operator_fail").Inc()
 			return nil
@@ -278,7 +278,7 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, peer *metapb.Peer, sta
 	}
 
 	replace := fmt.Sprintf("replace-%s-replica", status)
-	op, err := operator.CreateMovePeerOperator(replace, r.cluster, region, operator.OpReplica, peer.GetStoreId(), storeID, id)
+	op, err := operator.CreateMovePeerOperator(replace, r.cluster, r.cluster, region, operator.OpReplica, peer.GetStoreId(), storeID, id)
 	if err != nil {
 		return nil
 	}

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -1156,9 +1156,9 @@ func (c *RaftCluster) takeRegionStoresLocked(region *core.RegionInfo) []*core.St
 	return stores
 }
 
-// Alloc returns a new uniqe ID.
-func (c *RaftCluster) Alloc() (uint64, error) {
-	id, err := c.id.Alloc()
+// AllocID returns a new uniqe ID.
+func (c *RaftCluster) AllocID() (uint64, error) {
+	id, err := c.id.AllocID()
 	if err != nil {
 		log.Error("failed to alloc id", zap.Error(err))
 	}

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -1156,22 +1156,13 @@ func (c *RaftCluster) takeRegionStoresLocked(region *core.RegionInfo) []*core.St
 	return stores
 }
 
-func (c *RaftCluster) allocID() (uint64, error) {
-	return c.id.Alloc()
-}
-
-// AllocPeer allocs a new peer on a store.
-func (c *RaftCluster) AllocPeer(storeID uint64) (*metapb.Peer, error) {
-	peerID, err := c.allocID()
+// Alloc returns a new uniqe ID.
+func (c *RaftCluster) Alloc() (uint64, error) {
+	id, err := c.id.Alloc()
 	if err != nil {
-		log.Error("failed to alloc peer", zap.Error(err))
-		return nil, err
+		log.Error("failed to alloc id", zap.Error(err))
 	}
-	peer := &metapb.Peer{
-		Id:      peerID,
-		StoreId: storeID,
-	}
-	return peer, nil
+	return id, err
 }
 
 // OnStoreVersionChange changes the version of the cluster when needed.

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -65,7 +65,7 @@ func mustNewGrpcClient(c *C, addr string) pdpb.PDClient {
 }
 
 func (s *baseCluster) allocID(c *C) uint64 {
-	id, err := s.svr.idAllocator.Alloc()
+	id, err := s.svr.idAllocator.AllocID()
 	c.Assert(err, IsNil)
 	return id
 }

--- a/server/cluster_worker.go
+++ b/server/cluster_worker.go
@@ -51,14 +51,14 @@ func (c *RaftCluster) handleAskSplit(request *pdpb.AskSplitRequest) (*pdpb.AskSp
 		return nil, err
 	}
 
-	newRegionID, err := c.s.idAllocator.Alloc()
+	newRegionID, err := c.s.idAllocator.AllocID()
 	if err != nil {
 		return nil, err
 	}
 
 	peerIDs := make([]uint64, len(request.Region.Peers))
 	for i := 0; i < len(peerIDs); i++ {
-		if peerIDs[i], err = c.s.idAllocator.Alloc(); err != nil {
+		if peerIDs[i], err = c.s.idAllocator.AllocID(); err != nil {
 			return nil, err
 		}
 	}
@@ -107,14 +107,14 @@ func (c *RaftCluster) handleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*
 	// Disable merge the regions in a period of time.
 	c.coordinator.mergeChecker.RecordRegionSplit(reqRegion.GetId())
 	for i := 0; i < int(splitCount); i++ {
-		newRegionID, err := c.s.idAllocator.Alloc()
+		newRegionID, err := c.s.idAllocator.AllocID()
 		if err != nil {
 			return nil, errSchedulerNotFound
 		}
 
 		peerIDs := make([]uint64, len(request.Region.Peers))
 		for i := 0; i < len(peerIDs); i++ {
-			if peerIDs[i], err = c.s.idAllocator.Alloc(); err != nil {
+			if peerIDs[i], err = c.s.idAllocator.AllocID(); err != nil {
 				return nil, err
 			}
 		}

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -88,11 +88,11 @@ func (c *testCluster) addRegionStore(storeID uint64, regionCount int) error {
 
 func (c *testCluster) addLeaderRegion(regionID uint64, leaderID uint64, followerIds ...uint64) error {
 	region := newTestRegionMeta(regionID)
-	leaderPeerID, _ := c.Alloc()
+	leaderPeerID, _ := c.AllocID()
 	leader := &metapb.Peer{Id: leaderPeerID, StoreId: leaderID}
 	region.Peers = []*metapb.Peer{leader}
 	for _, id := range followerIds {
-		peerID, _ := c.Alloc()
+		peerID, _ := c.AllocID()
 		region.Peers = append(region.Peers, &metapb.Peer{Id: peerID, StoreId: id})
 	}
 	regionInfo := core.NewRegionInfo(region, leader, core.SetApproximateSize(10), core.SetApproximateKeys(10))
@@ -147,7 +147,7 @@ func (c *testCluster) LoadRegion(regionID uint64, followerIds ...uint64) error {
 	region := newTestRegionMeta(regionID)
 	region.Peers = []*metapb.Peer{}
 	for _, storeID := range followerIds {
-		peerID, _ := c.Alloc()
+		peerID, _ := c.AllocID()
 		region.Peers = append(region.Peers, &metapb.Peer{Id: peerID, StoreId: storeID})
 	}
 	return c.putRegion(core.NewRegionInfo(region, nil))

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -88,11 +88,12 @@ func (c *testCluster) addRegionStore(storeID uint64, regionCount int) error {
 
 func (c *testCluster) addLeaderRegion(regionID uint64, leaderID uint64, followerIds ...uint64) error {
 	region := newTestRegionMeta(regionID)
-	leader, _ := c.AllocPeer(leaderID)
+	leaderPeerID, _ := c.Alloc()
+	leader := &metapb.Peer{Id: leaderPeerID, StoreId: leaderID}
 	region.Peers = []*metapb.Peer{leader}
 	for _, id := range followerIds {
-		peer, _ := c.AllocPeer(id)
-		region.Peers = append(region.Peers, peer)
+		peerID, _ := c.Alloc()
+		region.Peers = append(region.Peers, &metapb.Peer{Id: peerID, StoreId: id})
 	}
 	regionInfo := core.NewRegionInfo(region, leader, core.SetApproximateSize(10), core.SetApproximateKeys(10))
 	return c.putRegion(regionInfo)
@@ -145,9 +146,9 @@ func (c *testCluster) LoadRegion(regionID uint64, followerIds ...uint64) error {
 	//  regions load from etcd will have no leader
 	region := newTestRegionMeta(regionID)
 	region.Peers = []*metapb.Peer{}
-	for _, id := range followerIds {
-		peer, _ := c.AllocPeer(id)
-		region.Peers = append(region.Peers, peer)
+	for _, storeID := range followerIds {
+		peerID, _ := c.Alloc()
+		region.Peers = append(region.Peers, &metapb.Peer{Id: peerID, StoreId: storeID})
 	}
 	return c.putRegion(core.NewRegionInfo(region, nil))
 }

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -140,7 +140,7 @@ func (s *Server) AllocID(ctx context.Context, request *pdpb.AllocIDRequest) (*pd
 	}
 
 	// We can use an allocator for all types ID allocation.
-	id, err := s.idAllocator.Alloc()
+	id, err := s.idAllocator.AllocID()
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, err.Error())
 	}

--- a/server/handler.go
+++ b/server/handler.go
@@ -474,12 +474,12 @@ func (h *Handler) AddTransferPeerOperator(regionID uint64, fromStoreID, toStoreI
 		return errcode.Op("operator.add").AddTo(core.StoreTombstonedErr{StoreID: toStoreID})
 	}
 
-	newPeer, err := c.cluster.AllocPeer(toStoreID)
+	peerID, err := c.cluster.Alloc()
 	if err != nil {
 		return err
 	}
 
-	op, err := operator.CreateMovePeerOperator("admin-move-peer", c.cluster, region, operator.OpAdmin, fromStoreID, toStoreID, newPeer.GetId())
+	op, err := operator.CreateMovePeerOperator("admin-move-peer", c.cluster, region, operator.OpAdmin, fromStoreID, toStoreID, peerID)
 	if err != nil {
 		return err
 	}
@@ -523,12 +523,12 @@ func (h *Handler) AddAddPeerOperator(regionID uint64, toStoreID uint64) error {
 		return err
 	}
 
-	newPeer, err := c.cluster.AllocPeer(toStoreID)
+	newPeerID, err := c.cluster.Alloc()
 	if err != nil {
 		return err
 	}
 
-	op := operator.CreateAddPeerOperator("admin-add-peer", c.cluster, region, newPeer.GetId(), toStoreID, operator.OpAdmin)
+	op := operator.CreateAddPeerOperator("admin-add-peer", c.cluster, region, newPeerID, toStoreID, operator.OpAdmin)
 	if ok := c.opController.AddOperator(op); !ok {
 		return errors.WithStack(ErrAddOperator)
 	}
@@ -546,12 +546,12 @@ func (h *Handler) AddAddLearnerOperator(regionID uint64, toStoreID uint64) error
 		return ErrOperatorNotFound
 	}
 
-	newPeer, err := c.cluster.AllocPeer(toStoreID)
+	newPeerID, err := c.cluster.Alloc()
 	if err != nil {
 		return err
 	}
 
-	op := operator.CreateAddLearnerOperator("admin-add-learner", c.cluster, region, newPeer.GetId(), toStoreID, operator.OpAdmin)
+	op := operator.CreateAddLearnerOperator("admin-add-learner", c.cluster, region, newPeerID, toStoreID, operator.OpAdmin)
 	if ok := c.opController.AddOperator(op); !ok {
 		return errors.WithStack(ErrAddOperator)
 	}

--- a/server/handler.go
+++ b/server/handler.go
@@ -474,7 +474,7 @@ func (h *Handler) AddTransferPeerOperator(regionID uint64, fromStoreID, toStoreI
 		return errcode.Op("operator.add").AddTo(core.StoreTombstonedErr{StoreID: toStoreID})
 	}
 
-	peerID, err := c.cluster.Alloc()
+	peerID, err := c.cluster.AllocID()
 	if err != nil {
 		return err
 	}
@@ -523,7 +523,7 @@ func (h *Handler) AddAddPeerOperator(regionID uint64, toStoreID uint64) error {
 		return err
 	}
 
-	newPeerID, err := c.cluster.Alloc()
+	newPeerID, err := c.cluster.AllocID()
 	if err != nil {
 		return err
 	}
@@ -546,7 +546,7 @@ func (h *Handler) AddAddLearnerOperator(regionID uint64, toStoreID uint64) error
 		return ErrOperatorNotFound
 	}
 
-	newPeerID, err := c.cluster.Alloc()
+	newPeerID, err := c.cluster.AllocID()
 	if err != nil {
 		return err
 	}

--- a/server/handler.go
+++ b/server/handler.go
@@ -439,7 +439,7 @@ func (h *Handler) AddTransferRegionOperator(regionID uint64, storeIDs map[uint64
 		}
 	}
 
-	op, err := operator.CreateMoveRegionOperator("admin-move-region", c.cluster, region, operator.OpAdmin, storeIDs)
+	op, err := operator.CreateMoveRegionOperator("admin-move-region", c.cluster, c.cluster, region, operator.OpAdmin, storeIDs)
 	if err != nil {
 		return err
 	}
@@ -479,7 +479,7 @@ func (h *Handler) AddTransferPeerOperator(regionID uint64, fromStoreID, toStoreI
 		return err
 	}
 
-	op, err := operator.CreateMovePeerOperator("admin-move-peer", c.cluster, region, operator.OpAdmin, fromStoreID, toStoreID, peerID)
+	op, err := operator.CreateMovePeerOperator("admin-move-peer", c.cluster, c.cluster, region, operator.OpAdmin, fromStoreID, toStoreID, peerID)
 	if err != nil {
 		return err
 	}
@@ -551,7 +551,7 @@ func (h *Handler) AddAddLearnerOperator(regionID uint64, toStoreID uint64) error
 		return err
 	}
 
-	op := operator.CreateAddLearnerOperator("admin-add-learner", c.cluster, region, newPeerID, toStoreID, operator.OpAdmin)
+	op := operator.CreateAddLearnerOperator("admin-add-learner", region, newPeerID, toStoreID, operator.OpAdmin)
 	if ok := c.opController.AddOperator(op); !ok {
 		return errors.WithStack(ErrAddOperator)
 	}
@@ -574,7 +574,7 @@ func (h *Handler) AddRemovePeerOperator(regionID uint64, fromStoreID uint64) err
 		return errors.Errorf("region has no peer in store %v", fromStoreID)
 	}
 
-	op, err := operator.CreateRemovePeerOperator("admin-remove-peer", c.cluster, operator.OpAdmin, region, fromStoreID)
+	op, err := operator.CreateRemovePeerOperator("admin-remove-peer", c.cluster, c.cluster, operator.OpAdmin, region, fromStoreID)
 	if err != nil {
 		return err
 	}
@@ -617,7 +617,7 @@ func (h *Handler) AddMergeRegionOperator(regionID uint64, targetID uint64) error
 		return ErrRegionNotAdjacent
 	}
 
-	ops, err := operator.CreateMergeRegionOperator("admin-merge-region", c.cluster, region, target, operator.OpAdmin)
+	ops, err := operator.CreateMergeRegionOperator("admin-merge-region", c.cluster, c.cluster, region, target, operator.OpAdmin)
 	if err != nil {
 		return err
 	}

--- a/server/heartbeat_stream_test.go
+++ b/server/heartbeat_stream_test.go
@@ -49,7 +49,7 @@ func (s *testHeartbeatStreamSuite) TestActivity(c *C) {
 	s.region = bootstrapReq.Region
 
 	// Add a new store and an addPeer operator.
-	storeID, err := s.svr.idAllocator.Alloc()
+	storeID, err := s.svr.idAllocator.AllocID()
 	c.Assert(err, IsNil)
 	_, err = putStore(c, s.grpcPDClient, s.svr.clusterID, &metapb.Store{Id: storeID, Address: "127.0.0.1:1"})
 	c.Assert(err, IsNil)

--- a/server/id/id.go
+++ b/server/id/id.go
@@ -28,7 +28,7 @@ import (
 
 // Allocator is the allocator to generate unique ID.
 type Allocator interface {
-	Alloc() (uint64, error)
+	AllocID() (uint64, error)
 }
 
 const allocStep = uint64(1000)
@@ -49,8 +49,8 @@ func NewAllocatorImpl(client *clientv3.Client, rootPath string, member string) *
 	return &AllocatorImpl{client: client, rootPath: rootPath, member: member}
 }
 
-// Alloc returns a new id.
-func (alloc *AllocatorImpl) Alloc() (uint64, error) {
+// AllocID returns a new id.
+func (alloc *AllocatorImpl) AllocID() (uint64, error) {
 	alloc.mu.Lock()
 	defer alloc.mu.Unlock()
 

--- a/server/schedule/operator/operator.go
+++ b/server/schedule/operator/operator.go
@@ -663,7 +663,7 @@ func CreateMoveRegionOperator(desc string, cluster Cluster, region *core.RegionI
 		if region.GetStorePeer(id) != nil {
 			continue
 		}
-		peerID, err := cluster.Alloc()
+		peerID, err := cluster.AllocID()
 		if err != nil {
 			return nil, err
 		}
@@ -808,7 +808,7 @@ func matchPeerSteps(cluster Cluster, source *core.RegionInfo, target *core.Regio
 		if _, found := intersection[storeID]; !found {
 			var addSteps []OpStep
 
-			peerID, err := cluster.Alloc()
+			peerID, err := cluster.AllocID()
 			if err != nil {
 				log.Debug("peer alloc failed", zap.Error(err))
 				return nil, kind, err

--- a/server/schedule/region_scatterer.go
+++ b/server/schedule/region_scatterer.go
@@ -157,7 +157,7 @@ func (r *RegionScatterer) selectPeerToReplace(stores map[uint64]*core.StoreInfo,
 	}
 
 	target := candidates[rand.Intn(len(candidates))]
-	id, err := r.cluster.Alloc()
+	id, err := r.cluster.AllocID()
 	if err != nil {
 		return nil
 	}

--- a/server/schedule/region_scatterer.go
+++ b/server/schedule/region_scatterer.go
@@ -157,11 +157,11 @@ func (r *RegionScatterer) selectPeerToReplace(stores map[uint64]*core.StoreInfo,
 	}
 
 	target := candidates[rand.Intn(len(candidates))]
-	newPeer, err := r.cluster.AllocPeer(target.GetID())
+	id, err := r.cluster.Alloc()
 	if err != nil {
 		return nil
 	}
-	return newPeer
+	return &metapb.Peer{Id: id, StoreId: target.GetID()}
 }
 
 func (r *RegionScatterer) collectAvailableStores(region *core.RegionInfo) map[uint64]*core.StoreInfo {

--- a/server/schedule/scheduler.go
+++ b/server/schedule/scheduler.go
@@ -16,9 +16,9 @@ package schedule
 import (
 	"time"
 
-	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/pd/server/core"
+	"github.com/pingcap/pd/server/id"
 	"github.com/pingcap/pd/server/namespace"
 	"github.com/pingcap/pd/server/schedule/operator"
 	"github.com/pingcap/pd/server/schedule/opt"
@@ -80,7 +80,5 @@ type Cluster interface {
 
 	// get config methods
 	GetOpt() namespace.ScheduleOptions
-	// TODO: it should be removed. Schedulers don't need to know anything
-	// about peers.
-	AllocPeer(storeID uint64) (*metapb.Peer, error)
+	id.Allocator
 }

--- a/server/schedulers/adjacent_region.go
+++ b/server/schedulers/adjacent_region.go
@@ -314,7 +314,7 @@ func (l *balanceAdjacentRegionScheduler) dispersePeer(cluster schedule.Cluster, 
 	// record the store id and exclude it in next time
 	l.cacheRegions.assignedStoreIds = append(l.cacheRegions.assignedStoreIds, target.GetID())
 
-	op, err := operator.CreateMovePeerOperator("balance-adjacent-peer", cluster, region, operator.OpAdjacent, leaderStoreID, target.GetID(), peerID)
+	op, err := operator.CreateMovePeerOperator("balance-adjacent-peer", cluster, cluster, region, operator.OpAdjacent, leaderStoreID, target.GetID(), peerID)
 	if err != nil {
 		schedulerCounter.WithLabelValues(l.GetName(), "create_operator_fail").Inc()
 		return nil

--- a/server/schedulers/adjacent_region.go
+++ b/server/schedulers/adjacent_region.go
@@ -306,7 +306,7 @@ func (l *balanceAdjacentRegionScheduler) dispersePeer(cluster schedule.Cluster, 
 	if target == nil {
 		return nil
 	}
-	peerID, err := cluster.Alloc()
+	peerID, err := cluster.AllocID()
 	if err != nil {
 		return nil
 	}

--- a/server/schedulers/adjacent_region.go
+++ b/server/schedulers/adjacent_region.go
@@ -306,19 +306,15 @@ func (l *balanceAdjacentRegionScheduler) dispersePeer(cluster schedule.Cluster, 
 	if target == nil {
 		return nil
 	}
-	newPeer, err := cluster.AllocPeer(target.GetID())
+	peerID, err := cluster.Alloc()
 	if err != nil {
-		return nil
-	}
-	if newPeer == nil {
-		schedulerCounter.WithLabelValues(l.GetName(), "no_peer").Inc()
 		return nil
 	}
 
 	// record the store id and exclude it in next time
-	l.cacheRegions.assignedStoreIds = append(l.cacheRegions.assignedStoreIds, newPeer.GetStoreId())
+	l.cacheRegions.assignedStoreIds = append(l.cacheRegions.assignedStoreIds, target.GetID())
 
-	op, err := operator.CreateMovePeerOperator("balance-adjacent-peer", cluster, region, operator.OpAdjacent, leaderStoreID, newPeer.GetStoreId(), newPeer.GetId())
+	op, err := operator.CreateMovePeerOperator("balance-adjacent-peer", cluster, region, operator.OpAdjacent, leaderStoreID, target.GetID(), peerID)
 	if err != nil {
 		schedulerCounter.WithLabelValues(l.GetName(), "create_operator_fail").Inc()
 		return nil

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -216,7 +216,7 @@ func (s *balanceRegionScheduler) transferPeer(cluster schedule.Cluster, region *
 		schedulerCounter.WithLabelValues(s.GetName(), "no_peer").Inc()
 		return nil
 	}
-	op, err := operator.CreateMovePeerOperator("balance-region", cluster, region, operator.OpBalance, oldPeer.GetStoreId(), storeID, peerID)
+	op, err := operator.CreateMovePeerOperator("balance-region", cluster, cluster, region, operator.OpBalance, oldPeer.GetStoreId(), storeID, peerID)
 	if err != nil {
 		schedulerCounter.WithLabelValues(s.GetName(), "create_operator_fail").Inc()
 		return nil

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -211,12 +211,12 @@ func (s *balanceRegionScheduler) transferPeer(cluster schedule.Cluster, region *
 		return nil
 	}
 
-	newPeer, err := cluster.AllocPeer(storeID)
+	peerID, err := cluster.Alloc()
 	if err != nil {
 		schedulerCounter.WithLabelValues(s.GetName(), "no_peer").Inc()
 		return nil
 	}
-	op, err := operator.CreateMovePeerOperator("balance-region", cluster, region, operator.OpBalance, oldPeer.GetStoreId(), newPeer.GetStoreId(), newPeer.GetId())
+	op, err := operator.CreateMovePeerOperator("balance-region", cluster, region, operator.OpBalance, oldPeer.GetStoreId(), storeID, peerID)
 	if err != nil {
 		schedulerCounter.WithLabelValues(s.GetName(), "create_operator_fail").Inc()
 		return nil

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -211,7 +211,7 @@ func (s *balanceRegionScheduler) transferPeer(cluster schedule.Cluster, region *
 		return nil
 	}
 
-	peerID, err := cluster.Alloc()
+	peerID, err := cluster.AllocID()
 	if err != nil {
 		schedulerCounter.WithLabelValues(s.GetName(), "no_peer").Inc()
 		return nil

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -172,7 +172,7 @@ func (h *balanceHotRegionsScheduler) balanceHotReadRegions(cluster schedule.Clus
 	// balance by peer
 	srcRegion, srcPeer, destPeer := h.balanceByPeer(cluster, h.stats.readStatAsLeader)
 	if srcRegion != nil {
-		op, err := operator.CreateMovePeerOperator("move-hot-read-region", cluster, srcRegion, operator.OpHotRegion, srcPeer.GetStoreId(), destPeer.GetStoreId(), destPeer.GetId())
+		op, err := operator.CreateMovePeerOperator("move-hot-read-region", cluster, cluster, srcRegion, operator.OpHotRegion, srcPeer.GetStoreId(), destPeer.GetStoreId(), destPeer.GetId())
 		if err != nil {
 			schedulerCounter.WithLabelValues(h.GetName(), "create_operator_fail").Inc()
 			return nil
@@ -195,7 +195,7 @@ func (h *balanceHotRegionsScheduler) balanceHotWriteRegions(cluster schedule.Clu
 			// balance by peer
 			srcRegion, srcPeer, destPeer := h.balanceByPeer(cluster, h.stats.writeStatAsPeer)
 			if srcRegion != nil {
-				op, err := operator.CreateMovePeerOperator("move-hot-write-region", cluster, srcRegion, operator.OpHotRegion, srcPeer.GetStoreId(), destPeer.GetStoreId(), destPeer.GetId())
+				op, err := operator.CreateMovePeerOperator("move-hot-write-region", cluster, cluster, srcRegion, operator.OpHotRegion, srcPeer.GetStoreId(), destPeer.GetStoreId(), destPeer.GetId())
 				if err != nil {
 					schedulerCounter.WithLabelValues(h.GetName(), "create_operator_fail").Inc()
 					return nil

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -325,13 +325,13 @@ func (h *balanceHotRegionsScheduler) balanceByPeer(cluster schedule.Cluster, sto
 
 			// When the target store is decided, we allocate a peer ID to hold the source region,
 			// because it doesn't exist in the system right now.
-			destPeer, err := cluster.AllocPeer(destStoreID)
+			peerID, err := cluster.Alloc()
 			if err != nil {
 				log.Error("failed to allocate peer", zap.Error(err))
 				return nil, nil, nil
 			}
 
-			return srcRegion, srcPeer, destPeer
+			return srcRegion, srcPeer, &metapb.Peer{Id: peerID, StoreId: destStoreID}
 		}
 	}
 

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -325,7 +325,7 @@ func (h *balanceHotRegionsScheduler) balanceByPeer(cluster schedule.Cluster, sto
 
 			// When the target store is decided, we allocate a peer ID to hold the source region,
 			// because it doesn't exist in the system right now.
-			peerID, err := cluster.Alloc()
+			peerID, err := cluster.AllocID()
 			if err != nil {
 				log.Error("failed to allocate peer", zap.Error(err))
 				return nil, nil, nil

--- a/server/schedulers/random_merge.go
+++ b/server/schedulers/random_merge.go
@@ -83,7 +83,7 @@ func (s *randomMergeScheduler) Schedule(cluster schedule.Cluster) []*operator.Op
 		return nil
 	}
 
-	ops, err := operator.CreateMergeRegionOperator("random-merge", cluster, region, target, operator.OpAdmin)
+	ops, err := operator.CreateMergeRegionOperator("random-merge", cluster, cluster, region, target, operator.OpAdmin)
 	if err != nil {
 		return nil
 	}

--- a/server/schedulers/shuffle_hot_region.go
+++ b/server/schedulers/shuffle_hot_region.go
@@ -139,7 +139,7 @@ func (s *shuffleHotRegionScheduler) randomSchedule(cluster schedule.Cluster, sto
 			log.Error("failed to allocate peer", zap.Error(err))
 			return nil
 		}
-		op, err := operator.CreateMoveLeaderOperator("random-move-hot-leader", cluster, srcRegion, operator.OpRegion|operator.OpLeader, srcStoreID, destStoreID, peerID)
+		op, err := operator.CreateMoveLeaderOperator("random-move-hot-leader", cluster, cluster, srcRegion, operator.OpRegion|operator.OpLeader, srcStoreID, destStoreID, peerID)
 		if err != nil {
 			return nil
 		}

--- a/server/schedulers/shuffle_hot_region.go
+++ b/server/schedulers/shuffle_hot_region.go
@@ -134,7 +134,7 @@ func (s *shuffleHotRegionScheduler) randomSchedule(cluster schedule.Cluster, sto
 		if srcPeer == nil {
 			return nil
 		}
-		peerID, err := cluster.Alloc()
+		peerID, err := cluster.AllocID()
 		if err != nil {
 			log.Error("failed to allocate peer", zap.Error(err))
 			return nil

--- a/server/schedulers/shuffle_hot_region.go
+++ b/server/schedulers/shuffle_hot_region.go
@@ -134,12 +134,12 @@ func (s *shuffleHotRegionScheduler) randomSchedule(cluster schedule.Cluster, sto
 		if srcPeer == nil {
 			return nil
 		}
-		destPeer, err := cluster.AllocPeer(destStoreID)
+		peerID, err := cluster.Alloc()
 		if err != nil {
 			log.Error("failed to allocate peer", zap.Error(err))
 			return nil
 		}
-		op, err := operator.CreateMoveLeaderOperator("random-move-hot-leader", cluster, srcRegion, operator.OpRegion|operator.OpLeader, srcStoreID, destStoreID, destPeer.GetId())
+		op, err := operator.CreateMoveLeaderOperator("random-move-hot-leader", cluster, srcRegion, operator.OpRegion|operator.OpLeader, srcStoreID, destStoreID, peerID)
 		if err != nil {
 			return nil
 		}

--- a/server/schedulers/shuffle_region.go
+++ b/server/schedulers/shuffle_region.go
@@ -114,7 +114,7 @@ func (s *shuffleRegionScheduler) scheduleAddPeer(cluster schedule.Cluster, filte
 		return nil
 	}
 
-	peerID, err := cluster.Alloc()
+	peerID, err := cluster.AllocID()
 	if err != nil {
 		log.Error("failed to allocate peer", zap.Error(err))
 		return nil

--- a/server/schedulers/shuffle_region.go
+++ b/server/schedulers/shuffle_region.go
@@ -75,7 +75,7 @@ func (s *shuffleRegionScheduler) Schedule(cluster schedule.Cluster) []*operator.
 		return nil
 	}
 
-	op, err := operator.CreateMovePeerOperator("shuffle-region", cluster, region, operator.OpAdmin, oldPeer.GetStoreId(), newPeer.GetStoreId(), newPeer.GetId())
+	op, err := operator.CreateMovePeerOperator("shuffle-region", cluster, cluster, region, operator.OpAdmin, oldPeer.GetStoreId(), newPeer.GetStoreId(), newPeer.GetId())
 	if err != nil {
 		schedulerCounter.WithLabelValues(s.GetName(), "create_operator_fail").Inc()
 		return nil

--- a/server/schedulers/shuffle_region.go
+++ b/server/schedulers/shuffle_region.go
@@ -114,11 +114,11 @@ func (s *shuffleRegionScheduler) scheduleAddPeer(cluster schedule.Cluster, filte
 		return nil
 	}
 
-	newPeer, err := cluster.AllocPeer(target.GetID())
+	peerID, err := cluster.Alloc()
 	if err != nil {
 		log.Error("failed to allocate peer", zap.Error(err))
 		return nil
 	}
 
-	return newPeer
+	return &metapb.Peer{Id: peerID, StoreId: target.GetID()}
 }

--- a/table/namespace_classifier.go
+++ b/table/namespace_classifier.go
@@ -218,7 +218,7 @@ func (c *tableNamespaceClassifier) CreateNamespace(name string) error {
 		return errors.New("Duplicate namespace Name")
 	}
 
-	id, err := c.idAlloc.Alloc()
+	id, err := c.idAlloc.AllocID()
 	if err != nil {
 		return err
 	}

--- a/tests/server/id/id_test.go
+++ b/tests/server/id/id_test.go
@@ -53,7 +53,7 @@ func (s *testAllocIDSuite) TestID(c *C) {
 	leaderServer := cluster.GetServer(cluster.GetLeader())
 	var last uint64
 	for i := uint64(0); i < allocStep; i++ {
-		id, err := leaderServer.GetAllocator().Alloc()
+		id, err := leaderServer.GetAllocator().AllocID()
 		c.Assert(err, IsNil)
 		c.Assert(id, Greater, last)
 		last = id
@@ -70,7 +70,7 @@ func (s *testAllocIDSuite) TestID(c *C) {
 			defer wg.Done()
 
 			for i := 0; i < 200; i++ {
-				id, err := leaderServer.GetAllocator().Alloc()
+				id, err := leaderServer.GetAllocator().AllocID()
 				c.Assert(err, IsNil)
 				m.Lock()
 				_, ok := ids[id]

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -43,7 +43,7 @@ type idAllocator struct {
 	id uint64
 }
 
-func (alloc *idAllocator) Alloc() uint64 {
+func (alloc *idAllocator) AllocID() uint64 {
 	alloc.id++
 	return alloc.id
 }
@@ -66,14 +66,14 @@ func (s *serverTestSuite) TestRegionSyncer(c *C) {
 	regions := make([]*core.RegionInfo, 0, regionLen)
 	for i := 0; i < regionLen; i++ {
 		r := &metapb.Region{
-			Id: id.Alloc(),
+			Id: id.AllocID(),
 			RegionEpoch: &metapb.RegionEpoch{
 				ConfVer: 1,
 				Version: 1,
 			},
 			StartKey: []byte{byte(i)},
 			EndKey:   []byte{byte(i + 1)},
-			Peers:    []*metapb.Peer{{Id: id.Alloc(), StoreId: uint64(0)}},
+			Peers:    []*metapb.Peer{{Id: id.AllocID(), StoreId: uint64(0)}},
 		}
 		regions = append(regions, core.NewRegionInfo(r, r.Peers[0]))
 	}
@@ -111,14 +111,14 @@ func (s *serverTestSuite) TestFullSyncWithAddMember(c *C) {
 	regions := make([]*core.RegionInfo, 0, regionLen)
 	for i := 0; i < regionLen; i++ {
 		r := &metapb.Region{
-			Id: id.Alloc(),
+			Id: id.AllocID(),
 			RegionEpoch: &metapb.RegionEpoch{
 				ConfVer: 1,
 				Version: 1,
 			},
 			StartKey: []byte{byte(i)},
 			EndKey:   []byte{byte(i + 1)},
-			Peers:    []*metapb.Peer{{Id: id.Alloc(), StoreId: uint64(0)}},
+			Peers:    []*metapb.Peer{{Id: id.AllocID(), StoreId: uint64(0)}},
 		}
 		regions = append(regions, core.NewRegionInfo(r, r.Peers[0]))
 	}


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Cleanup code, remove unnecessary interfaces.
Fix #1664

### What is changed and how it works?
- remove `cluster.AllocPeer()`, use `id.Allocator` interface directly
- rename `allocator.Alloc()` to `allocator.AllocID`
- remove `operator.Cluster`, use smaller interfaces instead.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test
