### PR TITLE
operator: use high priority for admin operators

### DIFF
--- a/server/schedule/operator/operator.go
+++ b/server/schedule/operator/operator.go
@@ -384,6 +384,10 @@ type Operator struct {
 
 // NewOperator creates a new operator.
 func NewOperator(desc string, regionID uint64, regionEpoch *metapb.RegionEpoch, kind OpKind, steps ...OpStep) *Operator {
+	level := core.NormalPriority
+	if kind&OpAdmin != 0 {
+		level = core.HighPriority
+	}
 	return &Operator{
 		desc:        desc,
 		regionID:    regionID,
@@ -392,7 +396,7 @@ func NewOperator(desc string, regionID uint64, regionEpoch *metapb.RegionEpoch, 
 		steps:       steps,
 		createTime:  time.Now(),
 		stepTime:    time.Now().UnixNano(),
-		level:       core.NormalPriority,
+		level:       level,
 	}
 }
 

--- a/server/schedule/operator/operator_test.go
+++ b/server/schedule/operator/operator_test.go
@@ -82,6 +82,7 @@ func (s *testOperatorSuite) TestOperator(c *C) {
 		RemovePeer{FromStore: 3},
 	}
 	op := s.newTestOperator(1, OpLeader|OpRegion, steps...)
+	c.Assert(op.GetPriorityLevel(), Equals, core.HighPriority)
 	s.checkSteps(c, op, steps)
 	c.Assert(op.Check(region), IsNil)
 	c.Assert(op.IsFinish(), IsTrue)


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Currently, the priority of the operator whose kind is `opAdmin` is normal. But the high priority is much suitable for this kind of operators.

### What is changed and how it works?
This PR changes the priority of this kind of operators to high.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch (Maybe)
