### PR TITLE
add config-check flag for pd-server

### DIFF
--- a/cmd/pd-server/main.go
+++ b/cmd/pd-server/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -55,6 +56,12 @@ func main() {
 	default:
 		log.Fatal("parse cmd flags error", zap.Error(err))
 	}
+
+	if cfg.ConfigCheck {
+		fmt.Println("config check successful")
+		exit(0)
+	}
+
 	// New zap logger
 	err = cfg.SetupLogger()
 	if err == nil {

--- a/cmd/pd-server/main.go
+++ b/cmd/pd-server/main.go
@@ -16,7 +16,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -58,7 +57,7 @@ func main() {
 	}
 
 	if cfg.ConfigCheck {
-		fmt.Println("config check successful")
+		server.PrintConfigCheckMsg(cfg)
 		exit(0)
 	}
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -44,6 +44,8 @@ type Config struct {
 
 	Version bool `json:"-"`
 
+	ConfigCheck bool `json:"-"`
+
 	ClientUrls          string `toml:"client-urls" json:"client-urls"`
 	PeerUrls            string `toml:"peer-urls" json:"peer-urls"`
 	AdvertiseClientUrls string `toml:"advertise-client-urls" json:"advertise-client-urls"`
@@ -145,6 +147,7 @@ func NewConfig() *Config {
 	fs.BoolVar(&cfg.Version, "V", false, "print version information and exit")
 	fs.BoolVar(&cfg.Version, "version", false, "print version information and exit")
 	fs.StringVar(&cfg.configFile, "config", "", "Config file")
+	fs.BoolVar(&cfg.ConfigCheck, "config-check", false, "check config file validity and exit")
 
 	fs.StringVar(&cfg.Name, "name", "", "human-readable name for this pd member")
 

--- a/server/util.go
+++ b/server/util.go
@@ -68,6 +68,18 @@ func PrintPDInfo() {
 	fmt.Println("UTC Build Time: ", PDBuildTS)
 }
 
+// PrintConfigCheckMsg prints the message about configuration checks.
+func PrintConfigCheckMsg(cfg *config.Config) {
+	if len(cfg.WarningMsgs) == 0 {
+		fmt.Println("config check successful")
+		return
+	}
+
+	for _, msg := range cfg.WarningMsgs {
+		fmt.Println(msg)
+	}
+}
+
 // CheckPDVersion checks if PD needs to be upgraded.
 func CheckPDVersion(opt *config.ScheduleOption) {
 	pdVersion := *MinSupportedVersion(Base)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
add `config-check` for pd-server, we can use it to check the config file before to start pd . 
tidb-ansible plans to use this to check config before upgrading cluster. 
related issue:  https://github.com/pingcap/tidb-ansible/issues/903

### What is changed and how it works? 

If we set `--config-check=true`, pd will exit after parsing config. 

### Check List <!--REMOVE the items that are not applicable-->


 - Manual test (add detailed scripts or steps below)

```
./bin/pd-server --config=./conf/config.toml  --config-check
```
