### PR TITLE
test: fix tests

### DIFF
--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -76,6 +76,9 @@ func (s *Server) Tso(stream pdpb.PD_TsoServer) error {
 		}
 		start := time.Now()
 		// TSO uses leader lease to determine validity. No need to check leader here.
+		if s.IsClosed() {
+			return status.Errorf(codes.Unknown, "server not started")
+		}
 		if request.GetHeader().GetClusterId() != s.clusterID {
 			return status.Errorf(codes.FailedPrecondition, "mismatch cluster id, need %d but got %d", s.clusterID, request.GetHeader().GetClusterId())
 		}

--- a/tests/server/api_test.go
+++ b/tests/server/api_test.go
@@ -75,7 +75,7 @@ func (s *serverTestSuite) TestReconnect(c *C) {
 			testutil.WaitUntil(c, func(c *C) bool {
 				res, err := http.Get(s.GetConfig().AdvertiseClientUrls + "/pd/api/v1/version")
 				c.Assert(err, IsNil)
-				return res.StatusCode == http.StatusInternalServerError
+				return res.StatusCode == http.StatusServiceUnavailable
 			})
 		}
 	}

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -81,8 +81,9 @@ func (s *serverTestSuite) TestRegionSyncer(c *C) {
 		err = rc.HandleRegionHeartbeat(region)
 		c.Assert(err, IsNil)
 	}
-	// ensure flush to region storage
-	time.Sleep(3 * time.Second)
+	// ensure flush to region storage, we use a duration larger than the
+	// region storage flush rate limit (3s).
+	time.Sleep(4 * time.Second)
 	err = leaderServer.Stop()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
`TestReconnect` and `TestRegionSync` cannot pass.

When the server is not started, serving tso request returns 'cluster id not match', which is incorrect:
```
[error="rpc error: code = FailedPrecondition desc = mismatch cluster id, need 0 but got 6727122697637626582"]
```

### What is changed and how it works?
- enlarge sleep time, Fix #1693
- fix wrong status code in `TestReconnect`
- check if server is started when handling tso 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test
