### PR TITLE
server: check if server is started when handling tso

### DIFF
--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -76,6 +76,9 @@ func (s *Server) Tso(stream pdpb.PD_TsoServer) error {
 		}
 		start := time.Now()
 		// TSO uses leader lease to determine validity. No need to check leader here.
+		if s.IsClosed() {
+			return status.Errorf(codes.Unknown, "server not started")
+		}
 		if request.GetHeader().GetClusterId() != s.clusterID {
 			return status.Errorf(codes.FailedPrecondition, "mismatch cluster id, need %d but got %d", s.clusterID, request.GetHeader().GetClusterId())
 		}


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
When the server is not started, serving tso request returns 'cluster id not match', which is incorrect:
```
[error="rpc error: code = FailedPrecondition desc = mismatch cluster id, need 0 but got 6727122697637626582"]
```

caused by https://github.com/pingcap/pd/pull/1676

### What is changed and how it works?
check if server is already started.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integration test
