### PR TITLE
tools: fix set namespace in pd-ctl

### DIFF
--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -15,6 +15,7 @@ package config_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/coreos/go-semver/semver"
@@ -96,6 +97,10 @@ func (s *configTestSuite) TestConfig(c *C) {
 	c.Assert(json.Unmarshal(output, &clusterVersion), IsNil)
 	c.Assert(clusterVersion, DeepEquals, svr.GetClusterVersion())
 
+	args2 = []string{"-u", pdAddr, "config", "set", "namespace", "ts1", "region-schedule-limit", "128"}
+	_, output, err = pdctl.ExecuteCommandC(cmd, args2...)
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "Failed"), IsTrue)
 	// config show namespace <name> && config set namespace <type> <key> <value>
 	args = []string{"-u", pdAddr, "table_ns", "create", "ts1"}
 	_, _, err = pdctl.ExecuteCommandC(cmd, args...)

--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -301,7 +301,7 @@ func setNamespaceConfigCommandFunc(cmd *cobra.Command, args []string) {
 	prefix := path.Join(namespacePrefix, name)
 	err := postConfigDataWithPath(cmd, opt, val, prefix)
 	if err != nil {
-		cmd.Printf("Failed to set namespace:%s config: %s\n", name, err)
+		cmd.Printf("Failed to set namespace: %s error: %s\n", name, err)
 		return
 	}
 	cmd.Println("Success!")


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
When the status of the response is not OK, it should return an error. Closes #1681. 

### What is changed and how it works?
After this PR:
```
$ ./pd-ctl -u http://127.0.0.1:2379 -i
>> config set namespace ts1 leader-schedule-limit 10
Failed to set namespace: ts1 error: [404] "invalid namespace Name ts1, not found"
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
