### PR TITLE
client: let GetTSAsync caller control the creation of tsoRequest

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -567,14 +567,6 @@ func (c *client) GetURLs() []string {
 	return c.urls
 }
 
-// TsoReqAlloc defines how client create and reuse tsoRequest.
-type TsoReqAlloc interface {
-	// Get gets a request from alloc.
-	Get() *TsoRequest
-	// Put put a request back to alloc.
-	Put(req *TsoRequest)
-}
-
 // NewReqAlloc creates a new TsoRequest.
 // only TsoReqAlloc implementor need use this.
 func NewReqAlloc() *TsoRequest {
@@ -624,7 +616,7 @@ func (req *TsoRequest) Wait() (physical int64, logical int64, err error) {
 	select {
 	case err = <-req.done:
 		err = errors.WithStack(err)
-		req.pool.Put(req)
+		defer req.pool.Put(req)
 		if err != nil {
 			cmdFailDurationTSO.Observe(time.Since(req.start).Seconds())
 			return 0, 0, err


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

ref TiDB https://github.com/pingcap/tidb/pull/11846

current GetTSAsync will use sync.Pool to reuse tsoRequest.

and we saw it have some cost in sysbench point-get test:

![image](https://user-images.githubusercontent.com/528332/63579622-ac369c00-c5c5-11e9-8483-5326bf39b0d8.png)

In TiDB, it's better reuse request in session level to avoid contend.

### What is changed and how it works?

add new method with new parameter TsoReqAlloc, so caller can define how to reuse.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Add new api

Side effects

 - n/a

Related changes

 - n/a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/pd/1702)
<!-- Reviewable:end -->
