### PR TITLE
tools: fix parse url without http prefix

### DIFF
--- a/tests/pdctl/cluster/cluster_test.go
+++ b/tests/pdctl/cluster/cluster_test.go
@@ -15,6 +15,7 @@ package cluster_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	. "github.com/pingcap/check"
@@ -45,6 +46,8 @@ func (s *clusterTestSuite) TestClusterAndPing(c *C) {
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
 	pdAddr := cluster.GetConfig().GetClientURLs()
+	i := strings.Index(pdAddr, "//")
+	pdAddr = pdAddr[i+2:]
 	cmd := pdctl.InitCommand()
 	defer cluster.Destroy()
 

--- a/tools/pd-ctl/pdctl/command/global.go
+++ b/tools/pd-ctl/pdctl/command/global.go
@@ -164,7 +164,13 @@ func getEndpoints(cmd *cobra.Command) []string {
 		cmd.Println("get pd address failed, should set flag with '-u'")
 		os.Exit(1)
 	}
-	return strings.Split(addrs, ",")
+	eps := strings.Split(addrs, ",")
+	for i, ep := range eps {
+		if j := strings.Index(ep, "//"); j == -1 {
+			eps[i] = "//" + ep
+		}
+	}
+	return eps
 }
 
 func postJSON(cmd *cobra.Command, prefix string, input map[string]interface{}) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
After #1629, we cannot use the address like `127.0.0.1:2379` in `pd-ctl`.

### What is changed and how it works?
This PR fixes this problem by checking if it has `//` in the address. It should be merged after #1701 is merged.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test