### PR TITLE
tests: support deadlock detection in make test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tags
 /.retools/
 vendor
 default*
+*.bak

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,14 @@ OVERALLS := overalls
 FAILPOINT_ENABLE  := $$(find $$PWD/ -type d | grep -vE "(\.git|\.retools)" | xargs ./scripts/retool do failpoint-ctl enable)
 FAILPOINT_DISABLE := $$(find $$PWD/ -type d | grep -vE "(\.git|\.retools)" | xargs ./scripts/retool do failpoint-ctl disable)
 
+DEADLOCK_ENABLE := $$(find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 sed -i.bak 's/sync.RWMutex/deadlock.RWMutex/' && \
+						find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 sed -i.bak 's/sync.Mutex/deadlock.Mutex/' && \
+						find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 ./scripts/retool do goimports -w)
+DEADLOCK_DISABLE := $$(find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 sed -i.bak 's/deadlock.RWMutex/sync.RWMutex/' && \
+						find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 sed -i.bak 's/deadlock.Mutex/sync.Mutex/' && \
+						find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 ./scripts/retool do goimports -w && \
+						find . -name "*.bak" | grep -vE "(vendor|\.retools)" | xargs rm)
+
 LDFLAGS += -X "$(PD_PKG)/server.PDReleaseVersion=$(shell git describe --tags --dirty)"
 LDFLAGS += -X "$(PD_PKG)/server.PDBuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
 LDFLAGS += -X "$(PD_PKG)/server.PDGitHash=$(shell git rev-parse HEAD)"
@@ -56,11 +64,11 @@ pd-recover:
 
 test: retool-setup
 	# testing...
-	make deadlock-enable
+	@$(DEADLOCK_ENABLE)
 	@$(FAILPOINT_ENABLE)
-	CGO_ENABLED=1 GO111MODULE=on go test -race -cover $(TEST_PKGS) || { $(FAILPOINT_DISABLE); make deadlock-disable; exit 1; }
+	CGO_ENABLED=1 GO111MODULE=on go test -race -cover $(TEST_PKGS) || { $(FAILPOINT_DISABLE); $(DEADLOCK_DISABLE); exit 1; }
 	@$(FAILPOINT_DISABLE)
-	make deadlock-disable
+	@$(DEADLOCK_DISABLE)
 
 basic-test:
 	@$(FAILPOINT_ENABLE)
@@ -133,15 +141,10 @@ deadlock-setup:
 	go get github.com/sasha-s/go-deadlock
 
 deadlock-enable: deadlock-setup
-	find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 sed -i.bak 's/sync.RWMutex/deadlock.RWMutex/'
-	find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 sed -i.bak 's/sync.Mutex/deadlock.Mutex/'
-	find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 ./scripts/retool do goimports -w
+	@$(DEADLOCK_ENABLE)
 
 deadlock-disable:
-	find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 sed -i.bak 's/deadlock.RWMutex/sync.RWMutex/'
-	find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 sed -i.bak 's/deadlock.Mutex/sync.Mutex/'
-	find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 ./scripts/retool do goimports -w
-	find . -name "*.bak" | grep -vE "(vendor|\.retools)" | xargs rm
+	@$(DEADLOCK_DISABLE)
 
 failpoint-enable:
 	# Converting failpoints...

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -13,9 +13,7 @@
 
 package cache
 
-import (
-	"sync"
-)
+import "sync"
 
 // Cache is an interface for cache system
 type Cache interface {

--- a/scripts/retool-install.sh
+++ b/scripts/retool-install.sh
@@ -23,3 +23,5 @@ which retool >/dev/null || go get github.com/twitchtv/retool
 ./scripts/retool add github.com/securego/gosec/cmd/gosec 1.0.0
 # go fail
 ./scripts/retool add github.com/pingcap/failpoint/failpoint-ctl master
+# deadlock detection
+./scripts/retool add golang.org/x/tools/cmd/goimports 04b5d21e00f1f47bd824a6ade581e7189bacde87

--- a/tools.json
+++ b/tools.json
@@ -19,6 +19,10 @@
     {
       "Repository": "github.com/golangci/golangci-lint/cmd/golangci-lint",
       "Commit": "4ba2155996359eabd8800d1fbf3e3a9777c80490"
+    },
+    {
+      "Repository": "golang.org/x/tools/cmd/goimports",
+      "Commit": "04b5d21e00f1f47bd824a6ade581e7189bacde87"
     }
   ],
   "RetoolVersion": "1.3.7"


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
We have a lot of lock-related problems, such as #1340, #1370, #1678.

### What is changed and how it works?
This PR uses `go-deadlock` to replace the `sync` package when running our tests in order to find some potential deadlock problems.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test