### PR TITLE
server: fix the dead lock in scatter region

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -293,6 +293,20 @@ func (c *RaftCluster) GetOperatorController() *schedule.OperatorController {
 	return c.coordinator.opController
 }
 
+// GetHeartbeatStreams returns the heartbeat streams.
+func (c *RaftCluster) GetHeartbeatStreams() *heartbeatStreams {
+	c.RLock()
+	defer c.RUnlock()
+	return c.coordinator.hbStreams
+}
+
+// GetCoordinator returns the coordinator.
+func (c *RaftCluster) GetCoordinator() *coordinator {
+	c.RLock()
+	defer c.RUnlock()
+	return c.coordinator
+}
+
 // handleStoreHeartbeat updates the store status.
 func (c *RaftCluster) handleStoreHeartbeat(stats *pdpb.StoreStats) error {
 	c.Lock()

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -361,9 +361,7 @@ func (s *Server) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error {
 		regionHeartbeatCounter.WithLabelValues(storeAddress, storeLabel, "report", "recv").Inc()
 		regionHeartbeatLatency.WithLabelValues(storeAddress, storeLabel).Observe(float64(time.Now().Unix()) - float64(request.GetInterval().GetEndTimestamp()))
 
-		cluster.RLock()
-		hbStreams := cluster.coordinator.hbStreams
-		cluster.RUnlock()
+		hbStreams := cluster.GetHeartbeatStreams()
 
 		if time.Since(lastBind) > s.cfg.HeartbeatStreamBindInterval.Duration {
 			regionHeartbeatCounter.WithLabelValues(storeAddress, storeLabel, "report", "bind").Inc()
@@ -633,9 +631,7 @@ func (s *Server) ScatterRegion(ctx context.Context, request *pdpb.ScatterRegionR
 		return nil, errors.Errorf("region %d is a hot region", region.GetID())
 	}
 
-	cluster.RLock()
-	defer cluster.RUnlock()
-	co := cluster.coordinator
+	co := cluster.GetCoordinator()
 	op, err := co.regionScatterer.Scatter(region)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
When using scatter region, there is a probability that the PD will hang due to the dead lock problem.

### What is changed and how it works?
This PR fixes this problem by removing defer and also clean up locks in grpc_service.go
Fix https://github.com/pingcap/pd/issues/1707

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test