### PR TITLE
scheduler: do not remove the operator when the step does not finish

### DIFF
--- a/server/schedule/operator/operator.go
+++ b/server/schedule/operator/operator.go
@@ -127,7 +127,7 @@ func (s u64Set) String() string {
 // OpStep describes the basic scheduling steps that can not be subdivided.
 type OpStep interface {
 	fmt.Stringer
-	ExpectConfVerChange() bool
+	ConfVerChanged(region *core.RegionInfo) bool
 	IsFinish(region *core.RegionInfo) bool
 	Influence(opInfluence OpInfluence, region *core.RegionInfo)
 }
@@ -137,10 +137,9 @@ type TransferLeader struct {
 	FromStore, ToStore uint64
 }
 
-// ExpectConfVerChange returns if the confver of a region should be increased
-// after this step
-func (tl TransferLeader) ExpectConfVerChange() bool {
-	return false
+// ConfVerChanged returns true if the conf version has been changed by this step
+func (tl TransferLeader) ConfVerChanged(region *core.RegionInfo) bool {
+	return false // transfer leader never change the conf version
 }
 
 func (tl TransferLeader) String() string {
@@ -168,10 +167,12 @@ type AddPeer struct {
 	ToStore, PeerID uint64
 }
 
-// ExpectConfVerChange returns if the confver of a region should be increased
-// after this step
-func (ap AddPeer) ExpectConfVerChange() bool {
-	return true
+// ConfVerChanged returns true if the conf version has been changed by this step
+func (ap AddPeer) ConfVerChanged(region *core.RegionInfo) bool {
+	if p := region.GetStoreVoter(ap.ToStore); p != nil {
+		return p.GetId() == ap.PeerID
+	}
+	return false
 }
 func (ap AddPeer) String() string {
 	return fmt.Sprintf("add peer %v on store %v", ap.PeerID, ap.ToStore)
@@ -208,10 +209,12 @@ type AddLearner struct {
 	ToStore, PeerID uint64
 }
 
-// ExpectConfVerChange returns if the confver of a region should be increased
-// after this step
-func (al AddLearner) ExpectConfVerChange() bool {
-	return true
+// ConfVerChanged returns true if the conf version has been changed by this step
+func (al AddLearner) ConfVerChanged(region *core.RegionInfo) bool {
+	if p := region.GetStoreLearner(al.ToStore); p != nil {
+		return p.GetId() == al.PeerID
+	}
+	return false
 }
 
 func (al AddLearner) String() string {
@@ -249,10 +252,12 @@ type PromoteLearner struct {
 	ToStore, PeerID uint64
 }
 
-// ExpectConfVerChange returns if the confver of a region should be increased
-// after this step
-func (pl PromoteLearner) ExpectConfVerChange() bool {
-	return true
+// ConfVerChanged returns true if the conf version has been changed by this step
+func (pl PromoteLearner) ConfVerChanged(region *core.RegionInfo) bool {
+	if p := region.GetStoreVoter(pl.ToStore); p != nil {
+		return p.GetId() == pl.PeerID
+	}
+	return false
 }
 
 func (pl PromoteLearner) String() string {
@@ -278,10 +283,9 @@ type RemovePeer struct {
 	FromStore uint64
 }
 
-// ExpectConfVerChange returns if the confver of a region should be increased
-// after this step
-func (rp RemovePeer) ExpectConfVerChange() bool {
-	return true
+// ConfVerChanged returns true if the conf version has been changed by this step
+func (rp RemovePeer) ConfVerChanged(region *core.RegionInfo) bool {
+	return region.GetStorePeer(rp.FromStore) == nil
 }
 
 func (rp RemovePeer) String() string {
@@ -314,9 +318,8 @@ type MergeRegion struct {
 	IsPassive bool
 }
 
-// ExpectConfVerChange returns if the confver of a region should be increased
-// after this step
-func (mr MergeRegion) ExpectConfVerChange() bool {
+// ConfVerChanged returns true if the conf version has been changed by this step
+func (mr MergeRegion) ConfVerChanged(region *core.RegionInfo) bool {
 	return false
 }
 
@@ -351,9 +354,8 @@ type SplitRegion struct {
 	Policy           pdpb.CheckPolicy
 }
 
-// ExpectConfVerChange returns if the confver of a region should be increased
-// after this step
-func (sr SplitRegion) ExpectConfVerChange() bool {
+// ConfVerChanged returns true if the conf version has been changed by this step
+func (sr SplitRegion) ConfVerChanged(region *core.RegionInfo) bool {
 	return false
 }
 
@@ -382,10 +384,12 @@ type AddLightPeer struct {
 	ToStore, PeerID uint64
 }
 
-// ExpectConfVerChange returns if the confver of a region should be increased
-// after this step
-func (ap AddLightPeer) ExpectConfVerChange() bool {
-	return true
+// ConfVerChanged returns true if the conf version has been changed by this step
+func (ap AddLightPeer) ConfVerChanged(region *core.RegionInfo) bool {
+	if p := region.GetStoreVoter(ap.ToStore); p != nil {
+		return p.GetId() == ap.PeerID
+	}
+	return false
 }
 
 func (ap AddLightPeer) String() string {
@@ -417,10 +421,12 @@ type AddLightLearner struct {
 	ToStore, PeerID uint64
 }
 
-// ExpectConfVerChange returns if the confver of a region should be increased
-// after this step
-func (al AddLightLearner) ExpectConfVerChange() bool {
-	return true
+// ConfVerChanged returns true if the conf version has been changed by this step
+func (al AddLightLearner) ConfVerChanged(region *core.RegionInfo) bool {
+	if p := region.GetStoreLearner(al.ToStore); p != nil {
+		return p.GetId() == al.PeerID
+	}
+	return false
 }
 
 func (al AddLightLearner) String() string {
@@ -582,11 +588,15 @@ func (o *Operator) Check(region *core.RegionInfo) OpStep {
 }
 
 // ConfVerChanged returns the number of confver has consumed by steps
-func (o *Operator) ConfVerChanged() int {
+func (o *Operator) ConfVerChanged(region *core.RegionInfo) int {
 	total := 0
 	current := atomic.LoadInt32(&o.currentStep)
-	for _, step := range o.steps[0:current] {
-		if step.ExpectConfVerChange() {
+	if current == int32(len(o.steps)) {
+		current--
+	}
+	// including current step, it may has taken effects in this heartbeat
+	for _, step := range o.steps[0 : current+1] {
+		if step.ConfVerChanged(region) {
 			total++
 		}
 	}

--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -102,7 +102,7 @@ func (oc *OperatorController) Dispatch(region *core.RegionInfo, source string) {
 			latest := region.GetRegionEpoch()
 			changes := latest.GetConfVer() - origin.GetConfVer()
 			if source == DispatchFromHeartBeat &&
-				changes > uint64(op.ConfVerChanged()) {
+				changes > uint64(op.ConfVerChanged(region)) {
 				log.Info("stale operator", zap.Uint64("region-id", region.GetID()),
 					zap.Reflect("operator", op), zap.Uint64("diff", changes))
 				operatorCounter.WithLabelValues(op.Desc(), "stale").Inc()


### PR DESCRIPTION
Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

There is a bug introduced by #1652, in some case, like adding peers or adding learners, the step is left unfinished if the peer is in pending state, although the conf version has changed, in these cases, the  operator will be removed because the controller thought someone has  changed the conf version(in fact, it self did). We fix that by checking if the conf version has actually changed by current step, if it is, the operator is not regarded as stale.

### What is changed and how it works?

Only check conf version changes when a new step to be executed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
