### PR TITLE
checker: fix the issue that a region does not merge to the sibling with smaller size 

### DIFF
--- a/server/checker/merge_checker.go
+++ b/server/checker/merge_checker.go
@@ -102,12 +102,9 @@ func (m *MergeChecker) Check(region *core.RegionInfo) []*operator.Operator {
 
 	prev, next := m.cluster.GetAdjacentRegions(region)
 
-	var target *core.RegionInfo
-	targetNext := m.checkTarget(region, next, target)
-	target = m.checkTarget(region, prev, target)
-	if target != targetNext && m.cluster.GetEnableOneWayMerge() {
-		checkerCounter.WithLabelValues("merge_checker", "skip_left").Inc()
-		target = targetNext
+	target := m.checkTarget(region, next, nil)
+	if !m.cluster.GetEnableOneWayMerge() {
+		target = m.checkTarget(region, prev, target)
 	}
 
 	if target == nil {


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
The `target` argument passed to `checkTarget` is always `nil`, so `next` and `prev` are never compared.

### What is changed and how it works?
Make it right and clear and add test.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test

Related changes

 - Need to cherry-pick to the release branch