### PR TITLE
tools: fix TLS in pd control

### DIFF
--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -67,6 +67,7 @@ func Start(args []string) {
 
 	rootCmd.SetArgs(args)
 	rootCmd.SilenceErrors = true
+	rootCmd.ParseFlags(args)
 	rootCmd.SetUsageTemplate(command.UsageTemplate)
 	rootCmd.SetOutput(os.Stdout)
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
For now, pd-ctl cannot work when enable the TLS option.

### What is changed and how it works?
This PR fixes this problem by adding `ParseFlags` back.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release notes
