### PR TITLE
makefile: improve deadlock-enable/disable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,12 @@ DEADLOCK_ENABLE := $$(\
 						find . -name "*.go" | grep -vE "(vendor|\.retools)" \
 						| xargs -n 1 sed -i.bak 's/sync\.RWMutex/deadlock.RWMutex/;s/sync\.Mutex/deadlock.Mutex/' && \
 						find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs grep -lE "(deadlock\.RWMutex|deadlock\.Mutex)" \
-						| xargs -n 1 ./scripts/retool do goimports -w)
+						| xargs ./scripts/retool do goimports -w)
 DEADLOCK_DISABLE := $$(\
 						find . -name "*.go" | grep -vE "(vendor|\.retools)" \
 						| xargs -n 1 sed -i.bak 's/deadlock\.RWMutex/sync.RWMutex/;s/deadlock\.Mutex/sync.Mutex/' && \
 						find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs grep -lE "(sync\.RWMutex|sync\.Mutex)" \
-						| xargs -n 1 ./scripts/retool do goimports -w && \
+						| xargs ./scripts/retool do goimports -w && \
 						find . -name "*.bak" | grep -vE "(vendor|\.retools)" | xargs rm && \
 						go mod tidy)
 

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,18 @@ OVERALLS := overalls
 FAILPOINT_ENABLE  := $$(find $$PWD/ -type d | grep -vE "(\.git|\.retools)" | xargs ./scripts/retool do failpoint-ctl enable)
 FAILPOINT_DISABLE := $$(find $$PWD/ -type d | grep -vE "(\.git|\.retools)" | xargs ./scripts/retool do failpoint-ctl disable)
 
-DEADLOCK_ENABLE := $$(find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 sed -i.bak 's/sync.RWMutex/deadlock.RWMutex/' && \
-						find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 sed -i.bak 's/sync.Mutex/deadlock.Mutex/' && \
-						find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 ./scripts/retool do goimports -w)
-DEADLOCK_DISABLE := $$(find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 sed -i.bak 's/deadlock.RWMutex/sync.RWMutex/' && \
-						find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 sed -i.bak 's/deadlock.Mutex/sync.Mutex/' && \
-						find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs -n 1 ./scripts/retool do goimports -w && \
-						find . -name "*.bak" | grep -vE "(vendor|\.retools)" | xargs rm)
+DEADLOCK_ENABLE := $$(\
+						find . -name "*.go" | grep -vE "(vendor|\.retools)" \
+						| xargs -n 1 sed -i.bak 's/sync\.RWMutex/deadlock.RWMutex/;s/sync\.Mutex/deadlock.Mutex/' && \
+						find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs grep -lE "(deadlock\.RWMutex|deadlock\.Mutex)" \
+						| xargs -n 1 ./scripts/retool do goimports -w)
+DEADLOCK_DISABLE := $$(\
+						find . -name "*.go" | grep -vE "(vendor|\.retools)" \
+						| xargs -n 1 sed -i.bak 's/deadlock\.RWMutex/sync.RWMutex/;s/deadlock\.Mutex/sync.Mutex/' && \
+						find . -name "*.go" | grep -vE "(vendor|\.retools)" | xargs grep -lE "(sync\.RWMutex|sync\.Mutex)" \
+						| xargs -n 1 ./scripts/retool do goimports -w && \
+						find . -name "*.bak" | grep -vE "(vendor|\.retools)" | xargs rm && \
+						go mod tidy)
 
 LDFLAGS += -X "$(PD_PKG)/server.PDReleaseVersion=$(shell git describe --tags --dirty)"
 LDFLAGS += -X "$(PD_PKG)/server.PDBuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
@@ -62,7 +67,7 @@ pd-recover: export GO111MODULE=on
 pd-recover:
 	CGO_ENABLED=0 go build -o bin/pd-recover tools/pd-recover/main.go
 
-test: retool-setup
+test: retool-setup deadlock-setup
 	# testing...
 	@$(DEADLOCK_ENABLE)
 	@$(FAILPOINT_ENABLE)

--- a/tools/pd-analysis/analysis/transfer_region_counter_test.go
+++ b/tools/pd-analysis/analysis/transfer_region_counter_test.go
@@ -14,8 +14,9 @@
 package analysis
 
 import (
-	. "github.com/pingcap/check"
 	"testing"
+
+	. "github.com/pingcap/check"
 )
 
 func TestCounter(t *testing.T) {

--- a/tools/pd-simulator/simulator/cases/redundant_balance_region.go
+++ b/tools/pd-simulator/simulator/cases/redundant_balance_region.go
@@ -13,12 +13,13 @@
 package cases
 
 import (
+	"time"
+
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/tools/pd-simulator/simulator/info"
 	"github.com/pingcap/pd/tools/pd-simulator/simulator/simutil"
 	"go.uber.org/zap"
-	"time"
 )
 
 func newRedundantBalanceRegion() *Case {


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

`deadlock-enable` and `deadlock-disable` in Makefile is too slow.

### What is changed and how it works?

The reason is that `goimports` is slow, and the origin script do this on every `*.go` files. The new script did three changes:
* replace `Mutex` and `RWMutex` in one command
* filter out unchanged files before calling `goimports` (the main improve)
* call `goimports` once with all changed files

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code
