### PR TITLE
client: add tso batch size metrics

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -427,11 +427,11 @@ func (c *client) processTSORequests(stream pdpb.PD_TsoClient, requests []*tsoReq
 		span := opentracing.StartSpan("pdclient.processTSORequests", opts...)
 		defer span.Finish()
 	}
-
+	count := len(requests)
 	start := time.Now()
 	req := &pdpb.TsoRequest{
 		Header: c.requestHeader(),
-		Count:  uint32(len(requests)),
+		Count:  uint32(count),
 	}
 
 	if err := stream.Send(req); err != nil {
@@ -446,6 +446,8 @@ func (c *client) processTSORequests(stream pdpb.PD_TsoClient, requests []*tsoReq
 		return err
 	}
 	requestDurationTSO.Observe(time.Since(start).Seconds())
+	TsoBatchSize.Observe(float64(count))
+
 	if resp.GetCount() != uint32(len(requests)) {
 		err = errors.WithStack(errTSOLength)
 		c.finishTSORequest(requests, 0, 0, err)

--- a/client/metrics.go
+++ b/client/metrics.go
@@ -42,6 +42,15 @@ var (
 			Help:      "Bucketed histogram of processing time (s) of handled requests.",
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 13),
 		}, []string{"type"})
+
+	TsoBatchSize = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "pd_client",
+			Subsystem: "request",
+			Name:      "handle_tso_batch_size",
+			Help:      "Bucketed histogram of the batch size of handled requests.",
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 13),
+		})
 )
 
 var (
@@ -74,4 +83,5 @@ func init() {
 	prometheus.MustRegister(cmdDuration)
 	prometheus.MustRegister(cmdFailedDuration)
 	prometheus.MustRegister(requestDuration)
+	prometheus.MustRegister(TsoBatchSize)
 }


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Tps is increasing.
![image](https://user-images.githubusercontent.com/6428910/64695368-874f8d80-d4ce-11e9-9e03-42f9d7c07dda.png)
But the get TSP request is decreasing.
![image](https://user-images.githubusercontent.com/6428910/64695319-6ab35580-d4ce-11e9-9f4f-80e26cf954c2.png)
![image](https://user-images.githubusercontent.com/6428910/64695345-7acb3500-d4ce-11e9-8cfd-b17499db69ff.png)
And the workload is `point_select`, we cannot know why the TSO request is decreasing.

### What is changed and how it works?
add a metrics about the batch size of the request.