### PR TITLE
cluster: update the region cache when flow changed

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -418,7 +418,7 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 				zap.Stringer("region-meta", core.RegionToHexMeta(region.GetMeta())),
 				zap.Error(err))
 		}
-		regionHeartbeatCounter.WithLabelValues("none", "none", "kv", "update").Inc()
+		regionEventCounter.WithLabelValues("update_kv").Inc()
 		select {
 		case c.changedRegions <- region:
 		default:
@@ -462,7 +462,7 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 		for _, p := range region.GetPeers() {
 			c.updateStoreStatusLocked(p.GetStoreId())
 		}
-		regionHeartbeatCounter.WithLabelValues("none", "none", "cache", "update").Inc()
+		regionEventCounter.WithLabelValues("update_cache").Inc()
 	}
 
 	if c.regionStats != nil {

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -401,10 +401,10 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 			saveCache = true
 		}
 
-		if (region.GetBytesWritten() != origin.GetBytesWritten()) ||
-			(region.GetBytesRead() != origin.GetBytesRead()) ||
-			(region.GetKeysWritten() != origin.GetKeysWritten()) ||
-			(region.GetKeysRead() != origin.GetKeysRead()) {
+		if region.GetBytesWritten() != origin.GetBytesWritten() ||
+			region.GetBytesRead() != origin.GetBytesRead() ||
+			region.GetKeysWritten() != origin.GetKeysWritten() ||
+			region.GetKeysRead() != origin.GetKeysRead() {
 			saveCache = true
 		}
 	}

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -871,6 +871,7 @@ func (s *testRegionsInfoSuite) Test(c *C) {
 }
 
 func checkRegion(c *C, a *core.RegionInfo, b *core.RegionInfo) {
+	c.Assert(a, DeepEquals, b)
 	c.Assert(a.GetMeta(), DeepEquals, b.GetMeta())
 	c.Assert(a.GetLeader(), DeepEquals, b.GetLeader())
 	c.Assert(a.GetPeers(), DeepEquals, b.GetPeers())
@@ -1114,6 +1115,48 @@ func (s *testClusterInfoSuite) TestRegionHeartbeat(c *C) {
 		c.Assert(cluster.processRegionHeartbeat(region), IsNil)
 		checkRegions(c, cluster.core.Regions, regions[:i+1])
 		checkRegionsKV(c, cluster.storage, regions[:i+1])
+
+		// Change leader.
+		region = region.Clone(core.WithLeader(region.GetPeers()[1]))
+		regions[i] = region
+		c.Assert(cluster.processRegionHeartbeat(region), IsNil)
+		checkRegions(c, cluster.core.Regions, regions[:i+1])
+
+		// Change ApproximateSize.
+		region = region.Clone(core.SetApproximateSize(144))
+		regions[i] = region
+		c.Assert(cluster.processRegionHeartbeat(region), IsNil)
+		checkRegions(c, cluster.core.Regions, regions[:i+1])
+
+		// Change ApproximateKeys.
+		region = region.Clone(core.SetApproximateKeys(144000))
+		regions[i] = region
+		c.Assert(cluster.processRegionHeartbeat(region), IsNil)
+		checkRegions(c, cluster.core.Regions, regions[:i+1])
+
+		// Change bytes written.
+		region = region.Clone(core.SetWrittenBytes(24000))
+		regions[i] = region
+		c.Assert(cluster.processRegionHeartbeat(region), IsNil)
+		checkRegions(c, cluster.core.Regions, regions[:i+1])
+
+		// Change keys written.
+		region = region.Clone(core.SetWrittenKeys(240))
+		regions[i] = region
+		c.Assert(cluster.processRegionHeartbeat(region), IsNil)
+		checkRegions(c, cluster.core.Regions, regions[:i+1])
+
+		// Change bytes read.
+		region = region.Clone(core.SetReadBytes(1080000))
+		regions[i] = region
+		c.Assert(cluster.processRegionHeartbeat(region), IsNil)
+		checkRegions(c, cluster.core.Regions, regions[:i+1])
+
+		// Change keys read.
+		region = region.Clone(core.SetReadKeys(1080))
+		regions[i] = region
+		c.Assert(cluster.processRegionHeartbeat(region), IsNil)
+		checkRegions(c, cluster.core.Regions, regions[:i+1])
 	}
 
 	regionCounts := make(map[uint64]int)

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -48,6 +48,14 @@ var (
 			Help:      "Counter of region hearbeat.",
 		}, []string{"address", "store", "type", "status"})
 
+	regionEventCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "pd",
+			Subsystem: "cluster",
+			Name:      "region_event",
+			Help:      "Counter of the region event",
+		}, []string{"event"})
+
 	regionHeartbeatLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "pd",
@@ -104,6 +112,7 @@ func init() {
 	prometheus.MustRegister(timeJumpBackCounter)
 	prometheus.MustRegister(schedulerStatusGauge)
 	prometheus.MustRegister(regionHeartbeatCounter)
+	prometheus.MustRegister(regionEventCounter)
 	prometheus.MustRegister(regionHeartbeatLatency)
 	prometheus.MustRegister(hotSpotStatusGauge)
 	prometheus.MustRegister(metadataGauge)


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
For https://github.com/pingcap/pd/issues/1721,  the flow changed but do not update the cache now. Sometimes we need the information to analyze the cluster workload, change the behavior for that. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test