### PR TITLE
*: clean temp dir after testing

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -80,8 +80,7 @@ var (
 )
 
 type testClientSuite struct {
-	cleanup server.CleanupFunc
-
+	cleanup         server.CleanupFunc
 	srv             *server.Server
 	client          Client
 	grpcPDClient    pdpb.PDClient
@@ -110,7 +109,6 @@ func (s *testClientSuite) SetUpSuite(c *C) {
 
 func (s *testClientSuite) TearDownSuite(c *C) {
 	s.client.Close()
-
 	s.cleanup()
 }
 

--- a/pkg/etcdutil/etcdutil_test.go
+++ b/pkg/etcdutil/etcdutil_test.go
@@ -186,5 +186,5 @@ func (s *testEtcdutilSuite) TestEtcdKVGet(c *C) {
 	resp, err = EtcdKVGet(client, next, withRange, withLimit, clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
 	c.Assert(err, IsNil)
 	c.Assert(len(resp.Kvs), Equals, 2)
-
+	cleanConfig(cfg)
 }

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -119,10 +119,10 @@ func (s *testClusterSuite) TestBootstrap(c *C) {
 	var err error
 	var cleanup func()
 	_, s.svr, cleanup, err = NewTestServer(c)
+	defer cleanup()
 	c.Assert(err, IsNil)
 	mustWaitLeader(c, []*Server{s.svr})
 	s.grpcPDClient = testutil.MustNewGrpcClient(c, s.svr.GetAddr())
-	defer cleanup()
 	clusterID := s.svr.clusterID
 
 	// IsBootstrapped returns false.
@@ -239,10 +239,10 @@ func (s *testClusterSuite) TestGetPutConfig(c *C) {
 	var err error
 	var cleanup func()
 	_, s.svr, cleanup, err = NewTestServer(c)
+	defer cleanup()
 	c.Assert(err, IsNil)
 	mustWaitLeader(c, []*Server{s.svr})
 	s.grpcPDClient = testutil.MustNewGrpcClient(c, s.svr.GetAddr())
-	defer cleanup()
 	clusterID := s.svr.clusterID
 
 	storeAddr := "127.0.0.1:0"
@@ -416,8 +416,8 @@ func (s *testClusterSuite) TestRaftClusterRestart(c *C) {
 	var err error
 	var cleanup func()
 	_, s.svr, cleanup, err = NewTestServer(c)
-	c.Assert(err, IsNil)
 	defer cleanup()
+	c.Assert(err, IsNil)
 	mustWaitLeader(c, []*Server{s.svr})
 	_, err = s.svr.bootstrapCluster(s.newBootstrapRequest(c, s.svr.clusterID, "127.0.0.1:0"))
 	c.Assert(err, IsNil)
@@ -468,10 +468,10 @@ func (s *testClusterSuite) TestGetPDMembers(c *C) {
 	var err error
 	var cleanup func()
 	_, s.svr, cleanup, err = NewTestServer(c)
+	defer cleanup()
 	c.Assert(err, IsNil)
 	mustWaitLeader(c, []*Server{s.svr})
 	s.grpcPDClient = testutil.MustNewGrpcClient(c, s.svr.GetAddr())
-	defer cleanup()
 	req := &pdpb.GetMembersRequest{
 		Header: testutil.NewRequestHeader(s.svr.ClusterID()),
 	}
@@ -486,10 +486,10 @@ func (s *testClusterSuite) TestStoreVersionChange(c *C) {
 	var err error
 	var cleanup func()
 	_, s.svr, cleanup, err = NewTestServer(c)
+	defer cleanup()
 	c.Assert(err, IsNil)
 	mustWaitLeader(c, []*Server{s.svr})
 	s.grpcPDClient = testutil.MustNewGrpcClient(c, s.svr.GetAddr())
-	defer cleanup()
 	_, err = s.svr.bootstrapCluster(s.newBootstrapRequest(c, s.svr.clusterID, "127.0.0.1:0"))
 	c.Assert(err, IsNil)
 	s.svr.SetClusterVersion("2.0.0")
@@ -631,10 +631,10 @@ func (s *testClusterSuite) TestSetScheduleOpt(c *C) {
 	var err error
 	var cleanup func()
 	_, s.svr, cleanup, err = NewTestServer(c)
+	defer cleanup()
 	c.Assert(err, IsNil)
 	mustWaitLeader(c, []*Server{s.svr})
 	s.grpcPDClient = testutil.MustNewGrpcClient(c, s.svr.GetAddr())
-	defer cleanup()
 	clusterID := s.svr.clusterID
 
 	storeAddr := "127.0.0.1:0"

--- a/server/cluster_worker_test.go
+++ b/server/cluster_worker_test.go
@@ -53,10 +53,10 @@ func (s *testClusterWorkerSuite) TestValidRequestRegion(c *C) {
 	var err error
 	var cleanup func()
 	_, s.svr, cleanup, err = NewTestServer(c)
+	defer cleanup()
 	c.Assert(err, IsNil)
 	mustWaitLeader(c, []*Server{s.svr})
 	s.grpcPDClient = testutil.MustNewGrpcClient(c, s.svr.GetAddr())
-	defer cleanup()
 	_, err = s.svr.bootstrapCluster(s.newBootstrapRequest(c, s.svr.clusterID, "127.0.0.1:0"))
 	c.Assert(err, IsNil)
 

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -160,7 +160,8 @@ func (s *testCoordinatorSuite) TestBasic(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestCluster(opt)
-	hbStreams := getHeartBeatStreams(c, tc)
+	hbStreams, cleanup := getHeartBeatStreams(c, tc)
+	defer cleanup()
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.RaftCluster, hbStreams, namespace.DefaultClassifier)
@@ -189,7 +190,8 @@ func (s *testCoordinatorSuite) TestDispatch(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestCluster(opt)
-	hbStreams := getHeartBeatStreams(c, tc)
+	hbStreams, cleanup := getHeartBeatStreams(c, tc)
+	defer cleanup()
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.RaftCluster, hbStreams, namespace.DefaultClassifier)
@@ -254,7 +256,8 @@ func (s *testCoordinatorSuite) TestCollectMetrics(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestCluster(opt)
-	hbStreams := getHeartBeatStreams(c, tc)
+	hbStreams, cleanup := getHeartBeatStreams(c, tc)
+	defer cleanup()
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.RaftCluster, hbStreams, namespace.DefaultClassifier)
@@ -279,7 +282,8 @@ func (s *testCoordinatorSuite) TestCheckRegion(c *C) {
 	c.Assert(err, IsNil)
 	cfg.DisableLearner = false
 	tc := newTestCluster(opt)
-	hbStreams := getHeartBeatStreams(c, tc)
+	hbStreams, cleanup := getHeartBeatStreams(c, tc)
+	defer cleanup()
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.RaftCluster, hbStreams, namespace.DefaultClassifier)
@@ -338,7 +342,8 @@ func (s *testCoordinatorSuite) TestReplica(c *C) {
 	cfg.RegionScheduleLimit = 0
 
 	tc := newTestCluster(opt)
-	hbStreams := getHeartBeatStreams(c, tc)
+	hbStreams, cleanup := getHeartBeatStreams(c, tc)
+	defer cleanup()
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.RaftCluster, hbStreams, namespace.DefaultClassifier)
@@ -401,7 +406,8 @@ func (s *testCoordinatorSuite) TestPeerState(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestCluster(opt)
-	hbStreams := getHeartBeatStreams(c, tc)
+	hbStreams, cleanup := getHeartBeatStreams(c, tc)
+	defer cleanup()
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.RaftCluster, hbStreams, namespace.DefaultClassifier)
@@ -451,7 +457,8 @@ func (s *testCoordinatorSuite) TestShouldRun(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestCluster(opt)
-	hbStreams := getHeartBeatStreams(c, tc)
+	hbStreams, cleanup := getHeartBeatStreams(c, tc)
+	defer cleanup()
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.RaftCluster, hbStreams, namespace.DefaultClassifier)
@@ -500,7 +507,8 @@ func (s *testCoordinatorSuite) TestShouldRunWithNonLeaderRegions(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestCluster(opt)
-	hbStreams := getHeartBeatStreams(c, tc)
+	hbStreams, cleanup := getHeartBeatStreams(c, tc)
+	defer cleanup()
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.RaftCluster, hbStreams, namespace.DefaultClassifier)
@@ -550,7 +558,8 @@ func (s *testCoordinatorSuite) TestAddScheduler(c *C) {
 	cfg.ReplicaScheduleLimit = 0
 
 	tc := newTestCluster(opt)
-	hbStreams := getHeartBeatStreams(c, tc)
+	hbStreams, cleanup := getHeartBeatStreams(c, tc)
+	defer cleanup()
 	defer hbStreams.Close()
 	co := newCoordinator(tc.RaftCluster, hbStreams, namespace.DefaultClassifier)
 	co.run()
@@ -609,7 +618,8 @@ func (s *testCoordinatorSuite) TestPersistScheduler(c *C) {
 	cfg.ReplicaScheduleLimit = 0
 
 	tc := newTestCluster(opt)
-	hbStreams := getHeartBeatStreams(c, tc)
+	hbStreams, cleanup := getHeartBeatStreams(c, tc)
+	defer cleanup()
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.RaftCluster, hbStreams, namespace.DefaultClassifier)
@@ -702,7 +712,8 @@ func (s *testCoordinatorSuite) TestRestart(c *C) {
 	cfg.RegionScheduleLimit = 0
 
 	tc := newTestCluster(opt)
-	hbStreams := getHeartBeatStreams(c, tc)
+	hbStreams, cleanup := getHeartBeatStreams(c, tc)
+	defer cleanup()
 	defer hbStreams.Close()
 
 	// Add 3 stores (1, 2, 3) and a region with 1 replica on store 1.
@@ -781,7 +792,8 @@ func (s *testOperatorControllerSuite) TestStoreOverloaded(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestCluster(opt)
-	hbStreams := getHeartBeatStreams(c, tc)
+	hbStreams, cleanup := getHeartBeatStreams(c, tc)
+	defer cleanup()
 	defer hbStreams.Close()
 	oc := schedule.NewOperatorController(tc.RaftCluster, hbStreams)
 	lb, err := schedule.CreateScheduler("balance-region", oc)
@@ -809,7 +821,8 @@ func (s *testOperatorControllerSuite) TestStoreOverloadedWithReplace(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestCluster(opt)
-	hbStreams := getHeartBeatStreams(c, tc)
+	hbStreams, cleanup := getHeartBeatStreams(c, tc)
+	defer cleanup()
 	defer hbStreams.Close()
 	oc := schedule.NewOperatorController(tc.RaftCluster, hbStreams)
 	lb, err := schedule.CreateScheduler("balance-region", oc)
@@ -853,7 +866,8 @@ func (s *testScheduleControllerSuite) TestController(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestCluster(opt)
-	hbStreams := getHeartBeatStreams(c, tc)
+	hbStreams, cleanup := getHeartBeatStreams(c, tc)
+	defer cleanup()
 	defer hbStreams.Close()
 
 	c.Assert(tc.addLeaderRegion(1, 1), IsNil)
@@ -931,7 +945,8 @@ func (s *testScheduleControllerSuite) TestInterval(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestCluster(opt)
-	hbStreams := getHeartBeatStreams(c, tc)
+	hbStreams, cleanup := getHeartBeatStreams(c, tc)
+	defer cleanup()
 	defer hbStreams.Close()
 
 	co := newCoordinator(tc.RaftCluster, hbStreams, namespace.DefaultClassifier)
@@ -1019,7 +1034,7 @@ func waitNoResponse(c *C, stream mockhbstream.HeartbeatStream) {
 	})
 }
 
-func getHeartBeatStreams(c *C, tc *testCluster) *heartbeatStreams {
+func getHeartBeatStreams(c *C, tc *testCluster) (*heartbeatStreams, func()) {
 	config := NewTestSingleConfig(c)
 	svr, err := CreateServer(config, nil)
 	c.Assert(err, IsNil)
@@ -1035,7 +1050,7 @@ func getHeartBeatStreams(c *C, tc *testCluster) *heartbeatStreams {
 	cluster.clusterRoot = svr.getClusterRootPath()
 	cluster.regionSyncer = syncer.NewRegionSyncer(svr)
 	hbStreams := newHeartbeatStreams(tc.getClusterID(), cluster)
-	return hbStreams
+	return hbStreams, func() { testutil.CleanServer(config) }
 }
 
 func createTestRaftCluster(id id.Allocator, opt *config.ScheduleOption, storage *core.Storage) *RaftCluster {

--- a/server/join/join_test.go
+++ b/server/join/join_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/pd/pkg/testutil"
 	"github.com/pingcap/pd/server"
 )
 
@@ -31,6 +32,7 @@ type testJoinServerSuite struct{}
 // A PD joins itself.
 func (s *testJoinServerSuite) TestPDJoinsItself(c *C) {
 	cfg := server.NewTestSingleConfig(c)
+	defer testutil.CleanServer(cfg)
 	cfg.Join = cfg.AdvertiseClientUrls
 	c.Assert(PrepareJoinCluster(cfg), NotNil)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -140,7 +140,8 @@ func (s *testServerSuite) TestCheckClusterID(c *C) {
 	// Start a standalone cluster
 	// TODO: clean up. For now tests failed because:
 	//    etcdserver: failed to purge snap file ...
-	svrsA, _ := newTestServersWithCfgs(c, []*config.Config{cfgA})
+	svrsA, cleanA := newTestServersWithCfgs(c, []*config.Config{cfgA})
+	defer cleanA()
 	// Close it.
 	for _, svr := range svrsA {
 		svr.Close()

--- a/tests/server/id/id_test.go
+++ b/tests/server/id/id_test.go
@@ -42,8 +42,8 @@ func (s *testAllocIDSuite) SetUpSuite(c *C) {
 func (s *testAllocIDSuite) TestID(c *C) {
 	var err error
 	cluster, err := tests.NewTestCluster(1)
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
@@ -86,8 +86,8 @@ func (s *testAllocIDSuite) TestID(c *C) {
 func (s *testAllocIDSuite) TestCommand(c *C) {
 	var err error
 	cluster, err := tests.NewTestCluster(1)
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)

--- a/tests/server/join/join_fail/join_fail_test.go
+++ b/tests/server/join/join_fail/join_fail_test.go
@@ -37,8 +37,8 @@ func (s *joinTestSuite) SetUpSuite(c *C) {
 
 func (s *joinTestSuite) TestFailedPDJoinInStep1(c *C) {
 	cluster, err := tests.NewTestCluster(1)
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)

--- a/tests/server/join/join_test.go
+++ b/tests/server/join/join_test.go
@@ -43,8 +43,8 @@ func (s *joinTestSuite) TestSimpleJoin(c *C) {
 	c.Parallel()
 
 	cluster, err := tests.NewTestCluster(1)
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
@@ -90,8 +90,8 @@ func (s *joinTestSuite) TestFailedAndDeletedPDJoinsPreviousCluster(c *C) {
 	c.Parallel()
 
 	cluster, err := tests.NewTestCluster(3)
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
@@ -126,8 +126,8 @@ func (s *joinTestSuite) TestDeletedPDJoinsPreviousCluster(c *C) {
 	c.Parallel()
 
 	cluster, err := tests.NewTestCluster(3)
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
@@ -161,8 +161,8 @@ func (s *joinTestSuite) TestFailedPDJoinsPreviousCluster(c *C) {
 	c.Parallel()
 
 	cluster, err := tests.NewTestCluster(1)
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)

--- a/tests/server/member/member_test.go
+++ b/tests/server/member/member_test.go
@@ -49,8 +49,8 @@ func (s *serverTestSuite) TestMemberDelete(c *C) {
 	c.Parallel()
 
 	cluster, err := tests.NewTestCluster(3)
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
@@ -137,8 +137,8 @@ func (s *serverTestSuite) TestLeaderPriority(c *C) {
 	c.Parallel()
 
 	cluster, err := tests.NewTestCluster(3)
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
@@ -196,8 +196,8 @@ func (s *serverTestSuite) TestLeaderResign(c *C) {
 	c.Parallel()
 
 	cluster, err := tests.NewTestCluster(3)
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
@@ -231,8 +231,8 @@ func (s *serverTestSuite) TestMoveLeader(c *C) {
 	c.Parallel()
 
 	cluster, err := tests.NewTestCluster(5)
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -51,8 +51,8 @@ func (alloc *idAllocator) Alloc() uint64 {
 func (s *serverTestSuite) TestRegionSyncer(c *C) {
 	c.Parallel()
 	cluster, err := tests.NewTestCluster(3, func(conf *config.Config) { conf.PDServerCfg.UseRegionStorage = true })
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
@@ -96,9 +96,8 @@ func (s *serverTestSuite) TestRegionSyncer(c *C) {
 func (s *serverTestSuite) TestFullSyncWithAddMember(c *C) {
 	c.Parallel()
 	cluster, err := tests.NewTestCluster(1, func(conf *config.Config) { conf.PDServerCfg.UseRegionStorage = true })
-
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)

--- a/tests/server/server_test.go
+++ b/tests/server/server_test.go
@@ -42,8 +42,8 @@ func (s *serverTestSuite) TestUpdateAdvertiseUrls(c *C) {
 	c.Parallel()
 
 	cluster, err := tests.NewTestCluster(2)
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
@@ -82,8 +82,8 @@ func (s *serverTestSuite) TestClusterID(c *C) {
 	c.Parallel()
 
 	cluster, err := tests.NewTestCluster(3)
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
@@ -109,8 +109,8 @@ func (s *serverTestSuite) TestLeader(c *C) {
 	c.Parallel()
 
 	cluster, err := tests.NewTestCluster(3)
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)

--- a/tests/server/tso/tso_test.go
+++ b/tests/server/tso/tso_test.go
@@ -41,8 +41,8 @@ func (s *testTsoSuite) SetUpSuite(c *C) {
 func (s *testTsoSuite) testGetTimestamp(c *C, n int) *pdpb.Timestamp {
 	var err error
 	cluster, err := tests.NewTestCluster(1)
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
@@ -75,8 +75,8 @@ func (s *testTsoSuite) testGetTimestamp(c *C, n int) *pdpb.Timestamp {
 func (s *testTsoSuite) TestTso(c *C) {
 	var err error
 	cluster, err := tests.NewTestCluster(1)
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
@@ -111,8 +111,8 @@ func (s *testTsoSuite) TestTso(c *C) {
 func (s *testTsoSuite) TestTsoCount0(c *C) {
 	var err error
 	cluster, err := tests.NewTestCluster(1)
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)

--- a/tests/server/watch/leader_watch_test.go
+++ b/tests/server/watch/leader_watch_test.go
@@ -41,8 +41,8 @@ func (s *serverTestSuite) SetUpSuite(c *C) {
 func (s *serverTestSuite) TestWatcher(c *C) {
 	c.Parallel()
 	cluster, err := tests.NewTestCluster(1, func(conf *config.Config) { conf.AutoCompactionRetention = "1s" })
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
@@ -78,8 +78,8 @@ func (s *serverTestSuite) TestWatcher(c *C) {
 func (s *serverTestSuite) TestWatcherCompacted(c *C) {
 	c.Parallel()
 	cluster, err := tests.NewTestCluster(1, func(conf *config.Config) { conf.AutoCompactionRetention = "1s" })
-	c.Assert(err, IsNil)
 	defer cluster.Destroy()
+	c.Assert(err, IsNil)
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
# What problem does this PR solve? <!--add the issue link with summary if it exists-->
Currently, after running the test, it will leave a lot of testing directories in temp directories according to the different OS. If there are some people running the tests in the same machine with different users. It may encounter privileges problems.

### What is changed and how it works?
No matter the test is failed or not, this PR tries to clean up these testing directories after the tests have existed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test