### PR TITLE
*: improve more metrics

### DIFF
--- a/server/checker/metrics.go
+++ b/server/checker/metrics.go
@@ -23,8 +23,17 @@ var (
 			Name:      "event_count",
 			Help:      "Counter of checker events.",
 		}, []string{"type", "name"})
+
+	processStatusCounter = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "checker",
+			Name:      "status",
+			Help:      "Status of the process of offline or down store.",
+		}, []string{"status", "event"})
 )
 
 func init() {
 	prometheus.MustRegister(checkerCounter)
+	prometheus.MustRegister(processStatusCounter)
 }

--- a/server/checker/metrics.go
+++ b/server/checker/metrics.go
@@ -23,17 +23,8 @@ var (
 			Name:      "event_count",
 			Help:      "Counter of checker events.",
 		}, []string{"type", "name"})
-
-	processStatusCounter = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "pd",
-			Subsystem: "checker",
-			Name:      "status",
-			Help:      "Status of the process of offline or down store.",
-		}, []string{"status", "event"})
 )
 
 func init() {
 	prometheus.MustRegister(checkerCounter)
-	prometheus.MustRegister(processStatusCounter)
 }

--- a/server/checker/replica_checker.go
+++ b/server/checker/replica_checker.go
@@ -257,8 +257,8 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, peer *metapb.Peer, sta
 	if len(region.GetPeers()) > r.cluster.GetMaxReplicas() {
 		op, err := operator.CreateRemovePeerOperator(removeExtra, r.cluster, operator.OpReplica, region, peer.GetStoreId())
 		if err != nil {
-			processStatusCounter.WithLabelValues(status, "remove-extra-fail").Inc()
-			checkerCounter.WithLabelValues("replica_checker", "create-operator-fail").Inc()
+			reason := fmt.Sprintf("%s-fail", removeExtra)
+			checkerCounter.WithLabelValues("replica_checker", reason).Inc()
 			return nil
 		}
 		return op
@@ -272,8 +272,8 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, peer *metapb.Peer, sta
 	if region.GetPendingPeer(peer.GetId()) != nil {
 		op, err := operator.CreateRemovePeerOperator(removePending, r.cluster, operator.OpReplica, region, peer.GetStoreId())
 		if err != nil {
-			processStatusCounter.WithLabelValues(status, "remove-pending-fail").Inc()
-			checkerCounter.WithLabelValues("replica_checker", "create-operator-fail").Inc()
+			reason := fmt.Sprintf("%s-fail", removePending)
+			checkerCounter.WithLabelValues("replica_checker", reason).Inc()
 			return nil
 		}
 		return op
@@ -281,7 +281,8 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, peer *metapb.Peer, sta
 
 	storeID, _ := r.SelectBestReplacementStore(region, peer, filter.NewStorageThresholdFilter(r.name))
 	if storeID == 0 {
-		processStatusCounter.WithLabelValues(status, "no-store").Inc()
+		reason := fmt.Sprintf("no-store-%s", status)
+		checkerCounter.WithLabelValues("replica_checker", reason).Inc()
 		log.Debug("no best store to add replica", zap.Uint64("region-id", region.GetID()))
 		return nil
 	}
@@ -293,8 +294,8 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, peer *metapb.Peer, sta
 	replace := fmt.Sprintf("replace-%s-replica", status)
 	op, err := operator.CreateMovePeerOperator(replace, r.cluster, region, operator.OpReplica, peer.GetStoreId(), newPeer.GetStoreId(), newPeer.GetId())
 	if err != nil {
-		processStatusCounter.WithLabelValues(status, "replace-fail").Inc()
-		checkerCounter.WithLabelValues("replica_checker", "create-operator-fail").Inc()
+		reason := fmt.Sprintf("%s-fail", replace)
+		checkerCounter.WithLabelValues("replica_checker", reason).Inc()
 		return nil
 	}
 	return op

--- a/server/checker/replica_checker.go
+++ b/server/checker/replica_checker.go
@@ -257,6 +257,7 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, peer *metapb.Peer, sta
 	if len(region.GetPeers()) > r.cluster.GetMaxReplicas() {
 		op, err := operator.CreateRemovePeerOperator(removeExtra, r.cluster, operator.OpReplica, region, peer.GetStoreId())
 		if err != nil {
+			processStatusCounter.WithLabelValues(status, "remove-extra-fail").Inc()
 			checkerCounter.WithLabelValues("replica_checker", "create-operator-fail").Inc()
 			return nil
 		}
@@ -271,6 +272,7 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, peer *metapb.Peer, sta
 	if region.GetPendingPeer(peer.GetId()) != nil {
 		op, err := operator.CreateRemovePeerOperator(removePending, r.cluster, operator.OpReplica, region, peer.GetStoreId())
 		if err != nil {
+			processStatusCounter.WithLabelValues(status, "remove-pending-fail").Inc()
 			checkerCounter.WithLabelValues("replica_checker", "create-operator-fail").Inc()
 			return nil
 		}
@@ -279,6 +281,7 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, peer *metapb.Peer, sta
 
 	storeID, _ := r.SelectBestReplacementStore(region, peer, filter.NewStorageThresholdFilter(r.name))
 	if storeID == 0 {
+		processStatusCounter.WithLabelValues(status, "no-store").Inc()
 		log.Debug("no best store to add replica", zap.Uint64("region-id", region.GetID()))
 		return nil
 	}
@@ -290,6 +293,8 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, peer *metapb.Peer, sta
 	replace := fmt.Sprintf("replace-%s-replica", status)
 	op, err := operator.CreateMovePeerOperator(replace, r.cluster, region, operator.OpReplica, peer.GetStoreId(), newPeer.GetStoreId(), newPeer.GetId())
 	if err != nil {
+		processStatusCounter.WithLabelValues(status, "replace-fail").Inc()
+		checkerCounter.WithLabelValues("replica_checker", "create-operator-fail").Inc()
 		return nil
 	}
 	return op

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -928,7 +928,6 @@ func (c *RaftCluster) putStoreLocked(store *core.StoreInfo) error {
 func (c *RaftCluster) checkStores() {
 	var offlineStores []*metapb.Store
 	var upStoreCount int
-
 	stores := c.GetStores()
 	for _, store := range stores {
 		// the store has already been tombstone
@@ -963,7 +962,7 @@ func (c *RaftCluster) checkStores() {
 
 	if upStoreCount < c.GetMaxReplicas() {
 		for _, offlineStore := range offlineStores {
-			log.Warn("store may not turn into Tombstone, there are no extra up node has enough space to accommodate the extra replica", zap.Stringer("store", offlineStore))
+			log.Warn("store may not turn into Tombstone, there are no extra up store has enough space to accommodate the extra replica", zap.Stringer("store", offlineStore))
 		}
 	}
 }

--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -112,7 +112,11 @@ func (l *balanceLeaderScheduler) Schedule(cluster schedule.Cluster) []*operator.
 
 	// No store can be selected as source or target.
 	if source == nil || target == nil {
-		schedulerCounter.WithLabelValues(l.GetName(), "no-store").Inc()
+		if source == nil {
+			schedulerCounter.WithLabelValues(l.GetName(), "no-source-store").Inc()
+		} else {
+			schedulerCounter.WithLabelValues(l.GetName(), "no-target-store").Inc()
+		}
 		// When the cluster is balanced, all stores will be added to the cache once
 		// all of them have been selected. This will cause the scheduler to not adapt
 		// to sudden change of a store's leader. Here we clear the taint cache and

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -119,7 +119,7 @@ func (s *balanceRegionScheduler) Schedule(cluster schedule.Cluster) []*operator.
 	f := s.hitsCounter.buildSourceFilter(s.GetName(), cluster)
 	source := s.selector.SelectSource(cluster, stores, f)
 	if source == nil {
-		schedulerCounter.WithLabelValues(s.GetName(), "no-store").Inc()
+		schedulerCounter.WithLabelValues(s.GetName(), "no-source-store").Inc()
 		// Unlike the balanceLeaderScheduler, we don't need to clear the taintCache
 		// here. Because normally region score won't change rapidly, and the region
 		// balance requires lower sensitivity compare to leader balance.

--- a/server/schedulers/random_merge.go
+++ b/server/schedulers/random_merge.go
@@ -83,7 +83,7 @@ func (s *randomMergeScheduler) Schedule(cluster schedule.Cluster) []*operator.Op
 		target = other
 	}
 	if target == nil {
-		schedulerCounter.WithLabelValues(s.GetName(), "no-adjacent").Inc()
+		schedulerCounter.WithLabelValues(s.GetName(), "no-target-store").Inc()
 		return nil
 	}
 

--- a/server/schedulers/random_merge.go
+++ b/server/schedulers/random_merge.go
@@ -69,7 +69,7 @@ func (s *randomMergeScheduler) Schedule(cluster schedule.Cluster) []*operator.Op
 	stores := cluster.GetStores()
 	store := s.selector.SelectSource(cluster, stores)
 	if store == nil {
-		schedulerCounter.WithLabelValues(s.GetName(), "no-store").Inc()
+		schedulerCounter.WithLabelValues(s.GetName(), "no-source-store").Inc()
 		return nil
 	}
 	region := cluster.RandLeaderRegion(store.GetID(), core.HealthRegion())

--- a/server/schedulers/shuffle_region.go
+++ b/server/schedulers/shuffle_region.go
@@ -94,7 +94,7 @@ func (s *shuffleRegionScheduler) scheduleRemovePeer(cluster schedule.Cluster) (*
 
 	source := s.selector.SelectSource(cluster, stores)
 	if source == nil {
-		schedulerCounter.WithLabelValues(s.GetName(), "no-store").Inc()
+		schedulerCounter.WithLabelValues(s.GetName(), "no-source-store").Inc()
 		return nil, nil
 	}
 

--- a/server/statistics/store_collection.go
+++ b/server/statistics/store_collection.go
@@ -198,11 +198,11 @@ func (s *storeStatistics) Collect() {
 		disableReplaceOfflineReplica = 1
 	}
 
-	configs["disable_makeup_replica"] = disableMakeUpReplica
-	configs["disable_learner"] = disableLearner
-	configs["disable_remove_down_replica"] = disableRemoveDownReplica
-	configs["disable_remove_extra_replica"] = disableRemoveExtraReplica
-	configs["disable_replace_offline_replica"] = disableReplaceOfflineReplica
+	configs["disable-makeup-replica"] = disableMakeUpReplica
+	configs["disable-learner"] = disableLearner
+	configs["disable-remove-down-replica"] = disableRemoveDownReplica
+	configs["disable-remove-extra-replica"] = disableRemoveExtraReplica
+	configs["disable-replace-offline-replica"] = disableReplaceOfflineReplica
 
 	for typ, value := range configs {
 		configStatusGauge.WithLabelValues(typ, s.namespace).Set(value)


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
At present, it's hard to know the process status of making replicas for offline or down stores. We might not know why the operator is failed to be created.

### What is changed and how it works?
This PR adds a new metrics named `processStatusCounter` to record the failure reason when creating the operator for the offline or down store. Also, this PR renames some labels to make them more clear.

Pros and cons:
Pros: 
1. We can know why the operator cannot be created and the kind of failure reasons.
2. After #1746, once we encounter "no-store", we can directly find some information from filter metrics.

Cons:
1. It records some duplicated information with `checkerCounter`.

**UPDATE:
According to the comments, reuse `checkerCounter`.**

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
