### PR TITLE
server: fix panic caused by GetLeader

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -157,6 +157,7 @@ github.com/urfave/negroni v0.3.0 h1:PaXOb61mWeZJxc1Ji2xJjpVg9QfPo0rrB+lHyBxGNSU=
 github.com/urfave/negroni v0.3.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/yookoala/realpath v1.0.0 h1:7OA9pj4FZd+oZDsyvXWQvjn5oBdcHRTV44PpdMSuImQ=
 github.com/yookoala/realpath v1.0.0/go.mod h1:gJJMA9wuX7AcqLy1+ffPatSCySA1FQ2S8Ya9AIoYBpE=
 go.etcd.io/bbolt v1.3.2 h1:Z/90sZLPOeCy2PwprqkFa25PdkusRzaj9P8zm/KNyvk=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/server/api/version_test.go
+++ b/server/api/version_test.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/pd/pkg/testutil"
+	"github.com/pingcap/pd/server"
+	"github.com/pingcap/pd/server/config"
+)
+
+var _ = Suite(&testVersionSuite{})
+
+type testVersionSuite struct{}
+
+func (s *testVersionSuite) TestGetVersion(c *C) {
+	fname := filepath.Join(os.TempDir(), "stdout")
+	old := os.Stdout
+	temp, _ := os.Create(fname)
+	os.Stdout = temp
+
+	cfg := server.NewTestSingleConfig(c)
+	stopCh := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+				func() {
+					addr := cfg.ClientUrls + apiPrefix + "/api/v1/version"
+					resp, err := dialClient.Get(addr)
+					if resp == nil {
+						return
+					}
+					c.Assert(err, IsNil)
+					defer resp.Body.Close()
+					_, err = ioutil.ReadAll(resp.Body)
+					c.Assert(err, IsNil)
+				}()
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan *server.Server)
+	go func(cfg *config.Config) {
+		s, err := server.CreateServer(cfg, NewHandler)
+		c.Assert(err, IsNil)
+		err = s.Run(ctx)
+		c.Assert(err, IsNil)
+		ch <- s
+	}(cfg)
+
+	svr := <-ch
+	close(ch)
+	out, _ := ioutil.ReadFile(fname)
+	c.Assert(strings.Contains(string(out), "PANIC"), IsFalse)
+	stopCh <- struct{}{}
+
+	// clean up
+	func() {
+		temp.Close()
+		os.Stdout = old
+		os.Remove(fname)
+		svr.Close()
+		cancel()
+		testutil.CleanServer(cfg)
+	}()
+}

--- a/server/api/version_test.go
+++ b/server/api/version_test.go
@@ -1,3 +1,16 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package api
 
 import (

--- a/server/api/version_test.go
+++ b/server/api/version_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
@@ -41,6 +42,7 @@ func (s *testVersionSuite) TestGetVersion(c *C) {
 	reqCh := make(chan struct{})
 	go func() {
 		<-reqCh
+		time.Sleep(200 * time.Millisecond)
 		addr := cfg.ClientUrls + apiPrefix + "/api/v1/version"
 		resp, err := dialClient.Get(addr)
 		c.Assert(err, IsNil)

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -509,6 +509,7 @@ func (s *testClusterSuite) TestStoreVersionChange(c *C) {
 	v, err := semver.NewVersion("1.0.0")
 	c.Assert(err, IsNil)
 	c.Assert(s.svr.GetClusterVersion(), Equals, *v)
+	c.Assert(failpoint.Disable("github.com/pingcap/pd/server/versionChangeConcurrency"), IsNil)
 }
 
 func (s *testClusterSuite) TestConcurrentHandleRegion(c *C) {

--- a/server/server.go
+++ b/server/server.go
@@ -111,6 +111,7 @@ func CreateServer(cfg *config.Config, apiRegister func(*Server) http.Handler) (*
 	s := &Server{
 		cfg:         cfg,
 		scheduleOpt: config.NewScheduleOption(cfg),
+		member:      &member.Member{},
 	}
 	s.handler = newHandler(s)
 

--- a/server/server.go
+++ b/server/server.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/golang/protobuf/proto"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
@@ -199,6 +200,9 @@ func (s *Server) startEtcd(ctx context.Context) error {
 		}
 	}
 	s.client = client
+	failpoint.Inject("memberNil", func() {
+		time.Sleep(500 * time.Millisecond)
+	})
 	s.member = member.NewMember(etcd, client, etcdServerID)
 	return nil
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Before executing `startEtcd`, if we send an HTTP request, e.g. `curl http://127.0.0.1:2379/pd/api/v1/version`. It will panic due to the nil pointer problem. See #1764.

### What is changed and how it works?
This PR fixes this problem by using an empty struct.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release notes
