### PR TITLE
Fix merge region doc and refactor

### DIFF
--- a/pkg/mock/mockoption/mockoption.go
+++ b/pkg/mock/mockoption/mockoption.go
@@ -155,8 +155,8 @@ func (mso *ScheduleOptions) GetSplitMergeInterval() time.Duration {
 	return mso.SplitMergeInterval
 }
 
-// GetEnableOneWayMerge mocks method
-func (mso *ScheduleOptions) GetEnableOneWayMerge() bool {
+// IsOneWayMergeEnabled mocks method
+func (mso *ScheduleOptions) IsOneWayMergeEnabled() bool {
 	return mso.EnableOneWayMerge
 }
 

--- a/server/checker/merge_checker.go
+++ b/server/checker/merge_checker.go
@@ -106,7 +106,7 @@ func (m *MergeChecker) Check(region *core.RegionInfo) []*operator.Operator {
 	if m.checkTarget(region, next) {
 		target = next
 	}
-	if !m.cluster.GetEnableOneWayMerge() && m.checkTarget(region, prev) { // allow to merge region right to left
+	if !m.cluster.IsOneWayMergeEnabled() && m.checkTarget(region, prev) { // allow to merge region right to left
 		if next == nil || prev.GetApproximateSize() < next.GetApproximateSize() { // pick smaller
 			target = prev
 		}

--- a/server/checker/merge_checker.go
+++ b/server/checker/merge_checker.go
@@ -103,7 +103,7 @@ func (m *MergeChecker) Check(region *core.RegionInfo) []*operator.Operator {
 	prev, next := m.cluster.GetAdjacentRegions(region)
 
 	target := m.checkTarget(region, next, nil)
-	if !m.cluster.GetEnableOneWayMerge() {
+	if !m.cluster.GetEnableOneWayMerge() { // allow to merge region right to left
 		target = m.checkTarget(region, prev, target)
 	}
 

--- a/server/checker/merge_checker.go
+++ b/server/checker/merge_checker.go
@@ -107,7 +107,7 @@ func (m *MergeChecker) Check(region *core.RegionInfo) []*operator.Operator {
 		target = next
 	}
 	if !m.cluster.IsOneWayMergeEnabled() && m.checkTarget(region, prev) { // allow to merge region right to left
-		if next == nil || prev.GetApproximateSize() < next.GetApproximateSize() { // pick smaller
+		if target == nil || prev.GetApproximateSize() < next.GetApproximateSize() { // pick smaller
 			target = prev
 		}
 	}

--- a/server/checker/merge_checker.go
+++ b/server/checker/merge_checker.go
@@ -135,5 +135,5 @@ func (m *MergeChecker) checkTarget(region, adjacent *core.RegionInfo) bool {
 	return adjacent != nil && !m.cluster.IsRegionHot(adjacent) &&
 		m.classifier.AllowMerge(region, adjacent) &&
 		len(adjacent.GetDownPeers()) == 0 && len(adjacent.GetPendingPeers()) == 0 && len(adjacent.GetLearners()) == 0 && // no special peer
-		len(adjacent.GetPeers()) == m.cluster.GetMaxReplicas()
+		len(adjacent.GetPeers()) == m.cluster.GetMaxReplicas() // peer count should equal
 }

--- a/server/checker/merge_checker.go
+++ b/server/checker/merge_checker.go
@@ -106,7 +106,7 @@ func (m *MergeChecker) Check(region *core.RegionInfo) []*operator.Operator {
 	if m.checkTarget(region, next) {
 		target = next
 	}
-	if !m.cluster.IsOneWayMergeEnabled() && m.checkTarget(region, prev) { // allow to merge region right to left
+	if !m.cluster.IsOneWayMergeEnabled() && m.checkTarget(region, prev) { // allow a region can be merged by two ways.
 		if target == nil || prev.GetApproximateSize() < next.GetApproximateSize() { // pick smaller
 			target = prev
 		}

--- a/server/checker/merge_checker.go
+++ b/server/checker/merge_checker.go
@@ -106,8 +106,8 @@ func (m *MergeChecker) Check(region *core.RegionInfo) []*operator.Operator {
 	if m.checkTarget(region, next) {
 		target = next
 	}
-	if !m.cluster.GetEnableOneWayMerge() { // allow to merge region right to left
-		if m.checkTarget(region, prev) && prev.GetApproximateSize() < next.GetApproximateSize() { // pick smaller
+	if !m.cluster.GetEnableOneWayMerge() && m.checkTarget(region, prev) { // allow to merge region right to left
+		if next == nil || prev.GetApproximateSize() < next.GetApproximateSize() { // pick smaller
 			target = prev
 		}
 	}

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -1244,7 +1244,7 @@ func (c *RaftCluster) GetSplitMergeInterval() time.Duration {
 	return c.opt.GetSplitMergeInterval()
 }
 
-// IsOneWayMergeEnabled returns if a region can only be merged into right.
+// IsOneWayMergeEnabled returns if a region can only be merged into the next region.
 func (c *RaftCluster) IsOneWayMergeEnabled() bool {
 	return c.opt.IsOneWayMergeEnabled()
 }

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -1244,9 +1244,9 @@ func (c *RaftCluster) GetSplitMergeInterval() time.Duration {
 	return c.opt.GetSplitMergeInterval()
 }
 
-// GetEnableOneWayMerge returns if a region can only be merged into right.
-func (c *RaftCluster) GetEnableOneWayMerge() bool {
-	return c.opt.GetEnableOneWayMerge()
+// IsOneWayMergeEnabled returns if a region can only be merged into right.
+func (c *RaftCluster) IsOneWayMergeEnabled() bool {
+	return c.opt.IsOneWayMergeEnabled()
 }
 
 // GetPatrolRegionInterval returns the interval of patroling region.

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -1244,7 +1244,7 @@ func (c *RaftCluster) GetSplitMergeInterval() time.Duration {
 	return c.opt.GetSplitMergeInterval()
 }
 
-// IsOneWayMergeEnabled returns if a region can only be merged into the next region.
+// IsOneWayMergeEnabled returns if a region can only be merged into the next region of it.
 func (c *RaftCluster) IsOneWayMergeEnabled() bool {
 	return c.opt.IsOneWayMergeEnabled()
 }

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -1244,7 +1244,7 @@ func (c *RaftCluster) GetSplitMergeInterval() time.Duration {
 	return c.opt.GetSplitMergeInterval()
 }
 
-// GetEnableOneWayMerge returns if the one way merge is enabled.
+// GetEnableOneWayMerge returns if a region can only be merged into right.
 func (c *RaftCluster) GetEnableOneWayMerge() bool {
 	return c.opt.GetEnableOneWayMerge()
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -481,7 +481,7 @@ type ScheduleConfig struct {
 	MaxMergeRegionKeys uint64 `toml:"max-merge-region-keys,omitempty" json:"max-merge-region-keys"`
 	// SplitMergeInterval is the minimum interval time to permit merge after split.
 	SplitMergeInterval typeutil.Duration `toml:"split-merge-interval,omitempty" json:"split-merge-interval"`
-	// EnableOneWayMerge is the option to enable one way merge
+	// EnableOneWayMerge is the option to enable one way merge. This means a Region can only be merged into right.
 	EnableOneWayMerge bool `toml:"enable-one-way-merge,omitempty" json:"enable-one-way-merge,string"`
 	// PatrolRegionInterval is the interval for scanning region during patrol.
 	PatrolRegionInterval typeutil.Duration `toml:"patrol-region-interval,omitempty" json:"patrol-region-interval"`

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -481,7 +481,7 @@ type ScheduleConfig struct {
 	MaxMergeRegionKeys uint64 `toml:"max-merge-region-keys,omitempty" json:"max-merge-region-keys"`
 	// SplitMergeInterval is the minimum interval time to permit merge after split.
 	SplitMergeInterval typeutil.Duration `toml:"split-merge-interval,omitempty" json:"split-merge-interval"`
-	// EnableOneWayMerge is the option to enable one way merge. This means a Region can only be merged into the next region.
+	// EnableOneWayMerge is the option to enable one way merge. This means a Region can only be merged into the next region of it.
 	EnableOneWayMerge bool `toml:"enable-one-way-merge,omitempty" json:"enable-one-way-merge,string"`
 	// PatrolRegionInterval is the interval for scanning region during patrol.
 	PatrolRegionInterval typeutil.Duration `toml:"patrol-region-interval,omitempty" json:"patrol-region-interval"`

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -481,7 +481,7 @@ type ScheduleConfig struct {
 	MaxMergeRegionKeys uint64 `toml:"max-merge-region-keys,omitempty" json:"max-merge-region-keys"`
 	// SplitMergeInterval is the minimum interval time to permit merge after split.
 	SplitMergeInterval typeutil.Duration `toml:"split-merge-interval,omitempty" json:"split-merge-interval"`
-	// EnableOneWayMerge is the option to enable one way merge. This means a Region can only be merged into right.
+	// EnableOneWayMerge is the option to enable one way merge. This means a Region can only be merged into the next region.
 	EnableOneWayMerge bool `toml:"enable-one-way-merge,omitempty" json:"enable-one-way-merge,string"`
 	// PatrolRegionInterval is the interval for scanning region during patrol.
 	PatrolRegionInterval typeutil.Duration `toml:"patrol-region-interval,omitempty" json:"patrol-region-interval"`

--- a/server/config/option.go
+++ b/server/config/option.go
@@ -155,8 +155,8 @@ func (o *ScheduleOption) GetSplitMergeInterval() time.Duration {
 	return o.Load().SplitMergeInterval.Duration
 }
 
-// GetEnableOneWayMerge returns if a region can only be merged into right.
-func (o *ScheduleOption) GetEnableOneWayMerge() bool {
+// IsOneWayMergeEnabled returns if a region can only be merged into right.
+func (o *ScheduleOption) IsOneWayMergeEnabled() bool {
 	return o.Load().EnableOneWayMerge
 }
 

--- a/server/config/option.go
+++ b/server/config/option.go
@@ -155,7 +155,7 @@ func (o *ScheduleOption) GetSplitMergeInterval() time.Duration {
 	return o.Load().SplitMergeInterval.Duration
 }
 
-// GetEnableOneWayMerge returns if the one way merge is enabled.
+// GetEnableOneWayMerge returns if a region can only be merged into right.
 func (o *ScheduleOption) GetEnableOneWayMerge() bool {
 	return o.Load().EnableOneWayMerge
 }

--- a/server/config/option.go
+++ b/server/config/option.go
@@ -155,7 +155,7 @@ func (o *ScheduleOption) GetSplitMergeInterval() time.Duration {
 	return o.Load().SplitMergeInterval.Duration
 }
 
-// IsOneWayMergeEnabled returns if a region can only be merged into right.
+// IsOneWayMergeEnabled returns if a region can only be merged into the next region.
 func (o *ScheduleOption) IsOneWayMergeEnabled() bool {
 	return o.Load().EnableOneWayMerge
 }

--- a/server/config/option.go
+++ b/server/config/option.go
@@ -155,7 +155,7 @@ func (o *ScheduleOption) GetSplitMergeInterval() time.Duration {
 	return o.Load().SplitMergeInterval.Duration
 }
 
-// IsOneWayMergeEnabled returns if a region can only be merged into the next region.
+// IsOneWayMergeEnabled returns if a region can only be merged into the next region of it.
 func (o *ScheduleOption) IsOneWayMergeEnabled() bool {
 	return o.Load().EnableOneWayMerge
 }

--- a/server/schedule/opt/opts.go
+++ b/server/schedule/opt/opts.go
@@ -36,7 +36,7 @@ type Options interface {
 	GetMaxMergeRegionSize() uint64
 	GetMaxMergeRegionKeys() uint64
 	GetSplitMergeInterval() time.Duration
-	GetEnableOneWayMerge() bool
+	IsOneWayMergeEnabled() bool
 
 	GetMaxReplicas() int
 	GetLocationLabels() []string

--- a/server/schedulers/random_merge.go
+++ b/server/schedulers/random_merge.go
@@ -79,7 +79,7 @@ func (s *randomMergeScheduler) Schedule(cluster schedule.Cluster) []*operator.Op
 	}
 
 	other, target := cluster.GetAdjacentRegions(region)
-	if !cluster.GetEnableOneWayMerge() && ((rand.Int()%2 == 0 && other != nil) || target == nil) {
+	if !cluster.IsOneWayMergeEnabled() && ((rand.Int()%2 == 0 && other != nil) || target == nil) {
 		target = other
 	}
 	if target == nil {

--- a/tools/pd-ctl/README.md
+++ b/tools/pd-ctl/README.md
@@ -197,7 +197,7 @@ Usage:
     >> config set split-merge-interval 24h  // Set the interval between `split` and `merge` to one day
     ```
 
-- `enable-one-way-merge` controls the merge scheduler behavior. This means a Region can only be merged into left.
+- `enable-one-way-merge` controls the merge scheduler behavior. This means a Region can only be merged into right.
 
     ```bash
     >> config set enable-one-way-merge true  // Enable one way merge.

--- a/tools/pd-ctl/README.md
+++ b/tools/pd-ctl/README.md
@@ -197,7 +197,7 @@ Usage:
     >> config set split-merge-interval 24h  // Set the interval between `split` and `merge` to one day
     ```
 
-- `enable-one-way-merge` controls the merge scheduler behavior. This means a region can only be merged into the next region.
+- `enable-one-way-merge` controls the merge scheduler behavior. This means a region can only be merged into the next region of it.
 
     ```bash
     >> config set enable-one-way-merge true  // Enable one way merge.

--- a/tools/pd-ctl/README.md
+++ b/tools/pd-ctl/README.md
@@ -197,7 +197,7 @@ Usage:
     >> config set split-merge-interval 24h  // Set the interval between `split` and `merge` to one day
     ```
 
-- `enable-one-way-merge` controls the merge scheduler behavior. This means a Region can only be merged into right.
+- `enable-one-way-merge` controls the merge scheduler behavior. This means a region can only be merged into the next region.
 
     ```bash
     >> config set enable-one-way-merge true  // Enable one way merge.


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->

Region merge left into right in https://github.com/pingcap/pd/pull/1564.

But [the description](https://github.com/pingcap/pd/tree/master/tools/pd-ctl) in this document is the opposite 

>  "This means a Region can only be merged into left."

### What is changed and how it works?

Fix document and add more comment.

Otherwise, replace `GetEnableOneWayMerge` with `IsOneWayMergeEnabled` and refactor to make it easier to understanding.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
