### PR TITLE
pkg: omit the btree warnings

### DIFF
--- a/pkg/btree/btree.go
+++ b/pkg/btree/btree.go
@@ -673,7 +673,7 @@ const (
 // will force the iterator to include the first item when it equals 'start',
 // thus creating a "greaterOrEqual" or "lessThanEqual" rather than just a
 // "greaterThan" or "lessThan" queries.
-func (n *node) iterate(dir direction, start, stop Item, includeStart bool, hit bool, iter ItemIterator) (bool, bool) {
+func (n *node) iterate(dir direction, start, stop Item, includeStart bool, hit bool, iter ItemIterator) (bool, bool) { // revive:disable-line:flag-parameter,confusing-results
 	var ok, found bool
 	var index int
 	switch dir {
@@ -1060,7 +1060,7 @@ func (t *BTree) getRootLength() int {
 //   O(tree size):  when all nodes are owned by another tree, all nodes are
 //       iterated over looking for nodes to add to the freelist, and due to
 //       ownership, none are.
-func (t *BTree) Clear(addNodesToFreelist bool) {
+func (t *BTree) Clear(addNodesToFreelist bool) { // revive:disable-line:flag-parameter
 	if t.root != nil && addNodesToFreelist {
 		t.root.reset(t.cow)
 	}

--- a/revive.toml
+++ b/revive.toml
@@ -20,14 +20,9 @@ warningCode = 0
 [rule.empty-block]
 [rule.superfluous-else]
 [rule.modifies-parameter]
-
-# Add these once issues are fixed
 [rule.confusing-naming]
-  severity = "warning"
 [rule.confusing-results]
-  severity = "warning"
 [rule.flag-parameter]
-  severity = "warning"
 
 # Currently this makes too much noise, but should add it in
 # and perhaps ignore it in a few files


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Closes #1769.

### What is changed and how it works?
This PR keeps the original btree implementation and omits the warnings by adding two rules.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code