### PR TITLE
Rename overloadFilter to storeLimitFilter

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -873,9 +873,9 @@ func (c *RaftCluster) UnblockStore(storeID uint64) {
 	c.core.UnblockStore(storeID)
 }
 
-// AttachOverloadStatus attaches the overload status to a store.
-func (c *RaftCluster) AttachOverloadStatus(storeID uint64, f func() bool) {
-	c.core.AttachOverloadStatus(storeID, f)
+// AttachAvailableFunc attaches an available function to a specific store.
+func (c *RaftCluster) AttachAvailableFunc(storeID uint64, f func() bool) {
+	c.core.AttachAvailableFunc(storeID, f)
 }
 
 // SetStoreState sets up a store's state.

--- a/server/core/basic_cluster.go
+++ b/server/core/basic_cluster.go
@@ -137,11 +137,11 @@ func (bc *BasicCluster) UnblockStore(storeID uint64) {
 	bc.Stores.UnblockStore(storeID)
 }
 
-// AttachOverloadStatus attaches the overload status to a store.
-func (bc *BasicCluster) AttachOverloadStatus(storeID uint64, f func() bool) {
+// AttachAvailableFunc attaches an available function to a specific store.
+func (bc *BasicCluster) AttachAvailableFunc(storeID uint64, f func() bool) {
 	bc.Lock()
 	defer bc.Unlock()
-	bc.Stores.AttachOverloadStatus(storeID, f)
+	bc.Stores.AttachAvailableFunc(storeID, f)
 }
 
 // UpdateStoreStatus updates the information of the store.
@@ -333,5 +333,5 @@ type StoreSetController interface {
 	BlockStore(id uint64) error
 	UnblockStore(id uint64)
 
-	AttachOverloadStatus(id uint64, f func() bool)
+	AttachAvailableFunc(id uint64, f func() bool)
 }

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -40,7 +40,7 @@ type StoreInfo struct {
 	lastHeartbeatTS  time.Time
 	leaderWeight     float64
 	regionWeight     float64
-	overloaded       func() bool
+	available        func() bool
 }
 
 // NewStoreInfo creates StoreInfo with meta data.
@@ -71,7 +71,7 @@ func (s *StoreInfo) Clone(opts ...StoreCreateOption) *StoreInfo {
 		lastHeartbeatTS:  s.lastHeartbeatTS,
 		leaderWeight:     s.leaderWeight,
 		regionWeight:     s.regionWeight,
-		overloaded:       s.overloaded,
+		available:        s.available,
 	}
 
 	for _, opt := range opts {
@@ -85,12 +85,12 @@ func (s *StoreInfo) IsBlocked() bool {
 	return s.blocked
 }
 
-// IsOverloaded returns if the store is overloaded.
-func (s *StoreInfo) IsOverloaded() bool {
-	if s.overloaded == nil {
-		return false
+// IsAvailable returns if the store bucket of limitation is available
+func (s *StoreInfo) IsAvailable() bool {
+	if s.available == nil {
+		return true
 	}
-	return s.overloaded()
+	return s.available()
 }
 
 // IsUp checks if the store's state is Up.
@@ -540,10 +540,10 @@ func (s *StoresInfo) UnblockStore(storeID uint64) {
 	s.stores[storeID] = store.Clone(SetStoreUnBlock())
 }
 
-// AttachOverloadStatus attaches the overload status to a store.
-func (s *StoresInfo) AttachOverloadStatus(storeID uint64, f func() bool) {
+// AttachAvailableFunc attaches f to a specific store.
+func (s *StoresInfo) AttachAvailableFunc(storeID uint64, f func() bool) {
 	if store, ok := s.stores[storeID]; ok {
-		s.stores[storeID] = store.Clone(SetOverloadStatus(f))
+		s.stores[storeID] = store.Clone(SetAvailableFunc(f))
 	}
 }
 

--- a/server/core/store_option.go
+++ b/server/core/store_option.go
@@ -138,9 +138,9 @@ func SetStoreStats(stats *pdpb.StoreStats) StoreCreateOption {
 	}
 }
 
-// SetOverloadStatus sets the overload status for the store.
-func SetOverloadStatus(f func() bool) StoreCreateOption {
+// SetAvailableFunc sets a customize function for the store. The function f returns true if the store limit is not exceeded.
+func SetAvailableFunc(f func() bool) StoreCreateOption {
 	return func(store *StoreInfo) {
-		store.overloaded = f
+		store.available = f
 	}
 }

--- a/server/schedule/checker/replica_checker.go
+++ b/server/schedule/checker/replica_checker.go
@@ -48,7 +48,7 @@ func NewReplicaChecker(cluster opt.Cluster, classifier namespace.Classifier, n .
 		name = n[0]
 	}
 	filters := []filter.Filter{
-		filter.NewOverloadFilter(name),
+		filter.NewStoreLimitFilter(name),
 		filter.NewHealthFilter(name),
 		filter.NewSnapshotCountFilter(name),
 		filter.NewPendingPeerCountFilter(name),

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -94,27 +94,27 @@ func (f *excludedFilter) Target(opt opt.Options, store *core.StoreInfo) bool {
 	return ok
 }
 
-type overloadFilter struct{ scope string }
+type storeLimitFilter struct{ scope string }
 
-// NewOverloadFilter creates a Filter that filters all stores that are overloaded from balance.
-func NewOverloadFilter(scope string) Filter {
-	return &overloadFilter{scope: scope}
+// NewStoreLimitFilter creates a Filter that filters all stores those exceed the limit of a store.
+func NewStoreLimitFilter(scope string) Filter {
+	return &storeLimitFilter{scope: scope}
 }
 
-func (f *overloadFilter) Scope() string {
+func (f *storeLimitFilter) Scope() string {
 	return f.scope
 }
 
-func (f *overloadFilter) Type() string {
-	return "overload-filter"
+func (f *storeLimitFilter) Type() string {
+	return "store-limit-filter"
 }
 
-func (f *overloadFilter) Source(opt opt.Options, store *core.StoreInfo) bool {
-	return store.IsOverloaded()
+func (f *storeLimitFilter) Source(opt opt.Options, store *core.StoreInfo) bool {
+	return !store.IsAvailable()
 }
 
-func (f *overloadFilter) Target(opt opt.Options, store *core.StoreInfo) bool {
-	return store.IsOverloaded()
+func (f *storeLimitFilter) Target(opt opt.Options, store *core.StoreInfo) bool {
+	return !store.IsAvailable()
 }
 
 type stateFilter struct{ scope string }
@@ -431,7 +431,7 @@ func (f StoreStateFilter) filterMoveRegion(opt opt.Options, store *core.StoreInf
 		return true
 	}
 
-	if store.IsOverloaded() {
+	if !store.IsAvailable() {
 		return true
 	}
 

--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -736,10 +736,10 @@ func (oc *OperatorController) getOrCreateStoreLimit(storeID uint64) *ratelimit.B
 	if oc.storesLimit[storeID] == nil {
 		rate := oc.cluster.GetStoreBalanceRate() / StoreBalanceBaseTime
 		oc.newStoreLimit(storeID, rate)
-		oc.cluster.AttachOverloadStatus(storeID, func() bool {
+		oc.cluster.AttachAvailableFunc(storeID, func() bool {
 			oc.RLock()
 			defer oc.RUnlock()
-			return oc.storesLimit[storeID].Available() < operator.RegionInfluence
+			return oc.storesLimit[storeID].Available() >= operator.RegionInfluence
 		})
 	}
 	return oc.storesLimit[storeID]


### PR DESCRIPTION
Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

The `overloadFilter` checks if a store has exceeded the store limitation, the word `overload` is too general to describe the feature, so I use `storeLimitFilter` instead.

### What is changed and how it works?
* Rename `overloadFilter` to `storeLimitFilter`
* Change method `IsOverloaded` to `IsAvailable`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

