### PR TITLE
tools: fix panic when using stores show limit

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -985,6 +985,7 @@ func (c *RaftCluster) RemoveTombStoneRecords() error {
 					zap.Error(err))
 				return err
 			}
+			c.coordinator.opController.RemoveStoreLimit(store.GetID())
 			log.Info("delete store successed",
 				zap.Stringer("store", store.GetMeta()))
 		}

--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -758,3 +758,10 @@ func (oc *OperatorController) GetAllStoresLimit() map[uint64]float64 {
 	}
 	return ret
 }
+
+// RemoveStoreLimit removes the store limit for a given store ID.
+func (oc *OperatorController) RemoveStoreLimit(storeID uint64) {
+	oc.Lock()
+	defer oc.Unlock()
+	delete(oc.storesLimit, storeID)
+}

--- a/tests/pdctl/store/store_test.go
+++ b/tests/pdctl/store/store_test.go
@@ -15,6 +15,7 @@ package store_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	. "github.com/pingcap/check"
@@ -168,4 +169,8 @@ func (s *storeTestSuite) TestStore(c *C) {
 	storesInfo = new(api.StoresInfo)
 	c.Assert(json.Unmarshal(output, &storesInfo), IsNil)
 	c.Assert(len([]*api.StoreInfo{storeInfo}), Equals, 1)
+
+	// It should be called after stores remove-tombstone.
+	echo := pdctl.GetEcho([]string{"-u", pdAddr, "stores", "show", "limit"})
+	c.Assert(strings.Contains(echo, "PANIC"), IsFalse)
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
If we firstly use `stores remove-tombstone` and then calling `stores show limit` in `pd-ctl`. It will panic due to the nil pointer.

### What is changed and how it works?
This PR fixes it by removing the store limit when removing a tombstone store.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release notes
