### PR TITLE
Rename store-balance-rate to default-store-limit

### DIFF
--- a/conf/simconfig.toml
+++ b/conf/simconfig.toml
@@ -29,4 +29,4 @@ leader-schedule-limit = 32
 region-schedule-limit = 128
 replica-schedule-limit = 32
 merge-schedule-limit = 32
-store-balance-rate = 512.0
+default-store-limit = 512.0

--- a/pkg/mock/mockoption/mockoption.go
+++ b/pkg/mock/mockoption/mockoption.go
@@ -32,7 +32,7 @@ const (
 	defaultReplicaScheduleLimit        = 64
 	defaultMergeScheduleLimit          = 8
 	defaultHotRegionScheduleLimit      = 4
-	defaultStoreBalanceRate            = 60
+	defaultStoreLimit                  = 64
 	defaultTolerantSizeRatio           = 2.5
 	defaultLowSpaceRatio               = 0.8
 	defaultHighSpaceRatio              = 0.6
@@ -49,7 +49,7 @@ type ScheduleOptions struct {
 	ReplicaScheduleLimit         uint64
 	MergeScheduleLimit           uint64
 	HotRegionScheduleLimit       uint64
-	StoreBalanceRate             float64
+	DefaultStoreLimit            float64
 	MaxSnapshotCount             uint64
 	MaxPendingPeerCount          uint64
 	MaxMergeRegionSize           uint64
@@ -82,7 +82,7 @@ func NewScheduleOptions() *ScheduleOptions {
 	mso.ReplicaScheduleLimit = defaultReplicaScheduleLimit
 	mso.MergeScheduleLimit = defaultMergeScheduleLimit
 	mso.HotRegionScheduleLimit = defaultHotRegionScheduleLimit
-	mso.StoreBalanceRate = defaultStoreBalanceRate
+	mso.DefaultStoreLimit = defaultStoreLimit
 	mso.MaxSnapshotCount = defaultMaxSnapshotCount
 	mso.MaxMergeRegionSize = defaultMaxMergeRegionSize
 	mso.MaxMergeRegionKeys = defaultMaxMergeRegionKeys
@@ -124,9 +124,9 @@ func (mso *ScheduleOptions) GetHotRegionScheduleLimit(name string) uint64 {
 	return mso.HotRegionScheduleLimit
 }
 
-// GetStoreBalanceRate mocks method
-func (mso *ScheduleOptions) GetStoreBalanceRate() float64 {
-	return mso.StoreBalanceRate
+// GetDefaultStoreLimit mocks method
+func (mso *ScheduleOptions) GetDefaultStoreLimit() float64 {
+	return mso.DefaultStoreLimit
 }
 
 // GetMaxSnapshotCount mocks method

--- a/pkg/mock/mockoption/mockoption.go
+++ b/pkg/mock/mockoption/mockoption.go
@@ -32,7 +32,7 @@ const (
 	defaultReplicaScheduleLimit        = 64
 	defaultMergeScheduleLimit          = 8
 	defaultHotRegionScheduleLimit      = 4
-	defaultStoreLimit                  = 64
+	defaultStoreLimit                  = 60
 	defaultTolerantSizeRatio           = 2.5
 	defaultLowSpaceRatio               = 0.8
 	defaultHighSpaceRatio              = 0.6

--- a/server/api/api.raml
+++ b/server/api/api.raml
@@ -73,7 +73,7 @@ types:
       merge-schedule-limit?: integer
       hot-region-schedule-limit?: integer
       hot-region-cache-hits-threshold?: integer
-      store-balance-rate?: number
+      default-store-limit?: number
       tolerant-size-ratio?: number
       low-space-ratio?: number
       high-space-ratio?: number

--- a/server/api/store.go
+++ b/server/api/store.go
@@ -330,7 +330,7 @@ func (h *storeHandler) SetLimit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.SetStoreLimit(storeID, rate/schedule.StoreBalanceBaseTime); err != nil {
+	if err := h.SetStoreLimit(storeID, rate/schedule.StoreLimitBaseTime); err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -383,7 +383,7 @@ func (h *storesHandler) SetAllLimit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.SetAllStoresLimit(rate / schedule.StoreBalanceBaseTime); err != nil {
+	if err := h.SetAllStoresLimit(rate / schedule.StoreLimitBaseTime); err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -401,7 +401,7 @@ func (h *storesHandler) GetAllLimit(w http.ResponseWriter, r *http.Request) {
 	for s, l := range limit {
 		ret[s] = struct {
 			Rate float64 `json:"rate"`
-		}{Rate: l * schedule.StoreBalanceBaseTime}
+		}{Rate: l * schedule.StoreLimitBaseTime}
 	}
 
 	h.rd.JSON(w, http.StatusOK, ret)

--- a/server/api/trend_test.go
+++ b/server/api/trend_test.go
@@ -30,7 +30,7 @@ var _ = Suite(&testTrendSuite{})
 type testTrendSuite struct{}
 
 func (s *testTrendSuite) TestTrend(c *C) {
-	svr, cleanup := mustNewServer(c, func(cfg *config.Config) { cfg.Schedule.StoreBalanceRate = 60 })
+	svr, cleanup := mustNewServer(c, func(cfg *config.Config) { cfg.Schedule.DefaultStoreLimit = 60 })
 	defer cleanup()
 	mustWaitLeader(c, []*server.Server{svr})
 

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -1226,9 +1226,9 @@ func (c *RaftCluster) GetHotRegionScheduleLimit() uint64 {
 	return c.opt.GetHotRegionScheduleLimit(namespace.DefaultNamespace)
 }
 
-// GetStoreBalanceRate returns the balance rate of a store.
-func (c *RaftCluster) GetStoreBalanceRate() float64 {
-	return c.opt.GetStoreBalanceRate()
+// GetDefaultStoreLimit returns the balance rate of a store.
+func (c *RaftCluster) GetDefaultStoreLimit() float64 {
+	return c.opt.GetDefaultStoreLimit()
 }
 
 // GetTolerantSizeRatio gets the tolerant size ratio.

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -656,6 +656,10 @@ func (s *testClusterSuite) TestSetScheduleOpt(c *C) {
 	typ, labelKey, labelValue := "testTyp", "testKey", "testValue"
 	nsConfig := config.NamespaceConfig{LeaderScheduleLimit: uint64(200)}
 
+	// clear the value of StoreBalanceRate otherwise it will
+	// cause an error in "SetScheduleConfig" because the option
+	// is deprecated.
+	scheduleCfg.StoreBalanceRate = 0
 	c.Assert(s.svr.SetScheduleConfig(*scheduleCfg), IsNil)
 	c.Assert(s.svr.SetPDServerConfig(*pdServerCfg), IsNil)
 	c.Assert(s.svr.SetLabelProperty(typ, labelKey, labelValue), IsNil)

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -656,6 +656,10 @@ func (s *testClusterSuite) TestSetScheduleOpt(c *C) {
 	typ, labelKey, labelValue := "testTyp", "testKey", "testValue"
 	nsConfig := config.NamespaceConfig{LeaderScheduleLimit: uint64(200)}
 
+	// store-balance-rate is deprecated, it will cause an deprecated error
+	// if the value is non-zero. TODO, remove the assignment when the fields
+	// is removed
+	scheduleCfg.StoreBalanceRate = 0
 	c.Assert(s.svr.SetScheduleConfig(*scheduleCfg), IsNil)
 	c.Assert(s.svr.SetPDServerConfig(*pdServerCfg), IsNil)
 	c.Assert(s.svr.SetLabelProperty(typ, labelKey, labelValue), IsNil)

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -656,10 +656,6 @@ func (s *testClusterSuite) TestSetScheduleOpt(c *C) {
 	typ, labelKey, labelValue := "testTyp", "testKey", "testValue"
 	nsConfig := config.NamespaceConfig{LeaderScheduleLimit: uint64(200)}
 
-	// clear the value of StoreBalanceRate otherwise it will
-	// cause an error in "SetScheduleConfig" because the option
-	// is deprecated.
-	scheduleCfg.StoreBalanceRate = 0
 	c.Assert(s.svr.SetScheduleConfig(*scheduleCfg), IsNil)
 	c.Assert(s.svr.SetPDServerConfig(*pdServerCfg), IsNil)
 	c.Assert(s.svr.SetLabelProperty(typ, labelKey, labelValue), IsNil)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -696,7 +696,7 @@ func (c *ScheduleConfig) Deprecated() error {
 		return errors.New("disable-raft-learner has already been deprecated")
 	}
 	if c.StoreBalanceRate != 0.0 {
-		return errors.New("store-balance-rate has been deprecated, use default-store-limit instread")
+		return errors.New("store-balance-rate has been deprecated, use default-store-limit instead")
 	}
 	return nil
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -695,9 +695,6 @@ func (c *ScheduleConfig) Deprecated() error {
 	if c.DisableLearner {
 		return errors.New("disable-raft-learner has already been deprecated")
 	}
-	if c.StoreBalanceRate != 0.0 {
-		return errors.New("store-balance-rate has been deprecated, use default-store-limit instead")
-	}
 	return nil
 }
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -507,9 +507,9 @@ type ScheduleConfig struct {
 	// threshold, it is considered a hot region.
 	HotRegionCacheHitsThreshold uint64 `toml:"hot-region-cache-hits-threshold,omitempty" json:"hot-region-cache-hits-threshold"`
 	// StoreBalanceRate is deprecated, use DefaultStoreLimit instead.
-	StoreBalanceRate float64 `toml:"store-balance-rate,omitempty" json:"store-balance-rate"`
+	StoreBalanceRate float64 `toml:"store-balance-rate,omitempty" json:"store-balance-rate,omitempty"`
 	// DefaultStoreLimit limits the number of operators to be executed per minute for each store.
-	DefaultStoreLimit float64 `toml:"default-store-limit,omitempty" json:"default-store-limit"`
+	DefaultStoreLimit float64 `toml:"default-store-limit,omitempty" json:"default-store-limit,omitempty"`
 	// TolerantSizeRatio is the ratio of buffer size for balance scheduler.
 	TolerantSizeRatio float64 `toml:"tolerant-size-ratio,omitempty" json:"tolerant-size-ratio"`
 	//
@@ -657,9 +657,7 @@ func (c *ScheduleConfig) adjust(meta *configMetaData) error {
 		c.DefaultStoreLimit = c.StoreBalanceRate
 	}
 	adjustFloat64(&c.DefaultStoreLimit, defaultStoreLimit)
-	// set c.StoreBalanceRate to ensure compatibility in case of the users
-	// fetch and use store-blance-rate from the api or command line.
-	c.StoreBalanceRate = c.DefaultStoreLimit
+	c.StoreBalanceRate = 0
 
 	adjustFloat64(&c.LowSpaceRatio, defaultLowSpaceRatio)
 	adjustFloat64(&c.HighSpaceRatio, defaultHighSpaceRatio)
@@ -694,6 +692,9 @@ func (c *ScheduleConfig) Validate() error {
 func (c *ScheduleConfig) Deprecated() error {
 	if c.DisableLearner {
 		return errors.New("disable-raft-learner has already been deprecated")
+	}
+	if c.StoreBalanceRate > 0 {
+		return errors.New("store-balance-rate is deprecated, use default-store-limit instead")
 	}
 	return nil
 }

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -197,7 +197,7 @@ func newTestScheduleOption() (*ScheduleOption, error) {
 	return opt, nil
 }
 
-func (s *testConfigSuite) TestDefaultStoreLimit_Upgrading(c *C) {
+func (s *testConfigSuite) TestDefaultStoreLimitUpgrade(c *C) {
 	var cfgData = `
 	[schedule]
 	store-balance-rate = 128.0
@@ -218,7 +218,7 @@ func (s *testConfigSuite) TestDefaultStoreLimit_Upgrading(c *C) {
 	c.Assert(conf.Schedule.StoreBalanceRate, Equals, 128.0)
 }
 
-func (s *testConfigSuite) TestDefaultStoreLimit_Overwrite(c *C) {
+func (s *testConfigSuite) TestDefaultStoreLimitOverwrite(c *C) {
 	var cfgData = `
 	[schedule]
 	store-balance-rate = 128.0

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -215,7 +215,7 @@ func (s *testConfigSuite) TestDefaultStoreLimitUpgrade(c *C) {
 	// After adjusting, default-store-limit has the save value of store-blance-rate
 	c.Assert(conf.Adjust(&meta), IsNil)
 	c.Assert(conf.Schedule.DefaultStoreLimit, Equals, 128.0)
-	c.Assert(conf.Schedule.StoreBalanceRate, Equals, 128.0)
+	c.Assert(conf.Schedule.StoreBalanceRate, Equals, 0.0)
 }
 
 func (s *testConfigSuite) TestDefaultStoreLimitOverwrite(c *C) {
@@ -237,5 +237,22 @@ func (s *testConfigSuite) TestDefaultStoreLimitOverwrite(c *C) {
 	// After adjusting, default-store-limit overwrites store-balance-rate
 	c.Assert(conf.Adjust(&meta), IsNil)
 	c.Assert(conf.Schedule.DefaultStoreLimit, Equals, 256.0)
-	c.Assert(conf.Schedule.StoreBalanceRate, Equals, 256.0)
+	c.Assert(conf.Schedule.StoreBalanceRate, Equals, 0.0)
+}
+
+func (s *testConfigSuite) TestDefaultStoreLimitPersist(c *C) {
+	opt, err := newTestScheduleOption()
+	c.Assert(err, IsNil)
+	storage := core.NewStorage(kv.NewMemoryKV())
+	scheduleCfg := opt.Load()
+	scheduleCfg.StoreBalanceRate = 10.0
+	scheduleCfg.DefaultStoreLimit = 0.0
+	c.Assert(opt.Persist(storage), IsNil)
+
+	newOpt, err := newTestScheduleOption()
+	c.Assert(err, IsNil)
+	c.Assert(newOpt.Reload(storage), IsNil)
+	scheduleCfg = newOpt.Load()
+	c.Assert(scheduleCfg.DefaultStoreLimit, Equals, 10.0)
+	c.Assert(scheduleCfg.StoreBalanceRate, Equals, 0.0)
 }

--- a/server/config/option.go
+++ b/server/config/option.go
@@ -210,9 +210,9 @@ func (o *ScheduleOption) GetHotRegionScheduleLimit(name string) uint64 {
 	return o.Load().HotRegionScheduleLimit
 }
 
-// GetStoreBalanceRate returns the balance rate of a store.
-func (o *ScheduleOption) GetStoreBalanceRate() float64 {
-	return o.Load().StoreBalanceRate
+// GetDefaultStoreLimit returns the default store limit.
+func (o *ScheduleOption) GetDefaultStoreLimit() float64 {
+	return o.Load().DefaultStoreLimit
 }
 
 // GetTolerantSizeRatio gets the tolerant size ratio.

--- a/server/config/option.go
+++ b/server/config/option.go
@@ -443,6 +443,17 @@ func (o *ScheduleOption) adjustScheduleCfg(persistentCfg *Config) {
 	}
 	scheduleCfg.Schedulers = append(scheduleCfg.Schedulers, restoredSchedulers...)
 	persistentCfg.Schedule.Schedulers = scheduleCfg.Schedulers
+
+	// the first time load from an old version
+	if persistentCfg.Schedule.DefaultStoreLimit ==
+		scheduleCfg.DefaultStoreLimit &&
+		persistentCfg.Schedule.StoreBalanceRate != 0 {
+		persistentCfg.Schedule.DefaultStoreLimit = persistentCfg.Schedule.StoreBalanceRate
+		scheduleCfg.DefaultStoreLimit = persistentCfg.Schedule.DefaultStoreLimit
+
+		persistentCfg.Schedule.StoreBalanceRate = 0
+		scheduleCfg.StoreBalanceRate = 0
+	}
 	o.Store(scheduleCfg)
 }
 

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -42,7 +42,7 @@ import (
 func newTestScheduleConfig() (*config.ScheduleConfig, *config.ScheduleOption, error) {
 	cfg := config.NewConfig()
 	cfg.Schedule.TolerantSizeRatio = 5
-	cfg.Schedule.StoreBalanceRate = 60
+	cfg.Schedule.DefaultStoreLimit = 60
 	if err := cfg.Adjust(nil); err != nil {
 		return nil, nil, err
 	}

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -795,7 +795,7 @@ func (s *testOperatorControllerSuite) TestStoreOverloaded(c *C) {
 	cfg, opt, err := newTestScheduleConfig()
 	c.Assert(cfg, NotNil)
 	c.Assert(err, IsNil)
-	cfg.StoreBalanceRate = 10
+	cfg.DefaultStoreLimit = 10
 	tc := newTestCluster(opt)
 	hbStreams, cleanup := getHeartBeatStreams(c, tc)
 	defer cleanup()
@@ -830,7 +830,7 @@ func (s *testOperatorControllerSuite) TestStoreOverloadedWithReplace(c *C) {
 	cfg, opt, err := newTestScheduleConfig()
 	c.Assert(cfg, NotNil)
 	c.Assert(err, IsNil)
-	cfg.StoreBalanceRate = 10
+	cfg.DefaultStoreLimit = 10
 	tc := newTestCluster(opt)
 	hbStreams, cleanup := getHeartBeatStreams(c, tc)
 	defer cleanup()

--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -47,8 +47,8 @@ var (
 	fastNotifyInterval = 2 * time.Second
 	// PushOperatorTickInterval is the interval try to push the operator.
 	PushOperatorTickInterval = 500 * time.Millisecond
-	// StoreBalanceBaseTime represents the base time of balance rate.
-	StoreBalanceBaseTime float64 = 60
+	// StoreLimitBaseTime represents the base time of store-limit.
+	StoreLimitBaseTime float64 = 60
 )
 
 // HeartbeatStreams is an interface of async region heartbeat.
@@ -734,7 +734,7 @@ func (oc *OperatorController) newStoreLimit(storeID uint64, rate float64) {
 // getOrCreateStoreLimit is used to get or create the limit of a store.
 func (oc *OperatorController) getOrCreateStoreLimit(storeID uint64) *ratelimit.Bucket {
 	if oc.storesLimit[storeID] == nil {
-		rate := oc.cluster.GetStoreBalanceRate() / StoreBalanceBaseTime
+		rate := oc.cluster.GetDefaultStoreLimit() / StoreLimitBaseTime
 		oc.newStoreLimit(storeID, rate)
 		oc.cluster.AttachAvailableFunc(storeID, func() bool {
 			oc.RLock()

--- a/server/schedule/operator_controller_test.go
+++ b/server/schedule/operator_controller_test.go
@@ -420,7 +420,7 @@ func (t *testOperatorControllerSuite) TestStoreLimitWithMerge(c *C) {
 	oc := NewOperatorController(tc, mockhbstream.NewHeartbeatStream())
 
 	cfg.SplitMergeInterval = time.Hour
-	cfg.StoreBalanceRate = 60
+	cfg.DefaultStoreLimit = 60
 
 	regions[2] = regions[2].Clone(
 		core.SetPeers([]*metapb.Peer{

--- a/server/schedule/opt/opts.go
+++ b/server/schedule/opt/opts.go
@@ -31,7 +31,7 @@ type Options interface {
 	GetHotRegionScheduleLimit() uint64
 
 	// store limit
-	GetStoreBalanceRate() float64
+	GetDefaultStoreLimit() float64
 
 	GetMaxSnapshotCount() uint64
 	GetMaxPendingPeerCount() uint64

--- a/server/statistics/schedule_options.go
+++ b/server/statistics/schedule_options.go
@@ -23,7 +23,7 @@ type ScheduleOptions interface {
 	GetLowSpaceRatio() float64
 	GetHighSpaceRatio() float64
 	GetTolerantSizeRatio() float64
-	GetStoreBalanceRate() float64
+	GetDefaultStoreLimit() float64
 
 	GetSchedulerMaxWaitingOperator() uint64
 	GetLeaderScheduleLimit(name string) uint64

--- a/server/statistics/store_collection.go
+++ b/server/statistics/store_collection.go
@@ -140,7 +140,7 @@ func (s *storeStatistics) Collect() {
 	configs["high-space-ratio"] = float64(s.opt.GetHighSpaceRatio())
 	configs["low-space-ratio"] = float64(s.opt.GetLowSpaceRatio())
 	configs["tolerant-size-ratio"] = float64(s.opt.GetTolerantSizeRatio())
-	configs["store-balance-rate"] = float64(s.opt.GetStoreBalanceRate())
+	configs["default-store-limit"] = float64(s.opt.GetDefaultStoreLimit())
 	configs["hot-region-schedule-limit"] = float64(s.opt.GetHotRegionScheduleLimit(s.namespace))
 	configs["hot-region-cache-hits-threshold"] = float64(s.opt.GetHotRegionCacheHitsThreshold())
 	configs["max-pending-peer-count"] = float64(s.opt.GetMaxPendingPeerCount())

--- a/tests/pdctl/operator/operator_test.go
+++ b/tests/pdctl/operator/operator_test.go
@@ -48,7 +48,7 @@ func (s *operatorTestSuite) TestOperator(c *C) {
 	cluster, err := tests.NewTestCluster(1,
 		func(conf *config.Config) { conf.Replication.MaxReplicas = 2 },
 		func(conf *config.Config) { conf.Schedule.MaxStoreDownTime.Duration = time.Since(t) },
-		func(conf *config.Config) { conf.Schedule.StoreBalanceRate = 240 },
+		func(conf *config.Config) { conf.Schedule.DefaultStoreLimit = 240 },
 	)
 	c.Assert(err, IsNil)
 	err = cluster.RunInitialServers()

--- a/tools/pd-ctl/README.md
+++ b/tools/pd-ctl/README.md
@@ -146,7 +146,7 @@ Usage:
       }
     ],
     "split-merge-interval": "1h0m0s",
-    "store-balance-rate": 1,
+    "default-store-limit": 1,
     "tolerant-size-ratio": 0
   }
 }


### PR DESCRIPTION
Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

Rename `store-balance-rate` to `default-store-limit` which is more friendly to users.

### What is changed and how it works?
* Rename the configration option
* Rename the related function names

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has configuration change

Related changes

 - Need to update the documentation

