### PR TITLE
checker: transfer leader first when offline a store

### DIFF
--- a/server/schedule/checker/replica_checker.go
+++ b/server/schedule/checker/replica_checker.go
@@ -29,6 +29,11 @@ import (
 
 const replicaCheckerName = "replica-checker"
 
+const (
+	offlineStatus = "offline"
+	downStatus    = "down"
+)
+
 // ReplicaChecker ensures region has the best replicas.
 // Including the following:
 // Replica number management.
@@ -185,7 +190,7 @@ func (r *ReplicaChecker) checkDownPeer(region *core.RegionInfo) *operator.Operat
 			continue
 		}
 
-		return r.fixPeer(region, peer, "down")
+		return r.fixPeer(region, peer, downStatus)
 	}
 	return nil
 }
@@ -211,7 +216,7 @@ func (r *ReplicaChecker) checkOfflinePeer(region *core.RegionInfo) *operator.Ope
 			continue
 		}
 
-		return r.fixPeer(region, peer, "offline")
+		return r.fixPeer(region, peer, offlineStatus)
 	}
 
 	return nil
@@ -277,7 +282,12 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, peer *metapb.Peer, sta
 	}
 
 	replace := fmt.Sprintf("replace-%s-replica", status)
-	op, err := operator.CreateMovePeerOperator(replace, r.cluster, region, operator.OpReplica, peer.GetStoreId(), newPeer.GetStoreId(), newPeer.GetId())
+	var op *operator.Operator
+	if status == offlineStatus {
+		op, err = operator.CreateOfflinePeerOperator(replace, r.cluster, region, operator.OpReplica, peer.GetStoreId(), newPeer.GetStoreId(), newPeer.GetId())
+	} else {
+		op, err = operator.CreateMovePeerOperator(replace, r.cluster, region, operator.OpReplica, peer.GetStoreId(), newPeer.GetStoreId(), newPeer.GetId())
+	}
 	if err != nil {
 		reason := fmt.Sprintf("%s-fail", replace)
 		checkerCounter.WithLabelValues("replica_checker", reason).Inc()

--- a/server/schedule/operator/operator.go
+++ b/server/schedule/operator/operator.go
@@ -890,6 +890,20 @@ func CreateMovePeerOperator(desc string, cluster Cluster, region *core.RegionInf
 	return NewOperator(desc, brief, region.GetID(), region.GetRegionEpoch(), removeKind|kind|OpRegion, steps...), nil
 }
 
+// CreateOfflinePeerOperator creates an operator that replaces an old peer with a new peer when offline a store.
+func CreateOfflinePeerOperator(desc string, cluster Cluster, region *core.RegionInfo, kind OpKind, oldStore, newStore uint64, peerID uint64) (*Operator, error) {
+	k, steps, err := transferLeaderStep(cluster, region, oldStore, append(getRegionFollowerIDs(region)))
+	if err != nil {
+		return nil, err
+	}
+	kind |= k
+	st := CreateAddPeerSteps(newStore, peerID)
+	steps = append(steps, st...)
+	steps = append(steps, RemovePeer{FromStore: oldStore})
+	brief := fmt.Sprintf("mv peer: store %v to %v", oldStore, newStore)
+	return NewOperator(desc, brief, region.GetID(), region.GetRegionEpoch(), kind|OpRegion, steps...), nil
+}
+
 // CreateMoveLeaderOperator creates an operator that replaces an old leader with a new leader.
 func CreateMoveLeaderOperator(desc string, cluster Cluster, region *core.RegionInfo, kind OpKind, oldStore, newStore uint64, peerID uint64) (*Operator, error) {
 	removeKind, steps, err := removePeerSteps(cluster, region, oldStore, []uint64{newStore})
@@ -925,15 +939,24 @@ func getRegionFollowerIDs(region *core.RegionInfo) []uint64 {
 
 // removePeerSteps returns the steps to safely remove a peer. It prevents removing leader by transfer its leadership first.
 func removePeerSteps(cluster Cluster, region *core.RegionInfo, storeID uint64, followerIDs []uint64) (kind OpKind, steps []OpStep, err error) {
+	kind, steps, err = transferLeaderStep(cluster, region, storeID, followerIDs)
+	if err != nil {
+		return
+	}
+
+	steps = append(steps, RemovePeer{FromStore: storeID})
+	kind |= OpRegion
+	return
+}
+
+func transferLeaderStep(cluster Cluster, region *core.RegionInfo, storeID uint64, followerIDs []uint64) (kind OpKind, steps []OpStep, err error) {
 	if region.GetLeader() != nil && region.GetLeader().GetStoreId() == storeID {
 		kind, steps, err = transferLeaderToSuitableSteps(cluster, storeID, followerIDs)
 		if err != nil {
-			log.Debug("failed to create remove peer operator", zap.Uint64("region-id", region.GetID()), zap.Error(err))
+			log.Debug("failed to create transfer leader step", zap.Uint64("region-id", region.GetID()), zap.Error(err))
 			return
 		}
 	}
-	steps = append(steps, RemovePeer{FromStore: storeID})
-	kind |= OpRegion
 	return
 }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
See #1720.

### What is changed and how it works?
This PR adds `CreateOfflinePeerOperator` to accelerate the offline speed.

- [ ] need manually test

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test