### PR TITLE
*: make random region tests more stable

### DIFF
--- a/server/core/region_tree_test.go
+++ b/server/core/region_tree_test.go
@@ -321,7 +321,7 @@ func (s *testRegionSuite) TestRandomRegionDiscontinuous(c *C) {
 
 func checkRandomRegion(c *C, tree *regionTree, regions []*RegionInfo, startKey, endKey []byte) {
 	keys := make(map[string]struct{})
-	for i := 1; i < 50; i++ {
+	for i := 0; i < 10000 && len(keys) < len(regions); i++ {
 		re := tree.RandomRegion(startKey, endKey)
 		c.Assert(re, NotNil)
 		k := string(re.GetStartKey())

--- a/server/core/region_tree_test.go
+++ b/server/core/region_tree_test.go
@@ -321,7 +321,7 @@ func (s *testRegionSuite) TestRandomRegionDiscontinuous(c *C) {
 
 func checkRandomRegion(c *C, tree *regionTree, regions []*RegionInfo, startKey, endKey []byte) {
 	keys := make(map[string]struct{})
-	for i := 1; i < 20; i++ {
+	for i := 1; i < 50; i++ {
 		re := tree.RandomRegion(startKey, endKey)
 		c.Assert(re, NotNil)
 		k := string(re.GetStartKey())


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
The current random region related tests are not stable enough. We have met some failures due to the `checkRandomRegion`

### What is changed and how it works?
This PR enlarges the loop count to reduce the possibility of failure.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test (manually run 1000 times)