### PR TITLE
api: add used size for store api

### DIFF
--- a/server/api/store.go
+++ b/server/api/store.go
@@ -42,6 +42,7 @@ type MetaStore struct {
 type StoreStatus struct {
 	Capacity           typeutil.ByteSize  `json:"capacity,omitempty"`
 	Available          typeutil.ByteSize  `json:"available,omitempty"`
+	UsedSize           typeutil.ByteSize  `json:"used_size,omitempty"`
 	LeaderCount        int                `json:"leader_count,omitempty"`
 	LeaderWeight       float64            `json:"leader_weight,omitempty"`
 	LeaderScore        float64            `json:"leader_score,omitempty"`
@@ -79,6 +80,7 @@ func newStoreInfo(opt *config.ScheduleConfig, store *core.StoreInfo) *StoreInfo 
 		Status: &StoreStatus{
 			Capacity:           typeutil.ByteSize(store.GetCapacity()),
 			Available:          typeutil.ByteSize(store.GetAvailable()),
+			UsedSize:           typeutil.ByteSize(store.GetUsedSize()),
 			LeaderCount:        store.GetLeaderCount(),
 			LeaderWeight:       store.GetLeaderWeight(),
 			LeaderScore:        store.LeaderScore(opt.GetLeaderScheduleStrategy(), 0),


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Add used size for store api. 

### What is changed and how it works?
The actual used size can't be deduced by `Capacity - Available` due to disk may be occupied by other applications.

### Check List <!--REMOVE the items that are not applicable-->
 - No code