### PR TITLE
client.go: Degrade log level when passing unavailable endpoint to client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -197,7 +197,7 @@ func (c *client) initClusterID() error {
 		members, err := c.getMembers(timeoutCtx, u)
 		timeoutCancel()
 		if err != nil || members.GetHeader() == nil {
-			log.Error("[pd] failed to get cluster id", zap.Error(err))
+			log.Warn("[pd] failed to get cluster id", zap.String("url", u), zap.Error(err))
 			continue
 		}
 		c.clusterID = members.GetHeader().GetClusterId()


### PR DESCRIPTION


<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
when some endpoint passing into the client is unavailable
in calling NewClient() will log the error log, but the service is
supported to be still available if one of the endpoints can work.
error level log will be too serious and confuse the user.

### What is changed and how it works?
client.go: Degrade log level when passing unavailable endpoint to client

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)
log after this pr:
```
[2019/10/28 18:51:04.975 +08:00] [INFO] [client.go:144] ["[pd] create pd client with endpoints"] [pd-address="[localhost:9999,localhost:2379]"]
[2019/10/28 18:51:04.987 +08:00] [WARN] [client.go:200] ["[pd] failed to get cluster id"] [url=http://localhost:9999] [error="rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = \"transport: Error while dialing dial tcp [::1]:9999: connect: connection refused\""] [errorVerbose="rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = \"transport: Error while dialing dial tcp [::1]:9999: connect: connection refused\"\ngithub.com/pingcap/pd/client.(*client).getMembers\n\t/Users/huangjiahao/go/pkg/mod/github.com/july2993/pd@v1.1.0-beta.0.20191028103916-ec504e3dce8f/client/client.go:235\ngithub.com/pingcap/pd/client.(*client).initClusterID\n\t/Users/huangjiahao/go/pkg/mod/github.com/july2993/pd@v1.1.0-beta.0.20191028103916-ec504e3dce8f/client/client.go:197\ngithub.com/pingcap/pd/client.(*client).initRetry\n\t/Users/huangjiahao/go/pkg/mod/github.com/july2993/pd@v1.1.0-beta.0.20191028103916-ec504e3dce8f/client/client.go:184\ngithub.com/pingcap/pd/client.NewClient\n\t/Users/huangjiahao/go/pkg/mod/github.com/july2993/pd@v1.1.0-beta.0.20191028103916-ec504e3dce8f/client/client.go:157\nmain.main\n\t/Users/huangjiahao/go/src/github.com/pingcap/tidb-binlog/cmd/pd.go:10\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:203\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1357"]
[2019/10/28 18:51:04.994 +08:00] [INFO] [client.go:252] ["[pd] switch leader"] [new-leader=http://127.0.0.1:2379] [old-leader=]
[2019/10/28 18:51:04.994 +08:00] [INFO] [client.go:163] ["[pd] init cluster id"] [cluster-id=6752802479515318396]
```
 

Code changes


Side effects



Related changes

 - Need to cherry-pick to the release branch

