### PR TITLE
*: add a log when getting timestamps are too slow

### DIFF
--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -87,6 +87,11 @@ func (s *Server) Tso(stream pdpb.PD_TsoServer) error {
 		if err != nil {
 			return status.Errorf(codes.Unknown, err.Error())
 		}
+
+		elapsed := time.Since(start)
+		if elapsed > time.Second {
+			log.Warn("get timestamp too slow", zap.Duration("cost", elapsed))
+		}
 		response := &pdpb.TsoResponse{
 			Header:    s.header(),
 			Timestamp: &ts,

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -31,7 +31,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-//revive:disable:unused-parameter
+const slowThreshold = 5 * time.Millisecond
 
 // notLeaderError is returned when current server is not the leader and not possible to process request.
 // TODO: work as proxy.
@@ -89,7 +89,7 @@ func (s *Server) Tso(stream pdpb.PD_TsoServer) error {
 		}
 
 		elapsed := time.Since(start)
-		if elapsed > time.Millisecond {
+		if elapsed > slowThreshold {
 			log.Warn("get timestamp too slow", zap.Duration("cost", elapsed))
 		}
 		response := &pdpb.TsoResponse{

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -89,7 +89,7 @@ func (s *Server) Tso(stream pdpb.PD_TsoServer) error {
 		}
 
 		elapsed := time.Since(start)
-		if elapsed > time.Second {
+		if elapsed > time.Millisecond {
 			log.Warn("get timestamp too slow", zap.Duration("cost", elapsed))
 		}
 		response := &pdpb.TsoResponse{


### PR DESCRIPTION
# What problem does this PR solve? <!--add the issue link with summary if it exists-->
To make clear about whether the server is slow or the network is slow when getting timestamps.

### What is changed and how it works?
This PR will print a log when the cost time of getting timestamps is more than one second.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
