### PR TITLE
server: merge status_address/git_hash fields of store meta

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8
 	github.com/pingcap/errcode v0.0.0-20180921232412-a1a7271709d9
 	github.com/pingcap/failpoint v0.0.0-20190512135322-30cc7431d99c
-	github.com/pingcap/kvproto v0.0.0-20191008063951-7a367e846b9f
+	github.com/pingcap/kvproto v0.0.0-20191030021250-51b332bcb20b
 	github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/pingcap/failpoint v0.0.0-20190512135322-30cc7431d99c h1:hvQd3aOLKLF7x
 github.com/pingcap/failpoint v0.0.0-20190512135322-30cc7431d99c/go.mod h1:DNS3Qg7bEDhU6EXNHF+XSv/PGznQaMJ5FWvctpm6pQI=
 github.com/pingcap/kvproto v0.0.0-20191008063951-7a367e846b9f h1:3yDrWq+gwV+MinP4HtEEntxsJnLDhTn3MgRIYWubGjA=
 github.com/pingcap/kvproto v0.0.0-20191008063951-7a367e846b9f/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
+github.com/pingcap/kvproto v0.0.0-20191030021250-51b332bcb20b h1:ftvwDk/eXlpQkQoZdJfkrSGJiyPWohyfkFcpHlChaK8=
+github.com/pingcap/kvproto v0.0.0-20191030021250-51b332bcb20b/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd h1:hWDol43WY5PGhsh3+8794bFHY1bPrmu6bTalpssCrGg=
 github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,6 @@ github.com/pingcap/errors v0.11.0 h1:DCJQB8jrHbQ1VVlMFIrbj2ApScNNotVmkSNplu2yUt4
 github.com/pingcap/errors v0.11.0/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/failpoint v0.0.0-20190512135322-30cc7431d99c h1:hvQd3aOLKLF7xvRV6DzvPkKY4QXzfVbjU1BhW0d9yL8=
 github.com/pingcap/failpoint v0.0.0-20190512135322-30cc7431d99c/go.mod h1:DNS3Qg7bEDhU6EXNHF+XSv/PGznQaMJ5FWvctpm6pQI=
-github.com/pingcap/kvproto v0.0.0-20191008063951-7a367e846b9f h1:3yDrWq+gwV+MinP4HtEEntxsJnLDhTn3MgRIYWubGjA=
-github.com/pingcap/kvproto v0.0.0-20191008063951-7a367e846b9f/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
 github.com/pingcap/kvproto v0.0.0-20191030021250-51b332bcb20b h1:ftvwDk/eXlpQkQoZdJfkrSGJiyPWohyfkFcpHlChaK8=
 github.com/pingcap/kvproto v0.0.0-20191030021250-51b332bcb20b/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd h1:hWDol43WY5PGhsh3+8794bFHY1bPrmu6bTalpssCrGg=

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -779,8 +779,8 @@ func (c *RaftCluster) putStore(store *metapb.Store) error {
 		labels := s.MergeLabels(store.GetLabels())
 
 		s = s.Clone(
-			core.SetStoreAddress(store.Address, store.PeerAddress),
-			core.SetStoreVersion(store.Version),
+			core.SetStoreAddress(store.Address, store.StatusAddress, store.PeerAddress),
+			core.SetStoreVersion(store.GitHash, store.Version),
 			core.SetStoreLabels(labels),
 		)
 	}

--- a/server/core/store_option.go
+++ b/server/core/store_option.go
@@ -25,10 +25,11 @@ import (
 type StoreCreateOption func(region *StoreInfo)
 
 // SetStoreAddress sets the address for the store.
-func SetStoreAddress(address, peerAddress string) StoreCreateOption {
+func SetStoreAddress(address, statusAddress, peerAddress string) StoreCreateOption {
 	return func(store *StoreInfo) {
 		meta := proto.Clone(store.meta).(*metapb.Store)
 		meta.Address = address
+		meta.StatusAddress = statusAddress
 		meta.PeerAddress = peerAddress
 		store.meta = meta
 	}
@@ -44,10 +45,11 @@ func SetStoreLabels(labels []*metapb.StoreLabel) StoreCreateOption {
 }
 
 // SetStoreVersion sets the version for the store.
-func SetStoreVersion(version string) StoreCreateOption {
+func SetStoreVersion(githash, version string) StoreCreateOption {
 	return func(store *StoreInfo) {
 		meta := proto.Clone(store.meta).(*metapb.Store)
 		meta.Version = version
+		meta.GitHash = githash
 		store.meta = meta
 	}
 }


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

The TiKV uses `status_address` to provide HTTP service for external components. But the original store metadata does not contain the `status_address` and `git_hash` information, so the TiDB cannot get the `status_address` from PD via `GetAllStores` gRPC interface. Furthermore, TiDB cannot use the HTTP service provided by TiKV.

This PR adds the support that reports the status_address and git_hash to PD on TiKV startup to make subsequent work easier.

Related change: 
- https://github.com/pingcap/kvproto/pull/481
- https://github.com/tikv/tikv/pull/5760
