### PR TITLE
core: refactor random region

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -633,6 +633,11 @@ func (c *RaftCluster) RandPendingRegion(storeID uint64, opts ...core.RegionOptio
 	return c.core.RandPendingRegion(storeID, opts...)
 }
 
+// RandLearnerRegion returns a random region that has a learner peer on the store.
+func (c *RaftCluster) RandLearnerRegion(storeID uint64, opts ...core.RegionOption) *core.RegionInfo {
+	return c.core.RandLearnerRegion(storeID, opts...)
+}
+
 // RandHotRegionFromStore randomly picks a hot region in specified store.
 func (c *RaftCluster) RandHotRegionFromStore(store uint64, kind statistics.FlowKind) *core.RegionInfo {
 	c.RLock()

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -134,12 +134,18 @@ func (*testRegionKey) TestRegionKey(c *C) {
 func BenchmarkRandomRegion(b *testing.B) {
 	regions := NewRegionsInfo()
 	for i := 0; i < 5000000; i++ {
-		item := &RegionInfo{meta: &metapb.Region{StartKey: []byte(fmt.Sprintf("%20d", i)), EndKey: []byte(fmt.Sprintf("%20d", i+1))}}
-		regions.AddRegion(item)
+		peer := &metapb.Peer{StoreId: 1, Id: uint64(i + 1)}
+		region := NewRegionInfo(&metapb.Region{
+			Id:       uint64(i + 1),
+			Peers:    []*metapb.Peer{peer},
+			StartKey: []byte(fmt.Sprintf("%20d", i)),
+			EndKey:   []byte(fmt.Sprintf("%20d", i+1)),
+		}, peer)
+		regions.AddRegion(region)
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		regions.RandRegion()
+		regions.RandLeaderRegion(1)
 	}
 }
 

--- a/server/schedule/range_cluster.go
+++ b/server/schedule/range_cluster.go
@@ -23,7 +23,7 @@ import (
 // RangeCluster isolates the cluster by range.
 type RangeCluster struct {
 	opt.Cluster
-	subCluster        *core.BasicCluster
+	subCluster        *core.BasicCluster // Collect all regions belong to the range.
 	tolerantSizeRatio float64
 }
 

--- a/server/schedule/range_cluster.go
+++ b/server/schedule/range_cluster.go
@@ -23,7 +23,7 @@ import (
 // RangeCluster isolates the cluster by range.
 type RangeCluster struct {
 	opt.Cluster
-	regions           *core.RegionsInfo
+	subCluster        *core.BasicCluster
 	tolerantSizeRatio float64
 }
 
@@ -32,13 +32,13 @@ const scanLimit = 128
 // GenRangeCluster gets a range cluster by specifying start key and end key.
 // The cluster can only know the regions within [startKey, endKey].
 func GenRangeCluster(cluster opt.Cluster, startKey, endKey []byte) *RangeCluster {
-	regions := core.NewRegionsInfo()
+	subCluster := core.NewBasicCluster()
 	for _, r := range cluster.ScanRegions(startKey, endKey, -1) {
-		regions.AddRegion(r)
+		subCluster.Regions.AddRegion(r)
 	}
 	return &RangeCluster{
-		Cluster: cluster,
-		regions: regions,
+		Cluster:    cluster,
+		subCluster: subCluster,
 	}
 }
 
@@ -50,11 +50,11 @@ func (r *RangeCluster) updateStoreInfo(s *core.StoreInfo) *core.StoreInfo {
 		return s
 	}
 	amplification := float64(s.GetRegionSize()) / used
-	leaderCount := r.regions.GetStoreLeaderCount(id)
-	leaderSize := r.regions.GetStoreLeaderRegionSize(id)
-	regionCount := r.regions.GetStoreRegionCount(id)
-	regionSize := r.regions.GetStoreRegionSize(id)
-	pendingPeerCount := r.regions.GetStorePendingPeerCount(id)
+	leaderCount := r.subCluster.GetStoreLeaderCount(id)
+	leaderSize := r.subCluster.GetStoreLeaderRegionSize(id)
+	regionCount := r.subCluster.GetStoreRegionCount(id)
+	regionSize := r.subCluster.GetStoreRegionSize(id)
+	pendingPeerCount := r.subCluster.GetStorePendingPeerCount(id)
 	newStats := proto.Clone(s.GetStoreStats()).(*pdpb.StoreStats)
 	newStats.UsedSize = uint64(float64(regionSize)/amplification) * (1 << 20)
 	newStats.Available = s.GetCapacity() - newStats.UsedSize
@@ -103,17 +103,17 @@ func (r *RangeCluster) GetTolerantSizeRatio() float64 {
 
 // RandFollowerRegion returns a random region that has a follower on the store.
 func (r *RangeCluster) RandFollowerRegion(storeID uint64, opts ...core.RegionOption) *core.RegionInfo {
-	return r.regions.RandFollowerRegion(storeID, opts...)
+	return r.subCluster.RandFollowerRegion(storeID, opts...)
 }
 
 // RandLeaderRegion returns a random region that has leader on the store.
 func (r *RangeCluster) RandLeaderRegion(storeID uint64, opts ...core.RegionOption) *core.RegionInfo {
-	return r.regions.RandLeaderRegion(storeID, opts...)
+	return r.subCluster.RandLeaderRegion(storeID, opts...)
 }
 
 // GetAverageRegionSize returns the average region approximate size.
 func (r *RangeCluster) GetAverageRegionSize() int64 {
-	return r.regions.GetAverageRegionSize()
+	return r.subCluster.GetAverageRegionSize()
 }
 
 // GetRegionStores returns all stores that contains the region's peer.

--- a/tools/pd-simulator/simulator/drive.go
+++ b/tools/pd-simulator/simulator/drive.go
@@ -160,7 +160,7 @@ func (d *Driver) TickCount() int64 {
 
 // GetBootstrapInfo returns a valid bootstrap store and region.
 func (d *Driver) GetBootstrapInfo(r *RaftEngine) (*metapb.Store, *metapb.Region, error) {
-	origin := r.RandRegion()
+	origin := r.BootstrapRegion()
 	if origin == nil {
 		return nil, nil, errors.New("no region found for bootstrap")
 	}

--- a/tools/pd-simulator/simulator/raft.go
+++ b/tools/pd-simulator/simulator/raft.go
@@ -286,11 +286,15 @@ func (r *RaftEngine) SearchRegion(regionKey []byte) *core.RegionInfo {
 	return r.regionsInfo.SearchRegion(regionKey)
 }
 
-// RandRegion gets a region by random
-func (r *RaftEngine) RandRegion() *core.RegionInfo {
+// BootstrapRegion gets a region to construct bootstrap info.
+func (r *RaftEngine) BootstrapRegion() *core.RegionInfo {
 	r.RLock()
 	defer r.RUnlock()
-	return r.regionsInfo.RandRegion()
+	regions := r.regionsInfo.ScanRange(nil, nil, 1)
+	if len(regions) > 0 {
+		return regions[0]
+	}
+	return nil
 }
 
 func (r *RaftEngine) allocID(storeID uint64) (uint64, error) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
In the `placement rules` implementation, the `RegionOption` which passed to `RandXxxRegion` needs to call `cluster.GetStores()`. It meets deadlock problem because it first needs lock `BasicCluster` before get into `regions.RandXxxRegion`.

### What is changed and how it works?
Check `RegionOption` in `BasicCluster`. The procedure is:
1. Lock `BasicCluster`
2. Get 10 random regions without check `RegionOption`.
3. Release Lock.
4. Check `RegionOption` (during the check it may require Lock again)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test