### PR TITLE
scheduler: introduce scheduler controller

### DIFF
--- a/pkg/mock/mockoption/mockoption.go
+++ b/pkg/mock/mockoption/mockoption.go
@@ -14,6 +14,7 @@
 package mockoption
 
 import (
+	"context"
 	"time"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -279,3 +280,12 @@ func (mso *ScheduleOptions) GetLeaderScheduleStrategy() core.ScheduleStrategy {
 func (mso *ScheduleOptions) GetKeyType() core.KeyType {
 	return core.StringToKeyType(mso.KeyType)
 }
+
+// AddSchedulerCfg mocks method.
+func (mso *ScheduleOptions) AddSchedulerCfg(tp string, args []string) {}
+
+// RemoveSchedulerCfg mocks method.
+func (mso *ScheduleOptions) RemoveSchedulerCfg(ctx context.Context, name string) error { return nil }
+
+// Persist mocks method.
+func (mso *ScheduleOptions) Persist(storage *core.Storage) error { return nil }

--- a/pkg/testutil/operator.go
+++ b/pkg/testutil/operator.go
@@ -15,8 +15,14 @@ package testutil
 
 import (
 	check "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/server/schedule/operator"
 )
+
+// NewTestOperator creates a new operator for test purpose.
+func NewTestOperator(regionID uint64, regionEpoch *metapb.RegionEpoch, kind operator.OpKind, steps ...operator.OpStep) *operator.Operator {
+	return operator.NewOperator("test", "test", regionID, regionEpoch, kind, steps...)
+}
 
 // CheckAddPeer checks if the operator is to add peer on specified store.
 func CheckAddPeer(c *check.C, op *operator.Operator, kind operator.OpKind, storeID uint64) {

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -696,8 +696,6 @@ func (c *RaftCluster) GetRegionStats(startKey, endKey []byte) *statistics.Region
 
 // GetStoresStats returns stores' statistics from cluster.
 func (c *RaftCluster) GetStoresStats() *statistics.StoresStats {
-	c.RLock()
-	defer c.RUnlock()
 	return c.storesStats
 }
 

--- a/server/cluster_worker.go
+++ b/server/cluster_worker.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/server/schedule"
+	"github.com/pingcap/pd/server/schedulers"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -106,7 +107,7 @@ func (c *RaftCluster) handleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*
 	for i := 0; i < int(splitCount); i++ {
 		newRegionID, err := c.s.idAllocator.Alloc()
 		if err != nil {
-			return nil, errSchedulerNotFound
+			return nil, schedulers.ErrSchedulerNotFound
 		}
 
 		peerIDs := make([]uint64, len(request.Region.Peers))

--- a/server/coordinator.go
+++ b/server/coordinator.go
@@ -33,7 +33,6 @@ const (
 	runSchedulerCheckInterval = 3 * time.Second
 	collectFactor             = 0.8
 	collectTimeout            = 5 * time.Minute
-	maxScheduleRetries        = 10
 	maxLoadConfigRetries      = 10
 
 	heartbeatChanCapacity = 1024
@@ -395,4 +394,10 @@ func (c *coordinator) getSchedulers() []string {
 	c.RLock()
 	defer c.RUnlock()
 	return c.schedulers.GetSchedulers()
+}
+
+func (c *coordinator) getScheduler(name string) *schedulers.Scheduler {
+	c.RLock()
+	defer c.RUnlock()
+	return c.schedulers.GetScheduler(name)
 }

--- a/server/handler.go
+++ b/server/handler.go
@@ -778,10 +778,10 @@ func (h *Handler) GetSchedulerConfigHandler() http.Handler {
 		return nil
 	}
 	mux := http.NewServeMux()
-	for name, handler := range c.schedulers {
+	for _, name := range c.schedulers.GetSchedulers() {
 		prefix := path.Join(pdRootPath, SchedulerConfigHandlerPath, name)
 		urlPath := prefix + "/"
-		mux.Handle(urlPath, http.StripPrefix(prefix, handler))
+		mux.Handle(urlPath, http.StripPrefix(prefix, c.schedulers.GetScheduler(name)))
 	}
 	return mux
 }

--- a/server/handler.go
+++ b/server/handler.go
@@ -90,11 +90,11 @@ func (h *Handler) IsSchedulerPaused(name string) (bool, error) {
 	if err != nil {
 		return true, err
 	}
-	sc, ok := c.schedulers[name]
-	if !ok {
+	s := c.getScheduler(name)
+	if s == nil {
 		return true, errors.Errorf("scheduler %v not found", name)
 	}
-	return sc.isPaused(), nil
+	return s.IsPaused(), nil
 }
 
 // GetScheduleConfig returns ScheduleConfig.

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -32,14 +32,6 @@ var (
 			Help:      "Counter of system time jumps backward.",
 		})
 
-	schedulerStatusGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "pd",
-			Subsystem: "scheduler",
-			Name:      "status",
-			Help:      "Status of the scheduler.",
-		}, []string{"kind", "type"})
-
 	regionHeartbeatCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "pd",
@@ -110,7 +102,6 @@ var (
 
 func init() {
 	prometheus.MustRegister(timeJumpBackCounter)
-	prometheus.MustRegister(schedulerStatusGauge)
 	prometheus.MustRegister(regionHeartbeatCounter)
 	prometheus.MustRegister(regionEventCounter)
 	prometheus.MustRegister(regionHeartbeatLatency)

--- a/server/schedule/operator/operator_test.go
+++ b/server/schedule/operator/operator_test.go
@@ -133,7 +133,7 @@ func (s *testOperatorSuite) TestOperator(c *C) {
 		TransferLeader{FromStore: 3, ToStore: 1},
 		RemovePeer{FromStore: 3},
 	}
-	op := newTestOperator(1, &metapb.RegionEpoch{}, OpAdmin|OpLeader|OpRegion, steps...)
+	op := s.newTestOperator(1, OpAdmin|OpLeader|OpRegion, steps...)
 	c.Assert(op.GetPriorityLevel(), Equals, core.HighPriority)
 	s.checkSteps(c, op, steps)
 	op.Start()
@@ -148,7 +148,7 @@ func (s *testOperatorSuite) TestOperator(c *C) {
 		TransferLeader{FromStore: 2, ToStore: 1},
 		RemovePeer{FromStore: 2},
 	}
-	op = newTestOperator(1, &metapb.RegionEpoch{}, OpAdmin|OpLeader|OpRegion, steps...)
+	op = s.newTestOperator(1, OpAdmin|OpLeader|OpRegion, steps...)
 	s.checkSteps(c, op, steps)
 	op.Start()
 	c.Assert(op.Check(region), Equals, RemovePeer{FromStore: 2})
@@ -401,4 +401,8 @@ func (s *testOperatorSuite) TestCheck(c *C) {
 		c.Assert(op.Check(region), IsNil)
 		c.Assert(op.Status(), Equals, SUCCESS)
 	}
+}
+
+func (s *testOperatorSuite) newTestOperator(regionID uint64, kind OpKind, steps ...OpStep) *Operator {
+	return NewOperator("test", "test", regionID, &metapb.RegionEpoch{}, OpAdmin|kind, steps...)
 }

--- a/server/schedule/operator/operator_test.go
+++ b/server/schedule/operator/operator_test.go
@@ -118,10 +118,6 @@ func (s *testOperatorSuite) TestOperatorStep(c *C) {
 	c.Assert(RemovePeer{FromStore: 3}.IsFinish(region), IsTrue)
 }
 
-func (s *testOperatorSuite) newTestOperator(regionID uint64, kind OpKind, steps ...OpStep) *Operator {
-	return NewOperator("test", "test", regionID, &metapb.RegionEpoch{}, OpAdmin|kind, steps...)
-}
-
 func (s *testOperatorSuite) checkSteps(c *C, op *Operator, steps []OpStep) {
 	c.Assert(op.Len(), Equals, len(steps))
 	for i := range steps {
@@ -137,7 +133,7 @@ func (s *testOperatorSuite) TestOperator(c *C) {
 		TransferLeader{FromStore: 3, ToStore: 1},
 		RemovePeer{FromStore: 3},
 	}
-	op := s.newTestOperator(1, OpLeader|OpRegion, steps...)
+	op := newTestOperator(1, &metapb.RegionEpoch{}, OpAdmin|OpLeader|OpRegion, steps...)
 	c.Assert(op.GetPriorityLevel(), Equals, core.HighPriority)
 	s.checkSteps(c, op, steps)
 	op.Start()
@@ -152,7 +148,7 @@ func (s *testOperatorSuite) TestOperator(c *C) {
 		TransferLeader{FromStore: 2, ToStore: 1},
 		RemovePeer{FromStore: 2},
 	}
-	op = s.newTestOperator(1, OpLeader|OpRegion, steps...)
+	op = newTestOperator(1, &metapb.RegionEpoch{}, OpAdmin|OpLeader|OpRegion, steps...)
 	s.checkSteps(c, op, steps)
 	op.Start()
 	c.Assert(op.Check(region), Equals, RemovePeer{FromStore: 2})

--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -270,7 +270,6 @@ func (oc *OperatorController) AddWaitingOperator(ops ...*operator.Operator) bool
 			oc.buryOperator(op)
 		}
 		oc.Unlock()
-		fmt.Println("xxxx1")
 		return false
 	}
 	oc.wop.PutOperator(op)

--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -258,6 +258,7 @@ func (oc *OperatorController) AddWaitingOperator(ops ...*operator.Operator) bool
 			oc.buryOperator(op)
 		}
 		oc.Unlock()
+		fmt.Println("xxxx2")
 		return false
 	}
 
@@ -270,6 +271,7 @@ func (oc *OperatorController) AddWaitingOperator(ops ...*operator.Operator) bool
 			oc.buryOperator(op)
 		}
 		oc.Unlock()
+		fmt.Println("xxxx1")
 		return false
 	}
 	oc.wop.PutOperator(op)

--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -258,7 +258,6 @@ func (oc *OperatorController) AddWaitingOperator(ops ...*operator.Operator) bool
 			oc.buryOperator(op)
 		}
 		oc.Unlock()
-		fmt.Println("xxxx2")
 		return false
 	}
 

--- a/server/schedulers/metrics.go
+++ b/server/schedulers/metrics.go
@@ -15,6 +15,14 @@ package schedulers
 
 import "github.com/prometheus/client_golang/prometheus"
 
+var schedulerStatusGauge = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: "pd",
+		Subsystem: "scheduler",
+		Name:      "status",
+		Help:      "Status of the scheduler.",
+	}, []string{"kind", "type"})
+
 var schedulerCounter = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "pd",
@@ -88,6 +96,7 @@ var scatterRangeRegionCounter = prometheus.NewCounterVec(
 	}, []string{"type", "address", "store"})
 
 func init() {
+	prometheus.MustRegister(schedulerStatusGauge)
 	prometheus.MustRegister(schedulerCounter)
 	prometheus.MustRegister(schedulerStatus)
 	prometheus.MustRegister(balanceLeaderCounter)

--- a/server/schedulers/scheduler_controller.go
+++ b/server/schedulers/scheduler_controller.go
@@ -16,17 +16,214 @@ package schedulers
 import (
 	"context"
 	"sync/atomic"
+	"sync"
 	"time"
 
+	"github.com/pingcap/log"
+	"github.com/pingcap/pd/pkg/logutil"
+	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/server/schedule"
 	"github.com/pingcap/pd/server/schedule/operator"
 	"github.com/pingcap/pd/server/schedule/opt"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
 )
 
 const maxScheduleRetries = 10
 
+var (
+	// ErrSchedulerExisted is error info for scheduler is existed.
+	ErrSchedulerExisted = errors.New("scheduler existed")
+	// ErrSchedulerNotFound is error info for scheduler is not found.
+	ErrSchedulerNotFound = errors.New("scheduler not found")
+)
+
+// Options for SchedulerController.
+type Options interface {
+	AddSchedulerCfg(tp string, args []string)
+	RemoveSchedulerCfg(ctx context.Context, name string) error
+
+	Persist(storage *core.Storage) error
+}
+
 // SchedulerController is used to manage a scheduler to schedule.
 type SchedulerController struct {
+	sync.RWMutex
+
+	wg           sync.WaitGroup
+	schedulers   map[string]*Scheduler
+	opt          Options
+	cluster      opt.Cluster
+	storage      *core.Storage
+	opController *schedule.OperatorController
+	ctx          context.Context
+	cancel       context.CancelFunc
+}
+
+// NewSchedulerController creates a new scheduleController.
+func NewSchedulerController(ctx context.Context, cluster opt.Cluster, opController *schedule.OperatorController, opt Options, s *core.Storage) *SchedulerController {
+	ctx, cancel := context.WithCancel(ctx)
+	return &SchedulerController{
+		schedulers:   make(map[string]*Scheduler),
+		cluster:      cluster,
+		opt:          opt,
+		storage:      s,
+		opController: opController,
+		ctx:          ctx,
+		cancel:       cancel,
+	}
+}
+
+// GetSchedulers returns all schedulers' name.
+func (sc *SchedulerController) GetSchedulers() []string {
+	sc.RLock()
+	defer sc.RUnlock()
+	names := make([]string, 0, len(sc.schedulers))
+	for name := range sc.schedulers {
+		names = append(names, name)
+	}
+	return names
+}
+
+// GetScheduler gets a scheduler with a given name.
+func (sc *SchedulerController) GetScheduler(name string) *Scheduler {
+	sc.RLock()
+	defer sc.RUnlock()
+	s, ok := sc.schedulers[name]
+	if !ok {
+		return nil
+	}
+	return s
+}
+
+// AddScheduler adds a scheduler.
+func (sc *SchedulerController) AddScheduler(scheduler schedule.Scheduler, args ...string) error {
+	if s := sc.GetScheduler(scheduler.GetName()); s != nil {
+		return ErrSchedulerExisted
+	}
+	sc.Lock()
+	defer sc.Unlock()
+	s := NewScheduler(sc, scheduler)
+	if err := s.Prepare(sc.cluster); err != nil {
+		return err
+	}
+
+	sc.wg.Add(1)
+	go sc.runScheduler(s)
+	sc.schedulers[s.GetName()] = s
+	sc.opt.AddSchedulerCfg(s.GetType(), args)
+	return nil
+}
+
+// RemoveScheduler removes a scheduler with a given name.
+func (sc *SchedulerController) RemoveScheduler(name string) error {
+	var s *Scheduler
+	if s = sc.GetScheduler(name); s == nil {
+		return ErrSchedulerNotFound
+	}
+
+	sc.Lock()
+	defer sc.Unlock()
+	s.Stop()
+	schedulerStatusGauge.WithLabelValues(name, "allow").Set(0)
+	delete(sc.schedulers, name)
+
+	var err error
+	if err = sc.opt.RemoveSchedulerCfg(s.Ctx(), name); err != nil {
+		log.Error("can not remove scheduler", zap.String("scheduler-name", name), zap.Error(err))
+	} else if err = sc.opt.Persist(sc.storage); err != nil {
+		log.Error("the option can not persist scheduler config", zap.Error(err))
+	} else {
+		err = sc.storage.RemoveScheduleConfig(name)
+		if err != nil {
+			log.Error("can not remove the scheduler config", zap.Error(err))
+		}
+	}
+	return nil
+}
+
+// PauseOrResumeScheduler pauses or resumes a scheduler.
+func (sc *SchedulerController) PauseOrResumeScheduler(name string, t int64) error {
+	s := make([]*Scheduler, 0)
+	if name != "all" {
+		sc := sc.GetScheduler(name)
+		if sc == nil {
+			return ErrSchedulerNotFound
+		}
+		s = append(s, sc)
+	} else {
+		for _, scheduler := range sc.schedulers {
+			s = append(s, scheduler)
+		}
+	}
+	var err error
+	for _, sc := range s {
+		var delayUntil int64 = 0
+		if t > 0 {
+			delayUntil = time.Now().Unix() + t
+		}
+		sc.SetDelay(delayUntil)
+		
+	}
+	return err
+}
+
+func (sc *SchedulerController) runScheduler(s *Scheduler) {
+	defer logutil.LogPanic()
+	defer sc.wg.Done()
+	defer s.Cleanup(sc.cluster)
+
+	timer := time.NewTimer(s.GetInterval())
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-timer.C:
+			timer.Reset(s.GetInterval())
+			if !s.AllowSchedule() {
+				continue
+			}
+			if op := s.Schedule(); op != nil {
+				sc.opController.AddWaitingOperator(op...)
+			}
+
+		case <-s.Ctx().Done():
+			log.Info("scheduler has been stopped",
+				zap.String("scheduler-name", s.GetName()),
+				zap.Error(s.Ctx().Err()))
+			return
+		}
+	}
+}
+
+// CollectMetrics collects metrics.
+func (sc *SchedulerController) CollectMetrics() {
+	sc.RLock()
+	defer sc.RUnlock()
+	for _, s := range sc.schedulers {
+		var allowScheduler float64
+		// If the scheduler is not allowed to schedule, it will disappear in Grafana panel.
+		// See issue #1341.
+		if s.AllowSchedule() {
+			allowScheduler = 1
+		}
+		schedulerStatusGauge.WithLabelValues(s.GetName(), "allow").Set(allowScheduler)
+	}
+}
+
+// ResetMetrics resets metrics.
+func (sc *SchedulerController) ResetMetrics() {
+	schedulerStatusGauge.Reset()
+}
+
+// Stop will stop SchedulerController and wait all schedulers stop.
+func (sc *SchedulerController) Stop() {
+	sc.cancel()
+	sc.wg.Wait()
+}
+
+// Scheduler is a warpper to manage the scheduler.
+type Scheduler struct {
 	schedule.Scheduler
 	cluster      opt.Cluster
 	opController *schedule.OperatorController
@@ -36,13 +233,13 @@ type SchedulerController struct {
 	cancel       context.CancelFunc
 }
 
-// NewSchedulerController creates a new scheduleController.
-func NewSchedulerController(ctx context.Context, cluster opt.Cluster, opController *schedule.OperatorController, s schedule.Scheduler) *SchedulerController {
-	ctx, cancel := context.WithCancel(ctx)
-	return &SchedulerController{
+// NewScheduler creates a new scheduler.
+func NewScheduler(sc *SchedulerController, s schedule.Scheduler) *Scheduler {
+	ctx, cancel := context.WithCancel(sc.ctx)
+	return &Scheduler{
 		Scheduler:    s,
-		cluster:      cluster,
-		opController: opController,
+		cluster:      sc.cluster,
+		opController: sc.opController,
 		nextInterval: s.GetMinInterval(),
 		ctx:          ctx,
 		cancel:       cancel,
@@ -50,17 +247,17 @@ func NewSchedulerController(ctx context.Context, cluster opt.Cluster, opControll
 }
 
 // Ctx return the context of scheduler controller.
-func (s *SchedulerController) Ctx() context.Context {
+func (s *Scheduler) Ctx() context.Context {
 	return s.ctx
 }
 
 // Stop stops the scheduler controller.
-func (s *SchedulerController) Stop() {
+func (s *Scheduler) Stop() {
 	s.cancel()
 }
 
 // Schedule returns operators created by each scheduler.
-func (s *SchedulerController) Schedule() []*operator.Operator {
+func (s *Scheduler) Schedule() []*operator.Operator {
 	for i := 0; i < maxScheduleRetries; i++ {
 		// If we have schedule, reset interval to the minimal interval.
 		if op := s.Scheduler.Schedule(s.cluster); op != nil {
@@ -73,16 +270,16 @@ func (s *SchedulerController) Schedule() []*operator.Operator {
 }
 
 // GetInterval returns the interval of scheduling for a scheduler.
-func (s *SchedulerController) GetInterval() time.Duration {
+func (s *Scheduler) GetInterval() time.Duration {
 	return s.nextInterval
 }
 
 // AllowSchedule returns if a scheduler is allowed to schedule.
-func (s *SchedulerController) AllowSchedule() bool {
+func (s *Scheduler) AllowSchedule() bool {
 	return s.Scheduler.IsScheduleAllowed(s.cluster)
 }
 
 // SetDelay sets the delay time.
-func (s *SchedulerController) SetDelay(delayUntil int64) {
+func (s *Scheduler) SetDelay(delayUntil int64) {
 	atomic.StoreInt64(&s.delayUntil, delayUntil)
 }

--- a/server/schedulers/scheduler_controller.go
+++ b/server/schedulers/scheduler_controller.go
@@ -139,7 +139,7 @@ func (sc *SchedulerController) RemoveScheduler(name string) error {
 			log.Error("can not remove the scheduler config", zap.Error(err))
 		}
 	}
-	return nil
+	return err
 }
 
 // PauseOrResumeScheduler pauses or resumes a scheduler.

--- a/server/schedulers/scheduler_controller.go
+++ b/server/schedulers/scheduler_controller.go
@@ -1,0 +1,88 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schedulers
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/pingcap/pd/server/schedule"
+	"github.com/pingcap/pd/server/schedule/operator"
+	"github.com/pingcap/pd/server/schedule/opt"
+)
+
+const maxScheduleRetries = 10
+
+// SchedulerController is used to manage a scheduler to schedule.
+type SchedulerController struct {
+	schedule.Scheduler
+	cluster      opt.Cluster
+	opController *schedule.OperatorController
+	nextInterval time.Duration
+	delayUntil   int64
+	ctx          context.Context
+	cancel       context.CancelFunc
+}
+
+// NewSchedulerController creates a new scheduleController.
+func NewSchedulerController(ctx context.Context, cluster opt.Cluster, opController *schedule.OperatorController, s schedule.Scheduler) *SchedulerController {
+	ctx, cancel := context.WithCancel(ctx)
+	return &SchedulerController{
+		Scheduler:    s,
+		cluster:      cluster,
+		opController: opController,
+		nextInterval: s.GetMinInterval(),
+		ctx:          ctx,
+		cancel:       cancel,
+	}
+}
+
+// Ctx return the context of scheduler controller.
+func (s *SchedulerController) Ctx() context.Context {
+	return s.ctx
+}
+
+// Stop stops the scheduler controller.
+func (s *SchedulerController) Stop() {
+	s.cancel()
+}
+
+// Schedule returns operators created by each scheduler.
+func (s *SchedulerController) Schedule() []*operator.Operator {
+	for i := 0; i < maxScheduleRetries; i++ {
+		// If we have schedule, reset interval to the minimal interval.
+		if op := s.Scheduler.Schedule(s.cluster); op != nil {
+			s.nextInterval = s.Scheduler.GetMinInterval()
+			return op
+		}
+	}
+	s.nextInterval = s.Scheduler.GetNextInterval(s.nextInterval)
+	return nil
+}
+
+// GetInterval returns the interval of scheduling for a scheduler.
+func (s *SchedulerController) GetInterval() time.Duration {
+	return s.nextInterval
+}
+
+// AllowSchedule returns if a scheduler is allowed to schedule.
+func (s *SchedulerController) AllowSchedule() bool {
+	return s.Scheduler.IsScheduleAllowed(s.cluster)
+}
+
+// SetDelay sets the delay time.
+func (s *SchedulerController) SetDelay(delayUntil int64) {
+	atomic.StoreInt64(&s.delayUntil, delayUntil)
+}

--- a/server/schedulers/scheduler_controller.go
+++ b/server/schedulers/scheduler_controller.go
@@ -15,8 +15,8 @@ package schedulers
 
 import (
 	"context"
-	"sync/atomic"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pingcap/log"
@@ -163,7 +163,6 @@ func (sc *SchedulerController) PauseOrResumeScheduler(name string, t int64) erro
 			delayUntil = time.Now().Unix() + t
 		}
 		sc.SetDelay(delayUntil)
-		
 	}
 	return err
 }
@@ -282,4 +281,10 @@ func (s *Scheduler) AllowSchedule() bool {
 // SetDelay sets the delay time.
 func (s *Scheduler) SetDelay(delayUntil int64) {
 	atomic.StoreInt64(&s.delayUntil, delayUntil)
+}
+
+// IsPaused return if the scheduler is paused.
+func (s *Scheduler) IsPaused() bool {
+	delayUntil := atomic.LoadInt64(&s.delayUntil)
+	return time.Now().Unix() < delayUntil
 }

--- a/server/schedulers/scheduler_controller_test.go
+++ b/server/schedulers/scheduler_controller_test.go
@@ -1,0 +1,156 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schedulers
+
+import (
+	"context"
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/pd/pkg/mock/mockcluster"
+	"github.com/pingcap/pd/pkg/mock/mockhbstream"
+	"github.com/pingcap/pd/pkg/mock/mockoption"
+	"github.com/pingcap/pd/pkg/testutil"
+	"github.com/pingcap/pd/server/core"
+	"github.com/pingcap/pd/server/kv"
+	"github.com/pingcap/pd/server/schedule"
+	"github.com/pingcap/pd/server/schedule/operator"
+	"github.com/pingcap/pd/server/schedule/opt"
+)
+
+var _ = Suite(&testScheduleControllerSuite{})
+
+type testScheduleControllerSuite struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func (s *testScheduleControllerSuite) SetUpSuite(c *C) {
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+}
+
+func (s *testScheduleControllerSuite) TearDownSuite(c *C) {
+	s.cancel()
+}
+
+// FIXME: remove after move into schedulers package
+type mockLimitScheduler struct {
+	schedule.Scheduler
+	limit   uint64
+	counter *schedule.OperatorController
+	kind    operator.OpKind
+}
+
+func (s *mockLimitScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
+	return s.counter.OperatorCount(s.kind) < s.limit
+}
+
+func (s *testScheduleControllerSuite) TestController(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opt := mockoption.NewScheduleOptions()
+	tc := mockcluster.NewCluster(opt)
+	oc := schedule.NewOperatorController(ctx, tc, mockhbstream.NewHeartbeatStream())
+
+	tc.AddLeaderRegion(1, 1)
+	tc.AddLeaderRegion(2, 2)
+
+	scheduler, err := schedule.CreateScheduler("balance-leader", oc, core.NewStorage(kv.NewMemoryKV()), nil)
+	c.Assert(err, IsNil)
+	lb := &mockLimitScheduler{
+		Scheduler: scheduler,
+		counter:   oc,
+		kind:      operator.OpLeader,
+	}
+
+	sc := NewSchedulerController(ctx, tc, oc, lb)
+
+	for i := MinScheduleInterval; sc.GetInterval() != MaxScheduleInterval; i = sc.GetNextInterval(i) {
+		c.Assert(sc.GetInterval(), Equals, i)
+		c.Assert(sc.Schedule(), IsNil)
+	}
+	// limit = 2
+	lb.limit = 2
+	// count = 0
+	c.Assert(sc.AllowSchedule(), IsTrue)
+	op1 := testutil.NewTestOperator(1, tc.GetRegion(1).GetRegionEpoch(), operator.OpLeader)
+	c.Assert(oc.AddWaitingOperator(op1), IsTrue)
+	// count = 1
+	c.Assert(sc.AllowSchedule(), IsTrue)
+	op2 := testutil.NewTestOperator(2, tc.GetRegion(2).GetRegionEpoch(), operator.OpLeader)
+	c.Assert(oc.AddWaitingOperator(op2), IsTrue)
+	// count = 2
+	c.Assert(sc.AllowSchedule(), IsFalse)
+	c.Assert(oc.RemoveOperator(op1), IsTrue)
+	// count = 1
+	c.Assert(sc.AllowSchedule(), IsTrue)
+
+	// add a PriorityKind operator will remove old operator
+	op3 := testutil.NewTestOperator(2, tc.GetRegion(2).GetRegionEpoch(), operator.OpHotRegion)
+	op3.SetPriorityLevel(core.HighPriority)
+	c.Assert(oc.AddWaitingOperator(op1), IsTrue)
+	c.Assert(sc.AllowSchedule(), IsFalse)
+	c.Assert(oc.AddWaitingOperator(op3), IsTrue)
+	c.Assert(sc.AllowSchedule(), IsTrue)
+	c.Assert(oc.RemoveOperator(op3), IsTrue)
+
+	// add a admin operator will remove old operator
+	c.Assert(oc.AddWaitingOperator(op2), IsTrue)
+	c.Assert(sc.AllowSchedule(), IsFalse)
+	op4 := testutil.NewTestOperator(2, tc.GetRegion(2).GetRegionEpoch(), operator.OpAdmin)
+	op4.SetPriorityLevel(core.HighPriority)
+	c.Assert(oc.AddWaitingOperator(op4), IsTrue)
+	c.Assert(sc.AllowSchedule(), IsTrue)
+	c.Assert(oc.RemoveOperator(op4), IsTrue)
+
+	// test wrong region id.
+	op5 := testutil.NewTestOperator(3, &metapb.RegionEpoch{}, operator.OpHotRegion)
+	c.Assert(oc.AddWaitingOperator(op5), IsFalse)
+
+	// test wrong region epoch.
+	c.Assert(oc.RemoveOperator(op1), IsTrue)
+	epoch := &metapb.RegionEpoch{
+		Version: tc.GetRegion(1).GetRegionEpoch().GetVersion() + 1,
+		ConfVer: tc.GetRegion(1).GetRegionEpoch().GetConfVer(),
+	}
+	op6 := testutil.NewTestOperator(1, epoch, operator.OpLeader)
+	c.Assert(oc.AddWaitingOperator(op6), IsFalse)
+	epoch.Version--
+	op6 = testutil.NewTestOperator(1, epoch, operator.OpLeader)
+	c.Assert(oc.AddWaitingOperator(op6), IsTrue)
+	c.Assert(oc.RemoveOperator(op6), IsTrue)
+}
+
+func (s *testScheduleControllerSuite) TestInterval(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opt := mockoption.NewScheduleOptions()
+	tc := mockcluster.NewCluster(opt)
+	oc := schedule.NewOperatorController(ctx, tc, mockhbstream.NewHeartbeatStream())
+
+	lb, err := schedule.CreateScheduler("balance-leader", oc, core.NewStorage(kv.NewMemoryKV()), nil)
+	c.Assert(err, IsNil)
+	sc := NewSchedulerController(ctx, tc, oc, lb)
+
+	// If no operator for x seconds, the next check should be in x/2 seconds.
+	idleSeconds := []int{5, 10, 20, 30, 60}
+	for _, n := range idleSeconds {
+		sc.nextInterval = MinScheduleInterval
+		for totalSleep := time.Duration(0); totalSleep <= time.Second*time.Duration(n); totalSleep += sc.GetInterval() {
+			c.Assert(sc.Schedule(), IsNil)
+		}
+		c.Assert(sc.GetInterval(), Less, time.Second*time.Duration(n/2))
+	}
+}

--- a/server/schedulers/scheduler_controller_test.go
+++ b/server/schedulers/scheduler_controller_test.go
@@ -67,7 +67,8 @@ func (s *testScheduleControllerSuite) TestController(c *C) {
 	tc.AddLeaderRegion(1, 1)
 	tc.AddLeaderRegion(2, 2)
 
-	scheduler, err := schedule.CreateScheduler("balance-leader", oc, core.NewStorage(kv.NewMemoryKV()), nil)
+	storage := core.NewStorage(kv.NewMemoryKV())
+	scheduler, err := schedule.CreateScheduler("balance-leader", oc, storage, nil)
 	c.Assert(err, IsNil)
 	lb := &mockLimitScheduler{
 		Scheduler: scheduler,
@@ -75,44 +76,45 @@ func (s *testScheduleControllerSuite) TestController(c *C) {
 		kind:      operator.OpLeader,
 	}
 
-	sc := NewSchedulerController(ctx, tc, oc, lb)
+	sc := NewSchedulerController(ctx, tc, oc, opt, storage)
+	bls := NewScheduler(sc, lb)
 
-	for i := MinScheduleInterval; sc.GetInterval() != MaxScheduleInterval; i = sc.GetNextInterval(i) {
-		c.Assert(sc.GetInterval(), Equals, i)
-		c.Assert(sc.Schedule(), IsNil)
+	for i := MinScheduleInterval; bls.GetInterval() != MaxScheduleInterval; i = bls.GetNextInterval(i) {
+		c.Assert(bls.GetInterval(), Equals, i)
+		c.Assert(bls.Schedule(), IsNil)
 	}
 	// limit = 2
 	lb.limit = 2
 	// count = 0
-	c.Assert(sc.AllowSchedule(), IsTrue)
+	c.Assert(bls.AllowSchedule(), IsTrue)
 	op1 := testutil.NewTestOperator(1, tc.GetRegion(1).GetRegionEpoch(), operator.OpLeader)
 	c.Assert(oc.AddWaitingOperator(op1), IsTrue)
 	// count = 1
-	c.Assert(sc.AllowSchedule(), IsTrue)
+	c.Assert(bls.AllowSchedule(), IsTrue)
 	op2 := testutil.NewTestOperator(2, tc.GetRegion(2).GetRegionEpoch(), operator.OpLeader)
 	c.Assert(oc.AddWaitingOperator(op2), IsTrue)
 	// count = 2
-	c.Assert(sc.AllowSchedule(), IsFalse)
+	c.Assert(bls.AllowSchedule(), IsFalse)
 	c.Assert(oc.RemoveOperator(op1), IsTrue)
 	// count = 1
-	c.Assert(sc.AllowSchedule(), IsTrue)
+	c.Assert(bls.AllowSchedule(), IsTrue)
 
 	// add a PriorityKind operator will remove old operator
 	op3 := testutil.NewTestOperator(2, tc.GetRegion(2).GetRegionEpoch(), operator.OpHotRegion)
 	op3.SetPriorityLevel(core.HighPriority)
 	c.Assert(oc.AddWaitingOperator(op1), IsTrue)
-	c.Assert(sc.AllowSchedule(), IsFalse)
+	c.Assert(bls.AllowSchedule(), IsFalse)
 	c.Assert(oc.AddWaitingOperator(op3), IsTrue)
-	c.Assert(sc.AllowSchedule(), IsTrue)
+	c.Assert(bls.AllowSchedule(), IsTrue)
 	c.Assert(oc.RemoveOperator(op3), IsTrue)
 
 	// add a admin operator will remove old operator
 	c.Assert(oc.AddWaitingOperator(op2), IsTrue)
-	c.Assert(sc.AllowSchedule(), IsFalse)
+	c.Assert(bls.AllowSchedule(), IsFalse)
 	op4 := testutil.NewTestOperator(2, tc.GetRegion(2).GetRegionEpoch(), operator.OpAdmin)
 	op4.SetPriorityLevel(core.HighPriority)
 	c.Assert(oc.AddWaitingOperator(op4), IsTrue)
-	c.Assert(sc.AllowSchedule(), IsTrue)
+	c.Assert(bls.AllowSchedule(), IsTrue)
 	c.Assert(oc.RemoveOperator(op4), IsTrue)
 
 	// test wrong region id.
@@ -140,17 +142,19 @@ func (s *testScheduleControllerSuite) TestInterval(c *C) {
 	tc := mockcluster.NewCluster(opt)
 	oc := schedule.NewOperatorController(ctx, tc, mockhbstream.NewHeartbeatStream())
 
-	lb, err := schedule.CreateScheduler("balance-leader", oc, core.NewStorage(kv.NewMemoryKV()), nil)
+	storage := core.NewStorage(kv.NewMemoryKV())
+	lb, err := schedule.CreateScheduler("balance-leader", oc, storage, nil)
 	c.Assert(err, IsNil)
-	sc := NewSchedulerController(ctx, tc, oc, lb)
+	sc := NewSchedulerController(ctx, tc, oc, opt, storage)
+	bls := NewScheduler(sc, lb)
 
 	// If no operator for x seconds, the next check should be in x/2 seconds.
 	idleSeconds := []int{5, 10, 20, 30, 60}
 	for _, n := range idleSeconds {
-		sc.nextInterval = MinScheduleInterval
-		for totalSleep := time.Duration(0); totalSleep <= time.Second*time.Duration(n); totalSleep += sc.GetInterval() {
-			c.Assert(sc.Schedule(), IsNil)
+		bls.nextInterval = MinScheduleInterval
+		for totalSleep := time.Duration(0); totalSleep <= time.Second*time.Duration(n); totalSleep += bls.GetInterval() {
+			c.Assert(bls.Schedule(), IsNil)
 		}
-		c.Assert(sc.GetInterval(), Less, time.Second*time.Duration(n/2))
+		c.Assert(bls.GetInterval(), Less, time.Second*time.Duration(n/2))
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Currently, the `scheduleController` in `coordinator.go` is used to manage the schedulers' behaviors. But it should be put into `schedulers` package. 

### What is changed and how it works?
This PR uses `SchedulerController` to manage the schedulers to make the code structure more clear.
And we also need to do something in the future:

1. move `HotStatus` related logic to a proper place.
2. merge `schedulerController` and `checkerController` together or put the whole `schedulers` package into `schedule` directory.
 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test