### PR TITLE
server/api: add HTTP header to allow follower handle requests

### DIFF
--- a/server/api/redirector.go
+++ b/server/api/redirector.go
@@ -28,7 +28,9 @@ import (
 )
 
 const (
-	redirectorHeader = "PD-Redirector"
+	redirectorHeader    = "PD-Redirector"
+	allowFollowerHandle = "PD-Allow-follower-handle"
+	followerHandle      = "PD-Follwer-handle"
 )
 
 const (
@@ -47,7 +49,11 @@ func newRedirector(s *server.Server) *redirector {
 }
 
 func (h *redirector) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	if !h.s.IsClosed() && h.s.GetMember().IsLeader() {
+	allowFollowerHandle := len(r.Header.Get(allowFollowerHandle)) > 0
+	if !h.s.IsClosed() && (h.s.GetMember().IsLeader() || allowFollowerHandle) {
+		if allowFollowerHandle {
+			w.Header().Add(followerHandle, "true")
+		}
 		next(w, r)
 		return
 	}


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

Some requests should be handled locally instead of redirecting to the leader (e.g: retrieve hardware information from the PD node)

### What is changed and how it works?

Add HTTP header to allow the follower handle requests locally.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has HTTP API interfaces change
 - Has persistent data change

Side effects

 - Possible performance regression
