### PR TITLE
core: fix remove region

### DIFF
--- a/server/core/region.go
+++ b/server/core/region.go
@@ -483,9 +483,10 @@ func (rst *regionSubTree) remove(region *RegionInfo) {
 	if rst.length() == 0 {
 		return
 	}
-	rst.totalSize -= region.approximateSize
-	rst.totalKeys -= region.approximateKeys
-	rst.regionTree.remove(region)
+	if rst.regionTree.remove(region) != nil {
+		rst.totalSize -= region.approximateSize
+		rst.totalKeys -= region.approximateKeys
+	}
 }
 
 func (rst *regionSubTree) length() int {

--- a/server/core/region_tree.go
+++ b/server/core/region_tree.go
@@ -107,16 +107,16 @@ func (t *regionTree) update(region *RegionInfo) []*RegionInfo {
 // remove removes a region if the region is in the tree.
 // It will do nothing if it cannot find the region or the found region
 // is not the same with the region.
-func (t *regionTree) remove(region *RegionInfo) {
+func (t *regionTree) remove(region *RegionInfo) btree.Item {
 	if t.length() == 0 {
-		return
+		return nil
 	}
 	result := t.find(region)
 	if result == nil || result.region.GetID() != region.GetID() {
-		return
+		return nil
 	}
 
-	t.tree.Delete(result)
+	return t.tree.Delete(result)
 }
 
 // search returns a region that contains the key.

--- a/server/core/region_tree_test.go
+++ b/server/core/region_tree_test.go
@@ -136,6 +136,9 @@ func (s *testRegionSuite) TestRegionSubTree(c *C) {
 	tree.remove(s.newRegionWithStat("a", "b", 1, 2))
 	c.Assert(tree.totalSize, Equals, int64(5))
 	c.Assert(tree.totalKeys, Equals, int64(6))
+	tree.remove(s.newRegionWithStat("f", "g", 1, 2))
+	c.Assert(tree.totalSize, Equals, int64(5))
+	c.Assert(tree.totalKeys, Equals, int64(6))
 }
 
 func (s *testRegionSuite) TestRegionTree(c *C) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fixes #1889.

### What is changed and how it works?
When the region is not in the tree, we don't need to change the region size and keys.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test