### PR TITLE
schedule: fix the issue that stale operator when scatting regions

### DIFF
--- a/server/schedule/operator/operator.go
+++ b/server/schedule/operator/operator.go
@@ -423,7 +423,7 @@ type AddLightLearner struct {
 
 // ConfVerChanged returns true if the conf version has been changed by this step
 func (al AddLightLearner) ConfVerChanged(region *core.RegionInfo) bool {
-	if p := region.GetStoreLearner(al.ToStore); p != nil {
+	if p := region.GetStorePeer(al.ToStore); p != nil {
 		return p.GetId() == al.PeerID
 	}
 	return false

--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -119,8 +119,13 @@ func (oc *OperatorController) Dispatch(region *core.RegionInfo, source string) {
 				changes > uint64(op.ConfVerChanged(region)) {
 
 				if oc.RemoveOperator(op) {
-					log.Info("stale operator", zap.Uint64("region-id", region.GetID()), zap.Duration("takes", op.RunningTime()),
-						zap.Reflect("operator", op), zap.Uint64("diff", changes))
+					log.Info("stale operator",
+						zap.Uint64("region-id", region.GetID()),
+						zap.Duration("takes", op.RunningTime()),
+						zap.Reflect("operator", op),
+						zap.Reflect("latest-epoch", region.GetRegionEpoch()),
+						zap.Uint64("diff", changes),
+					)
 					operatorCounter.WithLabelValues(op.Desc(), "stale").Inc()
 					oc.opRecords.Put(op, pdpb.OperatorStatus_CANCEL)
 					oc.PromoteWaitingOperator()

--- a/server/schedule/operator_controller_test.go
+++ b/server/schedule/operator_controller_test.go
@@ -339,83 +339,96 @@ func (t *testOperatorControllerSuite) TestDispatchUnfinishedStep(c *C) {
 
 	// The next allocated peer should have peerid 3, so we add this peer
 	// to store 3
-	steps := []operator.OpStep{
-		operator.AddLearner{ToStore: 3, PeerID: 3},
-		operator.PromoteLearner{ToStore: 3, PeerID: 3},
-		operator.TransferLeader{ToStore: 3},
-		operator.RemovePeer{FromStore: 1},
+	testSteps := [][]operator.OpStep{
+		{
+			operator.AddLearner{ToStore: 3, PeerID: 3},
+			operator.PromoteLearner{ToStore: 3, PeerID: 3},
+			operator.TransferLeader{ToStore: 3},
+			operator.RemovePeer{FromStore: 1},
+		},
+		{
+			operator.AddLightLearner{ToStore: 3, PeerID: 3},
+			operator.PromoteLearner{ToStore: 3, PeerID: 3},
+			operator.TransferLeader{ToStore: 3},
+			operator.RemovePeer{FromStore: 1},
+		},
 	}
 
-	// Create an operator
-	op := operator.NewOperator("test", "test", 1, epoch,
-		operator.OpRegion, steps...)
-	c.Assert(controller.AddOperator(op), Equals, true)
-	c.Assert(len(stream.MsgCh()), Equals, 1)
+	for _, steps := range testSteps {
+		// Create an operator
+		op := operator.NewOperator("test", "test", 1, epoch,
+			operator.OpRegion, steps...)
+		c.Assert(controller.AddOperator(op), Equals, true)
+		c.Assert(len(stream.MsgCh()), Equals, 1)
 
-	// Create region2 witch is cloned from the original region.
-	// region2 has peer 3 in pending state, so the AddPeer step
-	// is left unfinished
-	region2 := region.Clone(
-		core.WithAddPeer(&metapb.Peer{Id: 3, StoreId: 3, IsLearner: true}),
-		core.WithPendingPeers([]*metapb.Peer{
-			{Id: 3, StoreId: 3, IsLearner: true},
-		}),
-		core.WithIncConfVer(),
-	)
-	c.Assert(region2.GetPendingPeers(), NotNil)
-	c.Assert(steps[0].IsFinish(region2), Equals, false)
-	controller.Dispatch(region2, DispatchFromHeartBeat)
+		// Create region2 witch is cloned from the original region.
+		// region2 has peer 2 in pending state, so the AddPeer step
+		// is left unfinished
+		region2 := region.Clone(
+			core.WithAddPeer(&metapb.Peer{Id: 3, StoreId: 3, IsLearner: true}),
+			core.WithPendingPeers([]*metapb.Peer{
+				{Id: 3, StoreId: 3, IsLearner: true},
+			}),
+			core.WithIncConfVer(),
+		)
+		c.Assert(region2.GetPendingPeers(), NotNil)
+		c.Assert(steps[0].IsFinish(region2), Equals, false)
+		controller.Dispatch(region2, DispatchFromHeartBeat)
 
-	// In this case, the conf version has been changed, but the
-	// peer added is in peeding state, the operator should not be
-	// removed by the stale checker
-	c.Assert(op.ConfVerChanged(region2), Equals, 1)
-	c.Assert(controller.GetOperator(1), NotNil)
-	// The operator is valid yet, but the step should not be sent
-	// again, because it is in pending state, so the message channel
-	// should not be increased
-	c.Assert(len(stream.MsgCh()), Equals, 1)
+		// In this case, the conf version has been changed, but the
+		// peer added is in peeding state, the operator should not be
+		// removed by the stale checker
+		c.Assert(op.ConfVerChanged(region2), Equals, 1)
+		c.Assert(controller.GetOperator(1), NotNil)
+		// The operator is valid yet, but the step should not be sent
+		// again, because it is in pending state, so the message channel
+		// should not be increased
+		c.Assert(len(stream.MsgCh()), Equals, 1)
 
-	// Finish the step by clearing the pending state
-	region3 := region.Clone(
-		core.WithAddPeer(&metapb.Peer{Id: 3, StoreId: 3, IsLearner: true}),
-		core.WithIncConfVer(),
-	)
-	c.Assert(steps[0].IsFinish(region3), Equals, true)
-	controller.Dispatch(region3, DispatchFromHeartBeat)
-	c.Assert(op.ConfVerChanged(region3), Equals, 1)
-	c.Assert(len(stream.MsgCh()), Equals, 2)
+		// Finish the step by clearing the pending state
+		region3 := region.Clone(
+			core.WithAddPeer(&metapb.Peer{Id: 3, StoreId: 3, IsLearner: true}),
+			core.WithIncConfVer(),
+		)
+		c.Assert(steps[0].IsFinish(region3), Equals, true)
+		controller.Dispatch(region3, DispatchFromHeartBeat)
+		c.Assert(op.ConfVerChanged(region3), Equals, 1)
+		c.Assert(len(stream.MsgCh()), Equals, 2)
 
-	region4 := region3.Clone(
-		core.WithPromoteLearner(3),
-		core.WithIncConfVer(),
-	)
-	c.Assert(steps[1].IsFinish(region4), Equals, true)
-	controller.Dispatch(region4, DispatchFromHeartBeat)
-	c.Assert(op.ConfVerChanged(region4), Equals, 2)
-	c.Assert(len(stream.MsgCh()), Equals, 3)
+		region4 := region3.Clone(
+			core.WithPromoteLearner(3),
+			core.WithIncConfVer(),
+		)
+		c.Assert(steps[1].IsFinish(region4), Equals, true)
+		controller.Dispatch(region4, DispatchFromHeartBeat)
+		c.Assert(op.ConfVerChanged(region4), Equals, 2)
+		c.Assert(len(stream.MsgCh()), Equals, 3)
 
-	// Transfer leader
-	region5 := region4.Clone(
-		core.WithLeader(region4.GetStorePeer(3)),
-	)
-	c.Assert(steps[2].IsFinish(region5), Equals, true)
-	controller.Dispatch(region5, DispatchFromHeartBeat)
-	c.Assert(op.ConfVerChanged(region5), Equals, 2)
-	c.Assert(len(stream.MsgCh()), Equals, 4)
+		// Transfer leader
+		region5 := region4.Clone(
+			core.WithLeader(region4.GetStorePeer(3)),
+		)
+		c.Assert(steps[2].IsFinish(region5), Equals, true)
+		controller.Dispatch(region5, DispatchFromHeartBeat)
+		c.Assert(op.ConfVerChanged(region5), Equals, 2)
+		c.Assert(len(stream.MsgCh()), Equals, 4)
 
-	// Remove peer
-	region6 := region5.Clone(
-		core.WithRemoveStorePeer(1),
-		core.WithIncConfVer(),
-	)
-	c.Assert(steps[3].IsFinish(region6), Equals, true)
-	controller.Dispatch(region6, DispatchFromHeartBeat)
-	c.Assert(op.ConfVerChanged(region6), Equals, 3)
+		// Remove peer
+		region6 := region5.Clone(
+			core.WithRemoveStorePeer(1),
+			core.WithIncConfVer(),
+		)
+		c.Assert(steps[3].IsFinish(region6), Equals, true)
+		controller.Dispatch(region6, DispatchFromHeartBeat)
+		c.Assert(op.ConfVerChanged(region6), Equals, 3)
 
-	// The Operator has finished, so no message should be sent
-	c.Assert(len(stream.MsgCh()), Equals, 4)
-	c.Assert(controller.GetOperator(1), IsNil)
+		// The Operator has finished, so no message should be sent
+		c.Assert(len(stream.MsgCh()), Equals, 4)
+		c.Assert(controller.GetOperator(1), IsNil)
+		for i := 0; i < 4; i++ {
+			<-stream.MsgCh()
+		}
+	}
 }
 
 func (t *testOperatorControllerSuite) TestStoreLimitWithMerge(c *C) {

--- a/server/schedule/operator_controller_test.go
+++ b/server/schedule/operator_controller_test.go
@@ -361,7 +361,7 @@ func (t *testOperatorControllerSuite) TestDispatchUnfinishedStep(c *C) {
 		c.Assert(controller.AddOperator(op), Equals, true)
 		c.Assert(len(stream.MsgCh()), Equals, 1)
 
-		// Create region2 witch is cloned from the original region.
+		// Create region2 which is cloned from the original region.
 		// region2 has peer 2 in pending state, so the AddPeer step
 		// is left unfinished
 		region2 := region.Clone(
@@ -376,7 +376,7 @@ func (t *testOperatorControllerSuite) TestDispatchUnfinishedStep(c *C) {
 		controller.Dispatch(region2, DispatchFromHeartBeat)
 
 		// In this case, the conf version has been changed, but the
-		// peer added is in peeding state, the operator should not be
+		// peer added is in pending state, the operator should not be
 		// removed by the stale checker
 		c.Assert(op.ConfVerChanged(region2), Equals, 1)
 		c.Assert(controller.GetOperator(1), NotNil)


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Problem produce:
```
create table x(a int);
split table x between (0) and (1000000) regions 1000;
```
And found many stale operators:
```
[2019/11/04 23:43:33.176 +08:00] [INFO] [operator_controller.go:122] ["stale operator"] [region-id=9422] [takes=24.486979339s] [operator="\"scatter-region {scatter region: stores [1 6 7] to [4 6 7]} (kind:leader,region, region:9422(2019,8), createAt:2019-11-04 23:43:08.689465805 +0800 CST m=+242.334032834, startAt:2019-11-04 23:43:08.689582143 +0800 CST m=+242.334149184, currentStep:2, steps:[add learner peer 10733 on store 4, promote learner peer 10733 on store 4 to voter, transfer leader from store 6 to store 4, remove peer on store 1])\""] [diff=2] [latest="{\"id\":9422,\"start_key\":\"dIAAAAAAAAD/K19ygAAAAAD/HeRYAAAAAAD6\",\"end_key\":\"dIAAAAAAAAD/K19ygAAAAAD/HehAAAAAAAD6\",\"region_epoch\":{\"conf_ver\":10,\"version\":2019},\"peers\":[{\"id\":9423,\"store_id\":1},{\"id\":9424,\"store_id\":7},{\"id\":9425,\"store_id\":6},{\"id\":10733,\"store_id\":4}]}"] [origin="{\"conf_ver\":8,\"version\":2019}"]
[2019/11/04 23:43:33.176 +08:00] [INFO] [operator_controller.go:122] ["stale operator"] [region-id=8802] [takes=24.591804222s] [operator="\"scatter-region {scatter region: stores [1 6 7] to [4 6 7]} (kind:leader,region, region:8802(2019,8), createAt:2019-11-04 23:43:08.584864973 +0800 CST m=+242.229431969, startAt:2019-11-04 23:43:08.584949534 +0800 CST m=+242.229516563, currentStep:2, steps:[add learner peer 10547 on store 4, promote learner peer 10547 on store 4 to voter, transfer leader from store 6 to store 4, remove peer on store 1])\""] [diff=2] [latest="{\"id\":8802,\"start_key\":\"dIAAAAAAAAD/K19ygAAAAAD/G4bgAAAAAAD6\",\"end_key\":\"dIAAAAAAAAD/K19ygAAAAAD/G4rIAAAAAAD6\",\"region_epoch\":{\"conf_ver\":10,\"version\":2019},\"peers\":[{\"id\":8803,\"store_id\":1},{\"id\":8804,\"store_id\":7},{\"id\":8805,\"store_id\":6},{\"id\":10547,\"store_id\":4}]}"] [origin="{\"conf_ver\":8,\"version\":2019}"]
[2019/11/04 23:43:33.176 +08:00] [INFO] [operator_controller.go:122] ["stale operator"] [region-id=8634] [takes=24.622171763s] [operator="\"scatter-region {scatter region: stores [1 6 7] to [4 5 6]} (kind:region, region:8634(2019,8), createAt:2019-11-04 23:43:08.554697786 +0800 CST m=+242.199264820, startAt:2019-11-04 23:43:08.554785208 +0800 CST m=+242.199352229, currentStep:2, steps:[add learner peer 10496 on store 4, promote learner peer 10496 on store 4 to voter, remove peer on store 1, add learner peer 10497 on store 5, promote learner peer 10497 on store 5 to voter, remove peer on store 7])\""] [diff=2] [latest="{\"id\":8634,\"start_key\":\"dIAAAAAAAAD/K19ygAAAAAD/GuLQAAAAAAD6\",\"end_key\":\"dIAAAAAAAAD/K19ygAAAAAD/Gua4AAAAAAD6\",\"region_epoch\":{\"conf_ver\":10,\"version\":2019},\"peers\":[{\"id\":8635,\"store_id\":1},{\"id\":8636,\"store_id\":7},{\"id\":8637,\"store_id\":6},{\"id\":10496,\"store_id\":4}]}"] [origin="{\"conf_ver\":8,\"version\":2019}"]
[2019/11/04 23:43:33.177 +08:00] [INFO] [operator_controller.go:122] ["stale operator"] [region-id=9462] [takes=24.480428926s] [operator="\"scatter-region {scatter region: stores [1 6 7] to [4 6 7]} (kind:region, region:9462(2019,8), createAt:2019-11-04 23:43:08.696571071 +0800 CST m=+242.341138082, startAt:2019-11-04 23:43:08.696719225 +0800 CST m=+242.341286242, currentStep:2, steps:[add learner peer 10745 on store 4, promote learner peer 10745 on store 4 to voter, remove peer on store 1])\""] [diff=2] [latest="{\"id\":9462,\"start_key\":\"dIAAAAAAAAD/K19ygAAAAAD/HgtoAAAAAAD6\",\"end_key\":\"dIAAAAAAAAD/K19ygAAAAAD/Hg9QAAAAAAD6\",\"region_epoch\":{\"conf_ver\":10,\"version\":2019},\"peers\":[{\"id\":9463,\"store_id\":1},{\"id\":9464,\"store_id\":7},{\"id\":9465,\"store_id\":6},{\"id\":10745,\"store_id\":4}]}"] [origin="{\"conf_ver\":8,\"version\":2019}"]
```
Cause of the mismatch check of  the `AddLightLearner`. 
### What is changed and how it works?
consistent with `AddLearner`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test