### PR TITLE
*: make some tests stable

### DIFF
--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -477,8 +477,8 @@ func (s *testCoordinatorSuite) TestPeerState(c *C) {
 
 	// Transfer peer from store 4 to store 1.
 	c.Assert(tc.addRegionStore(1, 10), IsNil)
-	c.Assert(tc.addRegionStore(2, 20), IsNil)
-	c.Assert(tc.addRegionStore(3, 30), IsNil)
+	c.Assert(tc.addRegionStore(2, 10), IsNil)
+	c.Assert(tc.addRegionStore(3, 10), IsNil)
 	c.Assert(tc.addRegionStore(4, 40), IsNil)
 	c.Assert(tc.addLeaderRegion(1, 2, 3, 4), IsNil)
 

--- a/server/coordinator_test.go
+++ b/server/coordinator_test.go
@@ -215,7 +215,7 @@ func (s *testCoordinatorSuite) TestDispatch(c *C) {
 
 	// Transfer leader from store 4 to store 2.
 	c.Assert(tc.updateLeaderCount(4, 50), IsNil)
-	c.Assert(tc.updateLeaderCount(3, 30), IsNil)
+	c.Assert(tc.updateLeaderCount(3, 50), IsNil)
 	c.Assert(tc.updateLeaderCount(2, 20), IsNil)
 	c.Assert(tc.updateLeaderCount(1, 10), IsNil)
 	c.Assert(tc.addLeaderRegion(2, 4, 3, 2), IsNil)


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
After #1823 is merged, `TestPeerState` is not stable anymore.

### What is changed and how it works?
This PR prohibits to select other stores as a source store, only store 4 will meet the requirement and create an operator.

edit: This PR makes another test `TestDispatch` more stable by changing the leader count of the store 3.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test