### PR TITLE
client: add timeout for scanRegions (#1895)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -693,14 +693,20 @@ func (c *client) ScanRegions(ctx context.Context, key, endKey []byte, limit int)
 	}
 	start := time.Now()
 	defer cmdDuration.WithLabelValues("scan_regions").Observe(time.Since(start).Seconds())
-	ctx, cancel := context.WithTimeout(ctx, pdTimeout)
-	resp, err := c.leaderClient().ScanRegions(ctx, &pdpb.ScanRegionsRequest{
+
+	var cancel context.CancelFunc
+	scanCtx := ctx
+	if _, ok := ctx.Deadline(); !ok {
+		scanCtx, cancel = context.WithTimeout(ctx, pdTimeout)
+		defer cancel()
+	}
+
+	resp, err := c.leaderClient().ScanRegions(scanCtx, &pdpb.ScanRegionsRequest{
 		Header:   c.requestHeader(),
 		StartKey: key,
 		EndKey:   endKey,
 		Limit:    int32(limit),
 	})
-	cancel()
 	if err != nil {
 		cmdFailedDuration.WithLabelValues("scan_regions").Observe(time.Since(start).Seconds())
 		c.ScheduleCheckLeader()


### PR DESCRIPTION
cherry-pick #1895 to release-3.1

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
current pdTimeout(3s) is too small for backup & restore Scenario
so need set timeout outside 

### What is changed and how it works?
add timeout argument in scanRegions function

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes


Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release notes
