### PR TITLE
schedule: add more dimension for filter metrics (#1746)

### DIFF
--- a/server/schedule/filters_test.go
+++ b/server/schedule/filters_test.go
@@ -25,7 +25,7 @@ var _ = Suite(&testFiltersSuite{})
 type testFiltersSuite struct{}
 
 func (s *testReplicationSuite) TestPendingPeerFilter(c *C) {
-	filter := NewPendingPeerCountFilter()
+	filter := NewPendingPeerCountFilter("")
 	opt := mockoption.NewScheduleOptions()
 	tc := mockcluster.NewCluster(opt)
 	store := core.NewStoreInfo(&metapb.Store{Id: 1})

--- a/server/schedule/metrics.go
+++ b/server/schedule/metrics.go
@@ -39,7 +39,7 @@ var (
 			Subsystem: "schedule",
 			Name:      "filter",
 			Help:      "Counter of the filter",
-		}, []string{"action", "address", "store", "type"})
+		}, []string{"action", "address", "store", "scope", "type"})
 
 	operatorCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{

--- a/server/schedule/replica_checker.go
+++ b/server/schedule/replica_checker.go
@@ -23,26 +23,35 @@ import (
 	"go.uber.org/zap"
 )
 
+const replicaCheckerName = "replica-checker"
+
 // ReplicaChecker ensures region has the best replicas.
 // Including the following:
 // Replica number management.
 // Unhealth replica management, mainly used for disaster recovery of TiKV.
 // Location management, mainly used for cross data center deployment.
 type ReplicaChecker struct {
+	name       string
 	cluster    Cluster
 	classifier namespace.Classifier
 	filters    []Filter
 }
 
 // NewReplicaChecker creates a replica checker.
-func NewReplicaChecker(cluster Cluster, classifier namespace.Classifier) *ReplicaChecker {
+func NewReplicaChecker(cluster Cluster, classifier namespace.Classifier, n ...string) *ReplicaChecker {
+	name := replicaCheckerName
+	if len(n) != 0 {
+		name = n[0]
+	}
 	filters := []Filter{
-		NewOverloadFilter(),
-		NewHealthFilter(),
-		NewSnapshotCountFilter(),
+		NewOverloadFilter(name),
+		NewHealthFilter(name),
+		NewSnapshotCountFilter(name),
+		NewPendingPeerCountFilter(name),
 	}
 
 	return &ReplicaChecker{
+		name:       name,
 		cluster:    cluster,
 		classifier: classifier,
 		filters:    filters,
@@ -65,7 +74,7 @@ func (r *ReplicaChecker) Check(region *core.RegionInfo) *Operator {
 
 	if len(region.GetPeers()) < r.cluster.GetMaxReplicas() && r.cluster.IsMakeUpReplicaEnabled() {
 		log.Debug("region has fewer than max replicas", zap.Uint64("region-id", region.GetID()), zap.Int("peers", len(region.GetPeers())))
-		newPeer, _ := r.selectBestPeerToAddReplica(region, NewStorageThresholdFilter())
+		newPeer, _ := r.selectBestPeerToAddReplica(region, NewStorageThresholdFilter(r.name))
 		if newPeer == nil {
 			checkerCounter.WithLabelValues("replica_checker", "no_target_store").Inc()
 			return nil
@@ -97,7 +106,7 @@ func (r *ReplicaChecker) Check(region *core.RegionInfo) *Operator {
 
 // SelectBestReplacementStore returns a store id that to be used to replace the old peer and distinct score.
 func (r *ReplicaChecker) SelectBestReplacementStore(region *core.RegionInfo, oldPeer *metapb.Peer, filters ...Filter) (uint64, float64) {
-	filters = append(filters, NewExcludedFilter(nil, region.GetStoreIds()))
+	filters = append(filters, NewExcludedFilter(r.name, nil, region.GetStoreIds()))
 	newRegion := region.Clone(core.WithRemoveStorePeer(oldPeer.GetStoreId()))
 	return r.selectBestStoreToAddReplica(newRegion, filters...)
 }
@@ -120,14 +129,14 @@ func (r *ReplicaChecker) selectBestPeerToAddReplica(region *core.RegionInfo, fil
 func (r *ReplicaChecker) selectBestStoreToAddReplica(region *core.RegionInfo, filters ...Filter) (uint64, float64) {
 	// Add some must have filters.
 	newFilters := []Filter{
-		NewStateFilter(),
-		NewPendingPeerCountFilter(),
-		NewExcludedFilter(nil, region.GetStoreIds()),
+		NewStateFilter(r.name),
+		NewPendingPeerCountFilter(r.name),
+		NewExcludedFilter(r.name, nil, region.GetStoreIds()),
 	}
 	filters = append(filters, r.filters...)
 	filters = append(filters, newFilters...)
 	if r.classifier != nil {
-		filters = append(filters, NewNamespaceFilter(r.classifier, r.classifier.GetRegionNamespace(region)))
+		filters = append(filters, NewNamespaceFilter(r.name, r.classifier, r.classifier.GetRegionNamespace(region)))
 	}
 	regionStores := r.cluster.GetRegionStores(region)
 	selector := NewReplicaSelector(regionStores, r.cluster.GetLocationLabels(), r.filters...)
@@ -213,7 +222,7 @@ func (r *ReplicaChecker) checkBestReplacement(region *core.RegionInfo) *Operator
 		checkerCounter.WithLabelValues("replica_checker", "all_right").Inc()
 		return nil
 	}
-	storeID, newScore := r.SelectBestReplacementStore(region, oldPeer, NewStorageThresholdFilter())
+	storeID, newScore := r.SelectBestReplacementStore(region, oldPeer, NewStorageThresholdFilter(r.name))
 	if storeID == 0 {
 		checkerCounter.WithLabelValues("replica_checker", "no_replacement_store").Inc()
 		return nil
@@ -263,7 +272,7 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, peer *metapb.Peer, sta
 		return op
 	}
 
-	storeID, _ := r.SelectBestReplacementStore(region, peer, NewStorageThresholdFilter())
+	storeID, _ := r.SelectBestReplacementStore(region, peer, NewStorageThresholdFilter(r.name))
 	if storeID == 0 {
 		log.Debug("no best store to add replica", zap.Uint64("region-id", region.GetID()))
 		return nil

--- a/server/schedulers/evict_leader.go
+++ b/server/schedulers/evict_leader.go
@@ -45,13 +45,14 @@ type evictLeaderScheduler struct {
 // newEvictLeaderScheduler creates an admin scheduler that transfers all leaders
 // out of a store.
 func newEvictLeaderScheduler(opController *schedule.OperatorController, storeID uint64) schedule.Scheduler {
+	name := fmt.Sprintf("evict-leader-scheduler-%d", storeID)
 	filters := []schedule.Filter{
-		schedule.StoreStateFilter{TransferLeader: true},
+		schedule.StoreStateFilter{ActionScope: name, TransferLeader: true},
 	}
 	base := newBaseScheduler(opController)
 	return &evictLeaderScheduler{
 		baseScheduler: base,
-		name:          fmt.Sprintf("evict-leader-scheduler-%d", storeID),
+		name:          name,
 		storeID:       storeID,
 		selector:      schedule.NewRandomSelector(filters),
 	}

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -44,6 +44,7 @@ const (
 	hotRegionLimitFactor      = 0.75
 	storeHotRegionsDefaultLen = 100
 	hotRegionScheduleFactor   = 0.9
+	balanceHotRegionName      = "balance-hot-region-scheduler"
 )
 
 // BalanceType : the perspective of balance
@@ -69,6 +70,7 @@ func newStoreStaticstics() *storeStatistics {
 }
 
 type balanceHotRegionsScheduler struct {
+	name string
 	*baseScheduler
 	sync.RWMutex
 	leaderLimit uint64
@@ -83,6 +85,7 @@ type balanceHotRegionsScheduler struct {
 func newBalanceHotRegionsScheduler(opController *schedule.OperatorController) *balanceHotRegionsScheduler {
 	base := newBaseScheduler(opController)
 	return &balanceHotRegionsScheduler{
+		name:          balanceHotRegionName,
 		baseScheduler: base,
 		leaderLimit:   1,
 		peerLimit:     1,
@@ -117,7 +120,7 @@ func newBalanceHotWriteRegionsScheduler(opController *schedule.OperatorControlle
 }
 
 func (h *balanceHotRegionsScheduler) GetName() string {
-	return "balance-hot-region-scheduler"
+	return h.name
 }
 
 func (h *balanceHotRegionsScheduler) GetType() string {
@@ -305,10 +308,13 @@ func (h *balanceHotRegionsScheduler) balanceByPeer(cluster schedule.Cluster, sto
 		}
 
 		srcStore := cluster.GetStore(srcStoreID)
+		if srcStore == nil {
+			log.Error("failed to get the source store", zap.Uint64("store-id", srcStoreID))
+		}
 		filters := []schedule.Filter{
-			schedule.StoreStateFilter{MoveRegion: true},
-			schedule.NewExcludedFilter(srcRegion.GetStoreIds(), srcRegion.GetStoreIds()),
-			schedule.NewDistinctScoreFilter(cluster.GetLocationLabels(), cluster.GetRegionStores(srcRegion), srcStore),
+			schedule.StoreStateFilter{ActionScope: h.GetName(), MoveRegion: true},
+			schedule.NewExcludedFilter(h.GetName(), srcRegion.GetStoreIds(), srcRegion.GetStoreIds()),
+			schedule.NewDistinctScoreFilter(h.GetName(), cluster.GetLocationLabels(), cluster.GetRegionStores(srcRegion), srcStore),
 		}
 		candidateStoreIDs := make([]uint64, 0, len(stores))
 		for _, store := range stores {
@@ -367,7 +373,7 @@ func (h *balanceHotRegionsScheduler) balanceByLeader(cluster schedule.Cluster, s
 			continue
 		}
 
-		filters := []schedule.Filter{schedule.StoreStateFilter{TransferLeader: true}}
+		filters := []schedule.Filter{schedule.StoreStateFilter{ActionScope: h.GetName(), TransferLeader: true}}
 		candidateStoreIDs := make([]uint64, 0, len(srcRegion.GetPeers())-1)
 		for _, store := range cluster.GetFollowerStores(srcRegion) {
 			if !schedule.FilterTarget(cluster, store, filters) {

--- a/server/schedulers/metrics.go
+++ b/server/schedulers/metrics.go
@@ -47,6 +47,14 @@ var balanceRegionCounter = prometheus.NewCounterVec(
 		Help:      "Counter of balance region scheduler.",
 	}, []string{"type", "address", "store"})
 
+var balanceDirectionCounter = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "pd",
+		Subsystem: "scheduler",
+		Name:      "balance_direction",
+		Help:      "Counter of direction of balance related schedulers.",
+	}, []string{"type", "source", "target"})
+
 var scatterRangeLeaderCounter = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "pd",
@@ -68,6 +76,7 @@ func init() {
 	prometheus.MustRegister(schedulerStatus)
 	prometheus.MustRegister(balanceLeaderCounter)
 	prometheus.MustRegister(balanceRegionCounter)
+	prometheus.MustRegister(balanceDirectionCounter)
 	prometheus.MustRegister(scatterRangeLeaderCounter)
 	prometheus.MustRegister(scatterRangeRegionCounter)
 }

--- a/server/schedulers/random_merge.go
+++ b/server/schedulers/random_merge.go
@@ -26,7 +26,10 @@ func init() {
 	})
 }
 
+const randomMergeName = "random-merge-scheduler"
+
 type randomMergeScheduler struct {
+	name string
 	*baseScheduler
 	selector *schedule.RandomSelector
 }
@@ -35,17 +38,18 @@ type randomMergeScheduler struct {
 // then merges them.
 func newRandomMergeScheduler(opController *schedule.OperatorController) schedule.Scheduler {
 	filters := []schedule.Filter{
-		schedule.StoreStateFilter{MoveRegion: true},
+		schedule.StoreStateFilter{ActionScope: randomMergeName, MoveRegion: true},
 	}
 	base := newBaseScheduler(opController)
 	return &randomMergeScheduler{
+		name:          randomMergeName,
 		baseScheduler: base,
 		selector:      schedule.NewRandomSelector(filters),
 	}
 }
 
 func (s *randomMergeScheduler) GetName() string {
-	return "random-merge-scheduler"
+	return s.name
 }
 
 func (s *randomMergeScheduler) GetType() string {

--- a/server/schedulers/shuffle_hot_region.go
+++ b/server/schedulers/shuffle_hot_region.go
@@ -107,10 +107,13 @@ func (s *shuffleHotRegionScheduler) randomSchedule(cluster schedule.Cluster, sto
 		}
 		srcStoreID := srcRegion.GetLeader().GetStoreId()
 		srcStore := cluster.GetStore(srcStoreID)
+		if srcStore == nil {
+			log.Error("failed to get the source store", zap.Uint64("store-id", srcStoreID))
+		}
 		filters := []schedule.Filter{
-			schedule.StoreStateFilter{MoveRegion: true},
-			schedule.NewExcludedFilter(srcRegion.GetStoreIds(), srcRegion.GetStoreIds()),
-			schedule.NewDistinctScoreFilter(cluster.GetLocationLabels(), cluster.GetRegionStores(srcRegion), srcStore),
+			schedule.StoreStateFilter{ActionScope: s.GetName(), MoveRegion: true},
+			schedule.NewExcludedFilter(s.GetName(), srcRegion.GetStoreIds(), srcRegion.GetStoreIds()),
+			schedule.NewDistinctScoreFilter(s.GetName(), cluster.GetLocationLabels(), cluster.GetRegionStores(srcRegion), srcStore),
 		}
 		stores := cluster.GetStores()
 		destStoreIDs := make([]uint64, 0, len(stores))

--- a/server/schedulers/shuffle_leader.go
+++ b/server/schedulers/shuffle_leader.go
@@ -24,7 +24,10 @@ func init() {
 	})
 }
 
+const shuffleLeaderName = "shuffle-leader-scheduler"
+
 type shuffleLeaderScheduler struct {
+	name string
 	*baseScheduler
 	selector *schedule.RandomSelector
 }
@@ -33,17 +36,18 @@ type shuffleLeaderScheduler struct {
 // between stores.
 func newShuffleLeaderScheduler(opController *schedule.OperatorController) schedule.Scheduler {
 	filters := []schedule.Filter{
-		schedule.StoreStateFilter{TransferLeader: true},
+		schedule.StoreStateFilter{ActionScope: shuffleLeaderName, TransferLeader: true},
 	}
 	base := newBaseScheduler(opController)
 	return &shuffleLeaderScheduler{
+		name:          shuffleLeaderName,
 		baseScheduler: base,
 		selector:      schedule.NewRandomSelector(filters),
 	}
 }
 
 func (s *shuffleLeaderScheduler) GetName() string {
-	return "shuffle-leader-scheduler"
+	return s.name
 }
 
 func (s *shuffleLeaderScheduler) GetType() string {


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
cherry-pick #1746 to release-3.0

### What is changed and how it works?
This PR adds a new dimension named `ActOn` for each filter to indicate that each scheduler or checker is affected by the kind of the filter.
Also this PR removes two unused filters: `disconnectFilter` and `rejectLeaderFilter `

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to update the `tidb-ansible` repository
 - Need to be included in the release notes
