### PR TITLE
schedulers: make testHotWriteRegionSchedulerSuite stable

### DIFF
--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -201,8 +201,7 @@ const balanceHotRetryLimit = 10
 
 func (h *balanceHotRegionsScheduler) balanceHotWriteRegions(cluster opt.Cluster) []*operator.Operator {
 	for i := 0; i < balanceHotRetryLimit; i++ {
-		switch h.r.Int() % 2 {
-		case 0:
+		if h.allowBalanceRegion(cluster) && (!h.allowBalanceLeader(cluster) || h.r.Int()%2 == 0) {
 			// balance by peer
 			srcRegion, srcPeer, destPeer := h.balanceByPeer(cluster, h.stats.writeStatAsPeer)
 			if srcRegion != nil {
@@ -215,7 +214,7 @@ func (h *balanceHotRegionsScheduler) balanceHotWriteRegions(cluster opt.Cluster)
 				schedulerCounter.WithLabelValues(h.GetName(), "move-peer").Inc()
 				return []*operator.Operator{op}
 			}
-		case 1:
+		} else if h.allowBalanceLeader(cluster) {
 			// balance by leader
 			srcRegion, newLeader := h.balanceByLeader(cluster, h.stats.writeStatAsLeader)
 			if srcRegion != nil {
@@ -224,6 +223,8 @@ func (h *balanceHotRegionsScheduler) balanceHotWriteRegions(cluster opt.Cluster)
 				op.SetPriorityLevel(core.HighPriority)
 				return []*operator.Operator{op}
 			}
+		} else {
+			break
 		}
 	}
 

--- a/server/schedulers/hot_test.go
+++ b/server/schedulers/hot_test.go
@@ -162,6 +162,7 @@ func (s *testHotWriteRegionSchedulerSuite) TestSchedule(c *C) {
 	//   Region 1 and 2 are the same, cannot move peer to store 5 due to the label.
 	//   Region 3 can only move peer to store 5.
 	//   Region 5 can only move peer to store 6.
+	opt.LeaderScheduleLimit = 0
 	for i := 0; i < 30; i++ {
 		op := hb.Schedule(tc)[0]
 		switch op.RegionID() {


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fix https://github.com/pingcap/pd/issues/1901

### What is changed and how it works?
- Consider limits when deciding `byPeer` or `byLeader`
- Disable leader limit in test 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test
