### PR TITLE
client: check timestamp decrease and return error

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -19,8 +19,7 @@ import (
 	"sync"
 	"time"
 
-	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/pingcap/failpoint"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
@@ -459,9 +458,6 @@ func (c *client) processTSORequests(stream pdpb.PD_TsoClient, requests []*tsoReq
 	}
 
 	physical, logical := resp.GetTimestamp().GetPhysical(), resp.GetTimestamp().GetLogical()
-	failpoint.Inject("timestampDecrease", func() {
-		physical = c.lastPhysical - 1
-	})
 	// Server returns the highest ts.
 	logical -= int64(resp.GetCount() - 1)
 	c.finishTSORequest(requests, physical, logical, nil)

--- a/client/client.go
+++ b/client/client.go
@@ -465,7 +465,7 @@ func (c *client) processTSORequests(stream pdpb.PD_TsoClient, requests []*tsoReq
 }
 
 func (c *client) finishTSORequest(requests []*tsoRequest, physical, firstLogical int64, err error) {
-	if tsLessEqual(physical, firstLogical, c.lastPhysical, c.lastLogical) {
+	if err == nil && tsLessEqual(physical, firstLogical, c.lastPhysical, c.lastLogical) {
 		panic(errors.Errorf("timestamp fallback, newly acquired ts (%d,%d) is less or equal to last one (%d, %d)",
 			physical, firstLogical, c.lastLogical, c.lastLogical))
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -476,9 +476,8 @@ func (c *client) finishTSORequest(requests []*tsoRequest, physical, firstLogical
 		requests[i].physical, requests[i].logical = physical, firstLogical+int64(i)
 		requests[i].done <- err
 	}
-	lastRequest := requests[len(requests)-1]
-	c.lastPhysical = lastRequest.physical
-	c.lastLogical = lastRequest.logical
+	c.lastPhysical = physical
+	c.lastLogical = firstLogical + int64(len(requests)) - 1
 }
 
 func tsLessEqual(physical, logical, thatPhysical, thatLogical int64) bool {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	. "github.com/pingcap/check"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/pd/pkg/mock/mockid"
@@ -172,6 +173,10 @@ func (s *testClientSuite) TestTSO(c *C) {
 		c.Assert(ts, Greater, last)
 		last = ts
 	}
+	c.Assert(failpoint.Enable("github.com/pingcap/pd/client/timestampDecrease", "return(true)"), IsNil)
+	_, _, err := s.client.GetTS(context.Background())
+	c.Assert(err, NotNil)
+	c.Assert(failpoint.Disable("github.com/pingcap/pd/client/timestampDecrease"), IsNil)
 }
 
 func (s *testClientSuite) TestTSORace(c *C) {


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
If timestamp decrease, the transaction consistency can break

### What is changed and how it works?
Detects timestamp decreases and returns an error when it happens.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
