### PR TITLE
testing: temporary skip TestGetVersion

### DIFF
--- a/server/api/version_test.go
+++ b/server/api/version_test.go
@@ -33,6 +33,9 @@ var _ = Suite(&testVersionSuite{})
 type testVersionSuite struct{}
 
 func (s *testVersionSuite) TestGetVersion(c *C) {
+	// TODO: enable it.
+	c.Skip("Temporary disable. See issue: https://github.com/pingcap/pd/issues/1893")
+
 	fname := filepath.Join(os.TempDir(), "stdout")
 	old := os.Stdout
 	temp, _ := os.Create(fname)


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
`TestGetVersion` fails a lot in CI environment.

### What is changed and how it works?
temporary disable it.
