### PR TITLE
pd-ctl: fix echo when TiKV cluster not bootstrapped

### DIFF
--- a/tests/pdctl/operator/operator_test.go
+++ b/tests/pdctl/operator/operator_test.go
@@ -198,7 +198,9 @@ func (s *operatorTestSuite) TestOperator(c *C) {
 	c.Assert(strings.Contains(string(output), "scatter-region"), IsTrue)
 
 	// test echo
-	echo := pdctl.GetEcho([]string{"-u", pdAddr, "operator", "add", "scatter-region", "1"})
+	echo := pdctl.GetEcho([]string{"-u", pdAddr, "operator", "remove", "1"})
+	c.Assert(strings.Contains(echo, "Success!"), IsTrue)
+	echo = pdctl.GetEcho([]string{"-u", pdAddr, "operator", "add", "scatter-region", "1"})
 	c.Assert(strings.Contains(echo, "Success!"), IsTrue)
 	echo = pdctl.GetEcho([]string{"-u", pdAddr, "operator", "remove", "1"})
 	c.Assert(strings.Contains(echo, "Success!"), IsTrue)

--- a/tools/pd-ctl/pdctl/command/global.go
+++ b/tools/pd-ctl/pdctl/command/global.go
@@ -93,7 +93,7 @@ func doRequest(cmd *cobra.Command, prefix string, method string,
 			req.Header.Set("Content-Type", b.contentType)
 		}
 		// the resp would be returned by the outer function
-		resp, err = dail(req)
+		resp, err = dial(req)
 		if err != nil {
 			return err
 		}
@@ -102,7 +102,7 @@ func doRequest(cmd *cobra.Command, prefix string, method string,
 	return resp, err
 }
 
-func dail(req *http.Request) (string, error) {
+func dial(req *http.Request) (string, error) {
 	resp, err := dialClient.Do(req)
 	if err != nil {
 		return "", err
@@ -140,7 +140,7 @@ func tryURLs(cmd *cobra.Command, endpoints []string, f DoFunc) error {
 		}
 		// tolerate some schemes that will be used by users, the TiKV SDK
 		// use 'tikv' as the scheme, it is really confused if we do not
-		// support it by pdctl
+		// support it by pd-ctl
 		if u.Scheme == "" || u.Scheme == "pd" || u.Scheme == "tikv" {
 			u.Scheme = "http"
 		}
@@ -201,6 +201,7 @@ func postJSON(cmd *cobra.Command, prefix string, input map[string]interface{}) {
 	})
 	if err != nil {
 		cmd.Println(err)
+		return
 	}
 	cmd.Println("Success!")
 }

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -34,8 +34,8 @@ var (
 	regionsPrefix          = "pd/api/v1/regions"
 	regionsStorePrefix     = "pd/api/v1/regions/store"
 	regionsCheckPrefix     = "pd/api/v1/regions/check"
-	regionsWriteflowPrefix = "pd/api/v1/regions/writeflow"
-	regionsReadflowPrefix  = "pd/api/v1/regions/readflow"
+	regionsWriteFlowPrefix = "pd/api/v1/regions/writeflow"
+	regionsReadFlowPrefix  = "pd/api/v1/regions/readflow"
 	regionsConfVerPrefix   = "pd/api/v1/regions/confver"
 	regionsVersionPrefix   = "pd/api/v1/regions/version"
 	regionsSizePrefix      = "pd/api/v1/regions/size"
@@ -180,7 +180,7 @@ func scanRegionCommandFunc(cmd *cobra.Command, args []string) {
 }
 
 func showRegionTopWriteCommandFunc(cmd *cobra.Command, args []string) {
-	prefix := regionsWriteflowPrefix
+	prefix := regionsWriteFlowPrefix
 	if len(args) == 1 {
 		if _, err := strconv.Atoi(args[0]); err != nil {
 			cmd.Println("limit should be a number")
@@ -201,7 +201,7 @@ func showRegionTopWriteCommandFunc(cmd *cobra.Command, args []string) {
 }
 
 func showRegionTopReadCommandFunc(cmd *cobra.Command, args []string) {
-	prefix := regionsReadflowPrefix
+	prefix := regionsReadFlowPrefix
 	if len(args) == 1 {
 		if _, err := strconv.Atoi(args[0]); err != nil {
 			cmd.Println("limit should be a number")


### PR DESCRIPTION
Signed-off-by: lhy1024 <admin@liudos.us>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

#1943 

### What is changed and how it works?

fix echo and some typo

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
