### PR TITLE
checker: fix offline when only having one replica

### DIFF
--- a/server/schedule/checker/replica_checker.go
+++ b/server/schedule/checker/replica_checker.go
@@ -26,7 +26,10 @@ import (
 	"go.uber.org/zap"
 )
 
-const replicaCheckerName = "replica-checker"
+const (
+	replicaCheckerName = "replica-checker"
+	minReplicaCount    = 1
+)
 
 const (
 	offlineStatus = "offline"
@@ -277,7 +280,7 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, peer *metapb.Peer, sta
 
 	replace := fmt.Sprintf("replace-%s-replica", status)
 	var op *operator.Operator
-	if status == offlineStatus {
+	if status == offlineStatus && r.cluster.GetMaxReplicas() > minReplicaCount {
 		op, err = operator.CreateOfflinePeerOperator(replace, r.cluster, region, operator.OpReplica, peer.GetStoreId(), newPeer)
 	} else {
 		op, err = operator.CreateMovePeerOperator(replace, r.cluster, region, operator.OpReplica, peer.GetStoreId(), newPeer)

--- a/server/schedule/checker/replica_checker_test.go
+++ b/server/schedule/checker/replica_checker_test.go
@@ -128,3 +128,18 @@ func (s *testReplicaCheckerSuite) TestReplaceOfflinePeer(c *C) {
 	c.Assert(op.Step(2).(operator.PromoteLearner).ToStore, Equals, uint64(4))
 	c.Assert(op.Step(3).(operator.RemovePeer).FromStore, Equals, uint64(1))
 }
+
+func (s *testReplicaCheckerSuite) TestOfflineWithOneReplica(c *C) {
+	s.cluster.MaxReplicas = 1
+	peers := []*metapb.Peer{
+		{
+			Id:      4,
+			StoreId: 1,
+		},
+	}
+	r := core.NewRegionInfo(&metapb.Region{Id: 2, Peers: peers}, peers[0])
+	s.cluster.PutRegion(r)
+	op := s.rc.Check(r)
+	c.Assert(op, NotNil)
+	c.Assert(op.Desc(), Equals, "replace-offline-replica")
+}


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Closes #1923.

### What is changed and how it works?
This PR fixes it by checking if the max replica is 1 before transferring the leader.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test