### PR TITLE
add profile CPU/memory/mutex/allocs/block/goroutine HTTP API

### DIFF
--- a/server/api/router.go
+++ b/server/api/router.go
@@ -15,6 +15,7 @@ package api
 
 import (
 	"net/http"
+	"net/http/pprof"
 
 	"github.com/gorilla/mux"
 	"github.com/pingcap/pd/server"
@@ -148,6 +149,14 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	// metric query use to query metric data, the protocol is compatible with prometheus.
 	rootRouter.Handle("/api/v1/metric/query", newQueryMetric(svr)).Methods("GET", "POST")
 	rootRouter.Handle("/api/v1/metric/query_range", newQueryMetric(svr)).Methods("GET", "POST")
+
+	// profile API
+	rootRouter.HandleFunc("/api/v1/debug/pprof/profile", pprof.Profile)
+	rootRouter.Handle("/api/v1/debug/pprof/heap", pprof.Handler("heap"))
+	rootRouter.Handle("/api/v1/debug/pprof/mutex", pprof.Handler("mutex"))
+	rootRouter.Handle("/api/v1/debug/pprof/allocs", pprof.Handler("allocs"))
+	rootRouter.Handle("/api/v1/debug/pprof/block", pprof.Handler("block"))
+	rootRouter.Handle("/api/v1/debug/pprof/goroutine", pprof.Handler("goroutine"))
 
 	// Deprecated
 	rootRouter.Handle("/health", newHealthHandler(svr, rd)).Methods("GET")


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

This PR adds profile CPU/memory/mutex/allocs/block/goroutine HTTP API and make profile cluster component via SQL possible. (Part of https://github.com/pingcap/tidb/issues/13567)

### What is changed and how it works?

Add HTTP API for PD.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has HTTP API interfaces change (Don't forget to [update API document]