### PR TITLE
*: fix the max recv message size for the client (#1952)

### DIFF
--- a/pkg/grpcutil/grpcutil.go
+++ b/pkg/grpcutil/grpcutil.go
@@ -25,7 +25,7 @@ import (
 )
 
 // GetClientConn returns a gRPC client connection.
-func GetClientConn(addr string, caPath string, certPath string, keyPath string) (*grpc.ClientConn, error) {
+func GetClientConn(addr string, caPath string, certPath string, keyPath string, do ...grpc.DialOption) (*grpc.ClientConn, error) {
 	opt := grpc.WithInsecure()
 	if len(caPath) != 0 {
 		certificates := []tls.Certificate{}
@@ -61,7 +61,7 @@ func GetClientConn(addr string, caPath string, certPath string, keyPath string) 
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	cc, err := grpc.Dial(u.Host, opt)
+	cc, err := grpc.Dial(u.Host, append(do, opt)...)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/server/region_syncer/client.go
+++ b/server/region_syncer/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/pd/server/core"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -51,7 +52,7 @@ func (s *RegionSyncer) reset() {
 func (s *RegionSyncer) establish(addr string) (ClientStream, error) {
 	s.reset()
 
-	cc, err := grpcutil.GetClientConn(addr, s.securityConfig["caPath"], s.securityConfig["certPath"], s.securityConfig["keyPath"])
+	cc, err := grpcutil.GetClientConn(addr, s.securityConfig["caPath"], s.securityConfig["certPath"], s.securityConfig["keyPath"], grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(msgSize)))
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
cherry-pick #1952 

### What is changed and how it works?
The previous PR accidentally removes the max gRPC receive message size constraint for the client. This PR fixes it by adding it back.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
