### PR TITLE
server/api: drop indent, add streaming for Json API (PCP)

### DIFF
--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -14,10 +14,12 @@
 package api
 
 import (
+	"bytes"
 	"fmt"
 	"math/rand"
 	"net/url"
 	"sort"
+	"testing"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -329,5 +331,46 @@ func (s *testGetRegionSuite) TestScanRegionByKey(c *C) {
 	c.Assert(len(regionIds), Equals, regions.Count)
 	for i, v := range regionIds {
 		c.Assert(v, Equals, regions.Regions[i].ID)
+	}
+}
+
+// Create n regions (0..n) of n stores (0..n).
+// Each region contains np peers, the first peer is the leader.
+// (copied from server/cluster_test.go)
+func newTestRegions(n, np uint64) []*core.RegionInfo {
+	regions := make([]*core.RegionInfo, 0, n)
+	for i := uint64(0); i < n; i++ {
+		peers := make([]*metapb.Peer, 0, np)
+		for j := uint64(0); j < np; j++ {
+			peer := &metapb.Peer{
+				Id: i*np + j,
+			}
+			peer.StoreId = (i + j) % n
+			peers = append(peers, peer)
+		}
+		region := &metapb.Region{
+			Id:          i,
+			Peers:       peers,
+			StartKey:    []byte{byte(i)},
+			EndKey:      []byte{byte(i + 1)},
+			RegionEpoch: &metapb.RegionEpoch{ConfVer: 2, Version: 2},
+		}
+		regions = append(regions, core.NewRegionInfo(region, peers[0]))
+	}
+	return regions
+}
+
+func BenchmarkRenderJSON(b *testing.B) {
+	regionsCount := uint64(10_000)
+	storeCount := uint64(100)
+	regionInfos := newTestRegions(regionsCount, storeCount)
+
+	rd := createRender()
+	regions := convertToAPIRegions(regionInfos)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var buffer bytes.Buffer
+		rd.JSON(&buffer, 200, regions)
 	}
 }

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -21,10 +21,14 @@ import (
 	"github.com/unrolled/render"
 )
 
-func createRouter(prefix string, svr *server.Server) *mux.Router {
-	rd := render.New(render.Options{
-		IndentJSON: true,
+func createRender() *render.Render {
+	return render.New(render.Options{
+		StreamingJSON: true,
 	})
+}
+
+func createRouter(prefix string, svr *server.Server) *mux.Router {
+	rd := createRender()
 
 	rootRouter := mux.NewRouter().PathPrefix(prefix).Subrouter()
 	handler := svr.GetHandler()


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

PCP #1837

### What is changed and how it works?

- added `server/api/router.go#createRender` function for creating `*render.Render`
- removed option `IndentJSON` from the `render.New` call
- added option `StreamingJSON` to the  `render.New` call
- added `server/api/region_test.go#BenchmarkRenderJSON` for testing the performance of the last part of the `regionsHandler.GetAll` function (which takes 90% of the total time for the `/pd/api/v1/regions` endpoint in PCP #1837)

```sh
➜ GO111MODULE=on go test github.com/pingcap/pd/server/api -run=Benchmark -bench=BenchmarkRenderJSON -benchmem > new.txt
➜ git stash
➜ GO111MODULE=on go test github.com/pingcap/pd/server/api -run=Benchmark -bench=BenchmarkRenderJSON -benchmem > old.txt
➜ benchcmp old.txt new.txt
benchmark                  old ns/op     new ns/op     delta
BenchmarkRenderJSON-12     662659672     147632381     -77.72%

benchmark                  old allocs    new allocs    delta
BenchmarkRenderJSON-12     50            12            -76.00%

benchmark                  old bytes     new bytes     delta
BenchmarkRenderJSON-12     414771916     51753928      -87.52%
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
