### PR TITLE
PCP: Feat accelerate load region

### DIFF
--- a/server/cluster.go
+++ b/server/cluster.go
@@ -213,7 +213,7 @@ func (c *RaftCluster) loadClusterInfo() (*RaftCluster, error) {
 
 	start = time.Now()
 
-	if err := c.storage.LoadRegions(c.core.PutRegion); err != nil {
+	if err := c.regionSyncer.LoadRegionsCache(c.core.PutRegion); err != nil {
 		return nil, err
 	}
 	log.Info("load regions",

--- a/server/region_syncer/client.go
+++ b/server/region_syncer/client.go
@@ -128,6 +128,7 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 					err = s.server.GetStorage().SaveRegion(r)
 					if err == nil {
 						s.history.Record(core.NewRegionInfo(r, nil))
+						s.regionsCache = append(s.regionsCache, r)
 					}
 				}
 			}

--- a/server/region_syncer/client.go
+++ b/server/region_syncer/client.go
@@ -128,7 +128,7 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 					err = s.server.GetStorage().SaveRegion(r)
 					if err == nil {
 						s.history.Record(core.NewRegionInfo(r, nil))
-						s.regionsCache = append(s.regionsCache, r)
+						s.AddRegionCache(r)
 					}
 				}
 			}

--- a/server/region_syncer/server.go
+++ b/server/region_syncer/server.go
@@ -244,6 +244,7 @@ func (s *RegionSyncer) broadcast(regions *pdpb.SyncRegionResponse) {
 	}
 }
 
+// LoadRegionsCache loads all regions from cache to RegionsInfo.
 func (s *RegionSyncer) LoadRegionsCache(f func(region *core.RegionInfo) []*core.RegionInfo) error {
 	for _, region := range s.regionsCache {
 		overlaps := f(core.NewRegionInfo(region, nil))

--- a/server/region_syncer/server_test.go
+++ b/server/region_syncer/server_test.go
@@ -15,10 +15,12 @@ type testLoadRegionsCacheSuite struct{}
 func (s *testLoadRegionsCacheSuite) TestLoadRegionsCache(c *C) {
 	cache := core.NewRegionsInfo()
 	n := 10
-	regions := make([]*metapb.Region, 0, n)
+	regions := make(map[uint64]*metapb.Region)
+	copyCache := make(map[uint64]*metapb.Region)
 	for i := 0; i < n; i++ {
 		region := newTestRegionMeta(uint64(i))
-		regions = append(regions, region)
+		regions[region.GetId()] = region
+		copyCache[region.GetId()] = region
 	}
 	regionSyner := &RegionSyncer{
 		regionsCache: regions,
@@ -26,7 +28,7 @@ func (s *testLoadRegionsCacheSuite) TestLoadRegionsCache(c *C) {
 	c.Assert(regionSyner.LoadRegionsCache(cache.SetRegion), IsNil)
 	c.Assert(cache.GetRegionCount(), Equals, n)
 	for _, region := range cache.GetMetaRegions() {
-		c.Assert(region, DeepEquals, regions[region.GetId()])
+		c.Assert(region, DeepEquals, copyCache[region.GetId()])
 	}
 }
 func newTestRegionMeta(regionID uint64) *metapb.Region {

--- a/server/region_syncer/server_test.go
+++ b/server/region_syncer/server_test.go
@@ -1,0 +1,38 @@
+package syncer
+
+import (
+	"fmt"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/pd/server/core"
+)
+
+var _ = Suite(&testLoadRegionsCacheSuite{})
+
+type testLoadRegionsCacheSuite struct{}
+
+func (s *testLoadRegionsCacheSuite) TestLoadRegionsCache(c *C) {
+	cache := core.NewRegionsInfo()
+	n := 10
+	regions := make([]*metapb.Region, 0, n)
+	for i := 0; i < n; i++ {
+		region := newTestRegionMeta(uint64(i))
+		regions = append(regions, region)
+	}
+	regionSyner := &RegionSyncer{
+		regionsCache: regions,
+	}
+	c.Assert(regionSyner.LoadRegionsCache(cache.SetRegion), IsNil)
+	c.Assert(cache.GetRegionCount(), Equals, n)
+	for _, region := range cache.GetMetaRegions() {
+		c.Assert(region, DeepEquals, regions[region.GetId()])
+	}
+}
+func newTestRegionMeta(regionID uint64) *metapb.Region {
+	return &metapb.Region{
+		Id:       regionID,
+		StartKey: []byte(fmt.Sprintf("%20d", regionID)),
+		EndKey:   []byte(fmt.Sprintf("%20d", regionID+1)),
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -477,6 +477,7 @@ func (s *Server) bootstrapCluster(req *pdpb.BootstrapRequest) (*pdpb.BootstrapRe
 	if err != nil {
 		log.Warn("save the bootstrap region failed", zap.Error(err))
 	}
+	s.cluster.regionSyncer.AddRegionCache(req.GetRegion())
 	err = s.storage.Flush()
 	if err != nil {
 		log.Warn("flush the bootstrap region failed", zap.Error(err))


### PR DESCRIPTION
## Which problem does this PR solve?
PCP #1830
## What have you changed?
-  add `regionsCache` field in `RegionSyncer`
- `RegionSyncer` cache regions in `regionsCache` when recieves SyncRegionResponse
- add `LoadRegionsCache` func in `RegionSyncer`
- call `LoadRegionsCache` when cluster loadClusterInfo
## What are the type of the changes?
- New feature : add follower region cache
## How has this PR been tested?
unit test
