### PR TITLE
server: update region cache when peer list changed

### DIFF
--- a/server/cache.go
+++ b/server/cache.go
@@ -431,6 +431,9 @@ func (c *clusterInfo) handleRegionHeartbeat(region *core.RegionInfo) error {
 		if region.ApproximateSize != origin.ApproximateSize {
 			saveCache = true
 		}
+		if len(region.Peers) != len(origin.Peers) {
+			saveKV, saveCache = true, true
+		}
 	}
 
 	if saveKV && c.kv != nil {

--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -146,7 +146,7 @@ func (s *testRegionsInfoSuite) Test(c *C) {
 		checkRegion(c, cache.SearchRegion(regionKey), region)
 	}
 
-	for i := uint64(0); i < n; i++ {
+	for i := uint64(1); i <= n; i++ {
 		region := cache.RandLeaderRegion(i, core.HealthRegion())
 		c.Assert(region.Leader.GetStoreId(), Equals, i)
 
@@ -164,7 +164,7 @@ func (s *testRegionsInfoSuite) Test(c *C) {
 	c.Assert(cache.GetRegion(n-1), NotNil)
 
 	// All regions will be filtered out if they have pending peers.
-	for i := uint64(0); i < n; i++ {
+	for i := uint64(1); i <= n; i++ {
 		for j := 0; j < cache.GetStoreLeaderCount(i); j++ {
 			region := cache.RandLeaderRegion(i, core.HealthRegion())
 			region.PendingPeers = region.Peers
@@ -172,7 +172,7 @@ func (s *testRegionsInfoSuite) Test(c *C) {
 		}
 		c.Assert(cache.RandLeaderRegion(i, core.HealthRegion()), IsNil)
 	}
-	for i := uint64(0); i < n; i++ {
+	for i := uint64(1); i <= n; i++ {
 		c.Assert(cache.RandFollowerRegion(i, core.HealthRegion()), IsNil)
 	}
 }

--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -92,9 +92,9 @@ func newTestRegions(n, np uint64) []*core.RegionInfo {
 		peers := make([]*metapb.Peer, 0, np)
 		for j := uint64(0); j < np; j++ {
 			peer := &metapb.Peer{
-				Id: i*np + j,
+				Id: i*np + j + 1,
 			}
-			peer.StoreId = (i + j) % n
+			peer.StoreId = (i+j)%n + 1
 			peers = append(peers, peer)
 		}
 		region := &metapb.Region{
@@ -424,6 +424,12 @@ func (s *testClusterInfoSuite) testRegionHeartbeat(c *C, cache *clusterInfo) {
 		region.PendingPeers = nil
 		c.Assert(cache.handleRegionHeartbeat(region), IsNil)
 		checkRegions(c, cache.Regions, regions[:i+1])
+
+		// Different peer count.
+		region.Peers = region.Peers[:2]
+		c.Assert(cache.handleRegionHeartbeat(region), IsNil)
+		checkRegions(c, cache.Regions, regions[:i+1])
+		checkRegionsKV(c, cache.kv, regions[:i+1])
 	}
 
 	regionCounts := make(map[uint64]int)


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fix #1980

### What is changed and how it works?
Update cache and kv when peer list changed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test
