### PR TITLE
cluster: fix the health API problem

### DIFF
--- a/server/api/health.go
+++ b/server/api/health.go
@@ -49,12 +49,7 @@ func (h *healthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rc := h.svr.GetRaftCluster()
-	if rc == nil {
-		h.rd.JSON(w, http.StatusInternalServerError, cluster.ErrNotBootstrapped.Error())
-		return
-	}
-	unhealthMembers := rc.CheckHealth(members)
+	unhealthMembers := cluster.CheckHealth(members)
 	healths := []Health{}
 	for _, member := range members {
 		h := Health{

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1092,7 +1092,7 @@ func (c *RaftCluster) collectHealthStatus() {
 	if err != nil {
 		log.Error("get members error", zap.Error(err))
 	}
-	unhealth := c.CheckHealth(members)
+	unhealth := CheckHealth(members)
 	for _, member := range members {
 		if _, ok := unhealth[member.GetMemberId()]; ok {
 			healthStatusGauge.WithLabelValues(member.GetName()).Set(0)
@@ -1577,7 +1577,7 @@ var DialClient = &http.Client{
 var healthURL = "/pd/api/v1/ping"
 
 // CheckHealth checks if members are healthy.
-func (c *RaftCluster) CheckHealth(members []*pdpb.Member) map[uint64]*pdpb.Member {
+func CheckHealth(members []*pdpb.Member) map[uint64]*pdpb.Member {
 	unhealthMembers := make(map[uint64]*pdpb.Member)
 	for _, member := range members {
 		for _, cURL := range member.ClientUrls {

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -296,14 +296,6 @@ func (s *TestServer) GetStoreRegions(storeID uint64) []*core.RegionInfo {
 	return s.server.GetRaftCluster().GetStoreRegions(storeID)
 }
 
-// CheckHealth checks if members are healthy.
-func (s *TestServer) CheckHealth(members []*pdpb.Member) map[uint64]*pdpb.Member {
-	s.RLock()
-	defer s.RUnlock()
-	rc := s.server.GetRaftCluster()
-	return rc.CheckHealth(members)
-}
-
 // BootstrapCluster is used to bootstrap the cluster.
 func (s *TestServer) BootstrapCluster() error {
 	bootstrapReq := &pdpb.BootstrapRequest{
@@ -457,12 +449,6 @@ func (c *TestCluster) GetEtcdClient() *clientv3.Client {
 // GetConfig returns the current TestCluster's configuration.
 func (c *TestCluster) GetConfig() *clusterConfig {
 	return c.config
-}
-
-// CheckHealth checks if members are healthy.
-func (c *TestCluster) CheckHealth(members []*pdpb.Member) map[uint64]*pdpb.Member {
-	leader := c.GetLeader()
-	return c.servers[leader].CheckHealth(members)
 }
 
 // HandleRegionHeartbeat processes RegionInfo reports from the client.

--- a/tests/pdctl/health/health_test.go
+++ b/tests/pdctl/health/health_test.go
@@ -55,7 +55,7 @@ func (s *healthTestSuite) TestHealth(c *C) {
 	client := tc.GetEtcdClient()
 	members, err := cluster.GetMembers(client)
 	c.Assert(err, IsNil)
-	unhealthMembers := tc.CheckHealth(members)
+	unhealthMembers := cluster.CheckHealth(members)
 	healths := []api.Health{}
 	for _, member := range members {
 		h := api.Health{


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
After #1906 is merged. The health API cannot work due to the accidentally check.

### What is changed and how it works?
This PR fixes it by removing the bootstrap check.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test