### PR TITLE
client: export GetLeaderAddr

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -34,6 +34,9 @@ import (
 type Client interface {
 	// GetClusterID gets the cluster ID from PD.
 	GetClusterID(ctx context.Context) uint64
+	// GetLeaderAddr returns current leader's address. It returns "" before
+	// syncing leader from server.
+	GetLeaderAddr() string
 	// GetTS gets a timestamp from PD.
 	GetTS(ctx context.Context) (int64, int64, error)
 	// GetTSAsync gets a timestamp from PD, without block the caller.
@@ -540,7 +543,6 @@ func (c *client) GetClusterID(context.Context) uint64 {
 	return c.clusterID
 }
 
-// For testing use.
 func (c *client) GetLeaderAddr() string {
 	c.connMu.RLock()
 	defer c.connMu.RUnlock()


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Some tools need to access PD's HTTP API but cannot know which PD is current leader.

### What is changed and how it works?
export `GetLeaderAddr`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- only export exsisted function.
