### PR TITLE
fix bug of args -h in pd-ctl interactive mode

### DIFF
--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -26,6 +26,7 @@ type CommandFlags struct {
 	CAPath   string
 	CertPath string
 	KeyPath  string
+	Help     bool
 }
 
 var (
@@ -46,6 +47,7 @@ func Start(args []string) {
 	rootCmd.Flags().StringVar(&commandFlags.CAPath, "cacert", "", "path of file that contains list of trusted SSL CAs.")
 	rootCmd.Flags().StringVar(&commandFlags.CertPath, "cert", "", "path of file that contains X509 certificate in PEM format.")
 	rootCmd.Flags().StringVar(&commandFlags.KeyPath, "key", "", "path of file that contains X509 key in PEM format.")
+	rootCmd.PersistentFlags().BoolVarP(&commandFlags.Help, "help", "h", false, "Help message.")
 	rootCmd.AddCommand(
 		command.NewConfigCommand(),
 		command.NewRegionCommand(),


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
In step c below.

```
bin/pd-ctl -i

config show -h
```

Tips are as follows

```
show replication and schedule config of PD

Usage:
...
```

But enter the following command

```
config show
```

Tips are still as follows

```
show replication and schedule config of PD

Usage:
```

In fact, it should show specific content：

```
{
  "replication": {
    "EnablePlacementRules": false,
    "location-labels": "",
    "max-replicas": 3,
    "strictly-match-label": "false"
  },
...
```
### What is changed and how it works?
The reason is that in interactive mode the value of --help -h is passed down from the previous command.so I used 'PersistentFlags' to avoid it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)

Code changes


Side effects


Related changes

