### PR TITLE
core: fix misleading wrong keys log

### DIFF
--- a/server/core/region_tree.go
+++ b/server/core/region_tree.go
@@ -226,9 +226,11 @@ func (t *regionTree) RandomRegion(ranges []KeyRange) *RegionInfo {
 		}
 
 		if endIndex <= startIndex {
-			log.Error("wrong keys",
-				zap.String("start-key", string(HexRegionKey(startKey))),
-				zap.String("end-key", string(HexRegionKey(endKey))))
+			if len(endKey) > 0 && bytes.Compare(startKey, endKey) > 0 {
+				log.Error("wrong range keys",
+					zap.String("start-key", string(HexRegionKey(startKey))),
+					zap.String("end-key", string(HexRegionKey(endKey))))
+			}
 			continue
 		}
 		index := rand.Intn(endIndex-startIndex) + startIndex


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fix #1976 
Fix #1913 

### What is changed and how it works?
log when the keys are really wrong. (startIndex==endIndex can happen when there is simply no region in the range)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)
```
(in server/schedulers) $ go test
```
