### PR TITLE
pdctl:fix some parameters of region not displaying

### DIFF
--- a/server/api/region.go
+++ b/server/api/region.go
@@ -37,12 +37,12 @@ type RegionInfo struct {
 	Leader          *metapb.Peer      `json:"leader,omitempty"`
 	DownPeers       []*pdpb.PeerStats `json:"down_peers,omitempty"`
 	PendingPeers    []*metapb.Peer    `json:"pending_peers,omitempty"`
-	WrittenBytes    uint64            `json:"written_bytes,omitempty"`
-	ReadBytes       uint64            `json:"read_bytes,omitempty"`
+	WrittenBytes    uint64            `json:"written_bytes"`
+	ReadBytes       uint64            `json:"read_bytes"`
 	WrittenKeys     uint64            `json:"written_keys,omitempty"`
 	ReadKeys        uint64            `json:"read_keys,omitempty"`
-	ApproximateSize int64             `json:"approximate_size,omitempty"`
-	ApproximateKeys int64             `json:"approximate_keys,omitempty"`
+	ApproximateSize int64             `json:"approximate_size"`
+	ApproximateKeys int64             `json:"approximate_keys"`
 }
 
 // NewRegionInfo create a new api RegionInfo.


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
when I used the command 'pd-ctl region check empty-region'，output like this:

```
  {
      "id": 5404114,
      "start_key": "7480000000000002FFE500000000000000F8",
      "end_key": "7480000000000002FFE600000000000000F8",
      "epoch": {
        "conf_ver": 961,
        "version": 10348
      },
      "peers": [
        {
          "id": 5404116,
          "store_id": 1
        },
        {
          "id": 5770409,
          "store_id": 11
        },
        {
          "id": 5772468,
          "store_id": 8
        }
      ],
      "leader": {
        "id": 5404116,
        "store_id": 1
      },
      "approximate_size": 1
    }

```

I wanted to see the true value of approximate_keys,written_bytes,read_bytes ,because their true value is zero.
### What is changed and how it works?
remove the json 'omitempty' limit.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test


Code changes


Side effects

Related changes

