### PR TITLE
test: fix the race of TestRemoveTombstone

### DIFF
--- a/server/schedule/operator_controller_test.go
+++ b/server/schedule/operator_controller_test.go
@@ -567,6 +567,7 @@ func (t *testOperatorControllerSuite) TestStoreLimitWithMerge(c *C) {
 }
 
 func (t *testOperatorControllerSuite) TestRemoveTombstone(c *C) {
+	var mu sync.Mutex
 	cfg := mockoption.NewScheduleOptions()
 	cfg.StoreBalanceRate = 1000
 	cfg.LocationLabels = []string{"zone", "rack"}
@@ -598,11 +599,15 @@ func (t *testOperatorControllerSuite) TestRemoveTombstone(c *C) {
 	go func() {
 		defer wg.Done()
 		time.Sleep(100 * time.Millisecond)
+		mu.Lock()
+		defer mu.Unlock()
 		oc.RemoveStoreLimit(4)
 	}()
 	for i := 2; i < 20; i++ {
 		time.Sleep(10 * time.Millisecond)
+		mu.Lock()
 		op := rc.Check(regions[i])
+		mu.Unlock()
 		oc.AddOperator(op)
 		oc.RemoveOperator(op)
 	}


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
There is a probability that the data race may occur after #2015 is merged. It's because the `mock Cluster` doesn't have a lock to prevent the concurrency. Fixes #2030.

### What is changed and how it works?
This PR fixes it by adding an explicit lock to prevent `RemoveStoreLimit` and `Check` from running at the same time.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test