### PR TITLE
PCP: Accelerate the speed of the load region

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -239,16 +239,7 @@ func (c *RaftCluster) LoadClusterInfo() (*RaftCluster, error) {
 	start = time.Now()
 
 	// used to load region from kv storage to cache storage.
-	putRegion := func(region *core.RegionInfo) []*core.RegionInfo {
-		origin, err := c.core.PreCheckPutRegion(region)
-		if err != nil {
-			log.Warn("region is stale", zap.Error(err), zap.Stringer("origin", origin.GetMeta()))
-			// return the state region to delete.
-			return []*core.RegionInfo{region}
-		}
-		return c.core.PutRegion(region)
-	}
-	if err := c.storage.LoadRegionsOnce(putRegion); err != nil {
+	if err := c.storage.LoadRegionsOnce(c.core.CheckAndPutRegion); err != nil {
 		return nil, err
 	}
 	log.Info("load regions",

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -40,7 +40,7 @@ type testClusterInfoSuite struct{}
 func (s *testClusterInfoSuite) TestStoreHeartbeat(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()))
+	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 
 	n, np := uint64(3), uint64(3)
 	stores := newTestStores(n)
@@ -86,7 +86,7 @@ func (s *testClusterInfoSuite) TestStoreHeartbeat(c *C) {
 func (s *testClusterInfoSuite) TestRegionHeartbeat(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()))
+	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 
 	n, np := uint64(3), uint64(3)
 
@@ -339,7 +339,7 @@ func heartbeatRegions(c *C, cluster *RaftCluster, regions []*core.RegionInfo) {
 func (s *testClusterInfoSuite) TestHeartbeatSplit(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()))
+	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 
 	// 1: [nil, nil)
 	region1 := core.NewRegionInfo(&metapb.Region{Id: 1, RegionEpoch: &metapb.RegionEpoch{Version: 1, ConfVer: 1}}, nil)
@@ -378,7 +378,7 @@ func (s *testClusterInfoSuite) TestHeartbeatSplit(c *C) {
 func (s *testClusterInfoSuite) TestRegionSplitAndMerge(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()))
+	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 
 	regions := []*core.RegionInfo{core.NewTestRegionInfo([]byte{}, []byte{})}
 
@@ -485,7 +485,7 @@ func (s *testRegionsInfoSuite) Test(c *C) {
 	regions := newTestRegions(n, np)
 	_, opts, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	tc := newTestRaftCluster(mockid.NewIDAllocator(), opts, core.NewStorage(kv.NewMemoryKV()))
+	tc := newTestRaftCluster(mockid.NewIDAllocator(), opts, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 	cache := tc.core.Regions
 
 	for i := uint64(0); i < n; i++ {
@@ -595,7 +595,7 @@ type testGetStoresSuite struct {
 func (s *testGetStoresSuite) SetUpSuite(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()))
+	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 	s.cluster = cluster
 
 	stores := newTestStores(200)
@@ -629,13 +629,13 @@ func newTestScheduleConfig() (*config.ScheduleConfig, *config.ScheduleOption, er
 }
 
 func newTestCluster(opt *config.ScheduleOption) *testCluster {
-	rc := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()))
+	rc := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 	return &testCluster{RaftCluster: rc}
 }
 
-func newTestRaftCluster(id id.Allocator, opt *config.ScheduleOption, storage *core.Storage) *RaftCluster {
+func newTestRaftCluster(id id.Allocator, opt *config.ScheduleOption, storage *core.Storage, basicCluster *core.BasicCluster) *RaftCluster {
 	rc := &RaftCluster{}
-	rc.InitCluster(id, opt, storage)
+	rc.InitCluster(id, opt, storage, basicCluster)
 	return rc
 }
 

--- a/server/core/basic_cluster.go
+++ b/server/core/basic_cluster.go
@@ -16,11 +16,10 @@ package core
 import (
 	"sync"
 
-	"github.com/pingcap/log"
-	"go.uber.org/zap"
-
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/log"
 	"github.com/pingcap/pd/pkg/slice"
+	"go.uber.org/zap"
 )
 
 // BasicCluster provides basic data member and interface for a tikv cluster.

--- a/server/core/basic_cluster.go
+++ b/server/core/basic_cluster.go
@@ -16,6 +16,9 @@ package core
 import (
 	"sync"
 
+	"github.com/pingcap/log"
+	"go.uber.org/zap"
+
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/pkg/slice"
 )
@@ -310,6 +313,17 @@ func (bc *BasicCluster) PutRegion(region *RegionInfo) []*RegionInfo {
 	bc.Lock()
 	defer bc.Unlock()
 	return bc.Regions.SetRegion(region)
+}
+
+// CheckAndPutRegion checks if the region is valid to put,if valid then put.
+func (bc *BasicCluster) CheckAndPutRegion(region *RegionInfo) []*RegionInfo {
+	origin, err := bc.PreCheckPutRegion(region)
+	if err != nil {
+		log.Warn("region is stale", zap.Error(err), zap.Stringer("origin", origin.GetMeta()))
+		// return the state region to delete.
+		return []*RegionInfo{region}
+	}
+	return bc.PutRegion(region)
 }
 
 // RemoveRegion removes RegionInfo from regionTree and regionMap.

--- a/server/core/storage.go
+++ b/server/core/storage.go
@@ -162,6 +162,9 @@ func (s *Storage) LoadRegions(f func(region *RegionInfo) []*RegionInfo) error {
 
 // LoadRegionsOnce loads all regions from storage to RegionsInfo.Only load one time from regionStorage.
 func (s *Storage) LoadRegionsOnce(f func(region *RegionInfo) []*RegionInfo) error {
+	if atomic.LoadInt32(&s.useRegionStorage) == 0 {
+		return s.LoadRegions(f)
+	}
 	if atomic.CompareAndSwapInt32(&s.regionLoaded, 0, 1) {
 		if err := s.LoadRegions(f); err != nil {
 			return err

--- a/server/core/storage.go
+++ b/server/core/storage.go
@@ -51,7 +51,7 @@ type Storage struct {
 	regionStorage    *RegionStorage
 	useRegionStorage int32
 	regionLoaded     int32
-	mu               sync.RWMutex
+	mu               sync.Mutex
 }
 
 // NewStorage creates Storage instance with Base.

--- a/server/core/storage.go
+++ b/server/core/storage.go
@@ -163,7 +163,7 @@ func (s *Storage) LoadRegions(f func(region *RegionInfo) []*RegionInfo) error {
 // LoadRegionsOnce loads all regions from storage to RegionsInfo.Only load one time from regionStorage.
 func (s *Storage) LoadRegionsOnce(f func(region *RegionInfo) []*RegionInfo) error {
 	if atomic.LoadInt32(&s.useRegionStorage) == 0 {
-		return s.LoadRegions(f)
+		return loadRegions(s.Base, f)
 	}
 	if atomic.CompareAndSwapInt32(&s.regionLoaded, 0, 1) {
 		if err := s.LoadRegions(f); err != nil {

--- a/server/core/storage.go
+++ b/server/core/storage.go
@@ -166,7 +166,7 @@ func (s *Storage) LoadRegionsOnce(f func(region *RegionInfo) []*RegionInfo) erro
 		return loadRegions(s.Base, f)
 	}
 	if atomic.CompareAndSwapInt32(&s.regionLoaded, 0, 1) {
-		if err := s.LoadRegions(f); err != nil {
+		if err := loadRegions(s.regionStorage, f); err != nil {
 			return err
 		}
 	}

--- a/server/core/storage_test.go
+++ b/server/core/storage_test.go
@@ -161,7 +161,7 @@ func (s *testKVSuite) TestLoadRegionsToCache(c *C) {
 
 	old := n
 	n = 20
-	regions = mustSaveRegions(c, storage, n)
+	mustSaveRegions(c, storage, n)
 	c.Assert(storage.LoadRegionsOnce(cache.SetRegion), IsNil)
 	c.Assert(cache.GetRegionCount(), Equals, old)
 }

--- a/server/core/storage_test.go
+++ b/server/core/storage_test.go
@@ -146,6 +146,26 @@ func (s *testKVSuite) TestLoadRegions(c *C) {
 	}
 }
 
+func (s *testKVSuite) TestLoadRegionsToCache(c *C) {
+	storage := NewStorage(kv.NewMemoryKV())
+	cache := NewRegionsInfo()
+
+	n := 10
+	regions := mustSaveRegions(c, storage, n)
+	c.Assert(storage.LoadRegionsOnce(cache.SetRegion), IsNil)
+
+	c.Assert(cache.GetRegionCount(), Equals, n)
+	for _, region := range cache.GetMetaRegions() {
+		c.Assert(region, DeepEquals, regions[region.GetId()])
+	}
+
+	old := n
+	n = 20
+	regions = mustSaveRegions(c, storage, n)
+	c.Assert(storage.LoadRegionsOnce(cache.SetRegion), IsNil)
+	c.Assert(cache.GetRegionCount(), Equals, old)
+}
+
 func (s *testKVSuite) TestLoadRegionsExceedRangeLimit(c *C) {
 	storage := NewStorage(&KVWithMaxRangeLimit{Base: kv.NewMemoryKV(), rangeLimit: 500})
 	cache := NewRegionsInfo()

--- a/server/core/storage_test.go
+++ b/server/core/storage_test.go
@@ -159,11 +159,10 @@ func (s *testKVSuite) TestLoadRegionsToCache(c *C) {
 		c.Assert(region, DeepEquals, regions[region.GetId()])
 	}
 
-	old := n
 	n = 20
 	mustSaveRegions(c, storage, n)
 	c.Assert(storage.LoadRegionsOnce(cache.SetRegion), IsNil)
-	c.Assert(cache.GetRegionCount(), Equals, old)
+	c.Assert(cache.GetRegionCount(), Equals, n)
 }
 
 func (s *testKVSuite) TestLoadRegionsExceedRangeLimit(c *C) {

--- a/server/region_syncer/client.go
+++ b/server/region_syncer/client.go
@@ -86,6 +86,17 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 	s.RUnlock()
 	go func() {
 		defer s.wg.Done()
+		// used to load region from kv storage to cache storage.
+		putRegion := func(region *core.RegionInfo) []*core.RegionInfo {
+			origin, err := s.server.GetBasicCluster().PreCheckPutRegion(region)
+			if err != nil {
+				log.Warn("region is stale", zap.Error(err), zap.Stringer("origin", origin.GetMeta()))
+				// return the state region to delete.
+				return []*core.RegionInfo{region}
+			}
+			return s.server.GetBasicCluster().PutRegion(region)
+		}
+		s.server.GetStorage().LoadRegionsOnce(putRegion)
 		for {
 			select {
 			case <-closed:
@@ -125,6 +136,7 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 					s.history.ResetWithIndex(resp.GetStartIndex())
 				}
 				for _, r := range resp.GetRegions() {
+					putRegion(core.NewRegionInfo(r, nil))
 					err = s.server.GetStorage().SaveRegion(r)
 					if err == nil {
 						s.history.Record(core.NewRegionInfo(r, nil))

--- a/server/region_syncer/client.go
+++ b/server/region_syncer/client.go
@@ -87,7 +87,10 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 	go func() {
 		defer s.wg.Done()
 		// used to load region from kv storage to cache storage.
-		s.server.GetStorage().LoadRegionsOnce(s.server.GetBasicCluster().CheckAndPutRegion)
+		err := s.server.GetStorage().LoadRegionsOnce(s.server.GetBasicCluster().CheckAndPutRegion)
+		if err != nil {
+			log.Warn("failed to load regions.", zap.Error(err))
+		}
 		for {
 			select {
 			case <-closed:

--- a/server/region_syncer/server.go
+++ b/server/region_syncer/server.go
@@ -61,6 +61,7 @@ type Server interface {
 	Name() string
 	GetMetaRegions() []*metapb.Region
 	GetSecurityConfig() *config.SecurityConfig
+	GetBasicCluster() *core.BasicCluster
 }
 
 // RegionSyncer is used to sync the region information without raft.

--- a/server/server.go
+++ b/server/server.go
@@ -101,6 +101,8 @@ type Server struct {
 	idAllocator *id.AllocatorImpl
 	// for storage operation.
 	storage *core.Storage
+	// for baiscCluster operation.
+	basicCluster *core.BasicCluster
 	// for tso.
 	tso *tso.TimestampOracle
 	// for raft cluster
@@ -307,6 +309,7 @@ func (s *Server) startServer(ctx context.Context) error {
 		return err
 	}
 	s.storage = core.NewStorage(kvBase).SetRegionStorage(regionStorage)
+	s.basicCluster = core.NewBasicCluster()
 	s.cluster = cluster.NewRaftCluster(ctx, s.GetClusterRootPath(), s.clusterID, syncer.NewRegionSyncer(s), s.client)
 	s.hbStreams = newHeartbeatStreams(ctx, s.clusterID, s.cluster)
 	// Server has started.
@@ -559,6 +562,16 @@ func (s *Server) GetStorage() *core.Storage {
 // SetStorage changes the storage for test purpose.
 func (s *Server) SetStorage(storage *core.Storage) {
 	s.storage = storage
+}
+
+// GetStorage returns the backend storage of server.
+func (s *Server) GetBasicCluster() *core.BasicCluster {
+	return s.basicCluster
+}
+
+// SetStorage changes the storage for test purpose.
+func (s *Server) SetBasicCluster(basicCluster *core.BasicCluster) {
+	s.basicCluster = basicCluster
 }
 
 // GetScheduleOption returns the schedule option.

--- a/server/server.go
+++ b/server/server.go
@@ -564,14 +564,9 @@ func (s *Server) SetStorage(storage *core.Storage) {
 	s.storage = storage
 }
 
-// GetStorage returns the backend storage of server.
+// GetBasicCluster returns the basic cluster of server.
 func (s *Server) GetBasicCluster() *core.BasicCluster {
 	return s.basicCluster
-}
-
-// SetStorage changes the storage for test purpose.
-func (s *Server) SetBasicCluster(basicCluster *core.BasicCluster) {
-	s.basicCluster = basicCluster
 }
 
 // GetScheduleOption returns the schedule option.

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -400,6 +400,16 @@ func (c *TestCluster) GetLeader() string {
 	return ""
 }
 
+// GetLeader returns the leader of all servers
+func (c *TestCluster) GetFollower() string {
+	for name, s := range c.servers {
+		if !s.server.IsClosed() && !s.server.GetMember().IsLeader() {
+			return name
+		}
+	}
+	return ""
+}
+
 // WaitLeader is used to get leader.
 // If it exceeds the maximum number of loops, it will return an empty string.
 func (c *TestCluster) WaitLeader() string {

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -400,7 +400,7 @@ func (c *TestCluster) GetLeader() string {
 	return ""
 }
 
-// GetLeader returns the leader of all servers
+// GetFollower returns an follower of all servers
 func (c *TestCluster) GetFollower() string {
 	for name, s := range c.servers {
 		if !s.server.IsClosed() && !s.server.GetMember().IsLeader() {

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -678,6 +678,24 @@ func (s *clusterTestSuite) TestLoadClusterInfo(c *C) {
 	for _, region := range raftCluster.GetMetaRegions() {
 		c.Assert(region, DeepEquals, regions[region.GetId()])
 	}
+
+	n = 20
+	regions = make([]*metapb.Region, 0, n)
+	for i := uint64(0); i < uint64(n); i++ {
+		region := &metapb.Region{
+			Id:          i,
+			StartKey:    []byte(fmt.Sprintf("%20d", i)),
+			EndKey:      []byte(fmt.Sprintf("%20d", i+1)),
+			RegionEpoch: &metapb.RegionEpoch{Version: 1, ConfVer: 1},
+		}
+		regions = append(regions, region)
+	}
+
+	for _, region := range regions {
+		c.Assert(storage.SaveRegion(region), IsNil)
+	}
+	raftCluster.GetStorage().LoadRegionsOnce(raftCluster.GetCacheCluster().PutRegion)
+	c.Assert(raftCluster.GetRegionCount(), Equals, 10)
 }
 
 func newIsBootstrapRequest(clusterID uint64) *pdpb.IsBootstrappedRequest {

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -624,12 +624,13 @@ func (s *clusterTestSuite) TestLoadClusterInfo(c *C) {
 	rc := cluster.NewRaftCluster(s.ctx, svr.GetClusterRootPath(), svr.ClusterID(), syncer.NewRegionSyncer(svr), svr.GetClient())
 
 	// Cluster is not bootstrapped.
-	rc.InitCluster(svr.GetAllocator(), svr.GetScheduleOption(), svr.GetStorage())
+	rc.InitCluster(svr.GetAllocator(), svr.GetScheduleOption(), svr.GetStorage(), svr.GetBasicCluster())
 	raftCluster, err := rc.LoadClusterInfo()
 	c.Assert(err, IsNil)
 	c.Assert(raftCluster, IsNil)
 
 	storage := rc.GetStorage()
+	basicCluster := rc.GetCacheCluster()
 	opt := rc.GetOpt()
 	// Save meta, stores and regions.
 	n := 10
@@ -662,7 +663,7 @@ func (s *clusterTestSuite) TestLoadClusterInfo(c *C) {
 	c.Assert(storage.Flush(), IsNil)
 
 	raftCluster = &cluster.RaftCluster{}
-	raftCluster.InitCluster(mockid.NewIDAllocator(), opt, storage)
+	raftCluster.InitCluster(mockid.NewIDAllocator(), opt, storage, basicCluster)
 	raftCluster, err = raftCluster.LoadClusterInfo()
 	c.Assert(err, IsNil)
 	c.Assert(raftCluster, NotNil)

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -679,9 +679,9 @@ func (s *clusterTestSuite) TestLoadClusterInfo(c *C) {
 		c.Assert(region, DeepEquals, regions[region.GetId()])
 	}
 
-	n = 20
+	m := 20
 	regions = make([]*metapb.Region, 0, n)
-	for i := uint64(0); i < uint64(n); i++ {
+	for i := uint64(0); i < uint64(m); i++ {
 		region := &metapb.Region{
 			Id:          i,
 			StartKey:    []byte(fmt.Sprintf("%20d", i)),
@@ -695,7 +695,7 @@ func (s *clusterTestSuite) TestLoadClusterInfo(c *C) {
 		c.Assert(storage.SaveRegion(region), IsNil)
 	}
 	raftCluster.GetStorage().LoadRegionsOnce(raftCluster.GetCacheCluster().PutRegion)
-	c.Assert(raftCluster.GetRegionCount(), Equals, 10)
+	c.Assert(raftCluster.GetRegionCount(), Equals, n)
 }
 
 func newIsBootstrapRequest(clusterID uint64) *pdpb.IsBootstrappedRequest {

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -125,7 +125,7 @@ func (s *serverTestSuite) TestRegionSyncer(c *C) {
 	followerServer := cluster.GetServer(cluster.GetFollower())
 	c.Assert(followerServer, NotNil)
 	cacheRegions := followerServer.GetServer().GetBasicCluster().GetRegions()
-	c.Assert(len(cacheRegions), Equals, regionLen)
+	c.Assert(cacheRegions, HasLen, regionLen)
 	for _, region := range cacheRegions {
 		c.Assert(followerServer.GetServer().GetBasicCluster().GetRegion(region.GetID()).GetMeta(), DeepEquals, region.GetMeta())
 	}

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -120,6 +120,16 @@ func (s *serverTestSuite) TestRegionSyncer(c *C) {
 	// ensure flush to region storage, we use a duration larger than the
 	// region storage flush rate limit (3s).
 	time.Sleep(4 * time.Second)
+
+	//test All regions have been synchronized to the cache of followerServer
+	followerServer := cluster.GetServer(cluster.GetFollower())
+	c.Assert(followerServer, NotNil)
+	cacheRegions := followerServer.GetServer().GetBasicCluster().GetRegions()
+	c.Assert(len(cacheRegions), Equals, regionLen)
+	for _, region := range cacheRegions {
+		c.Assert(followerServer.GetServer().GetBasicCluster().GetRegion(region.GetID()).GetMeta(), DeepEquals, region.GetMeta())
+	}
+
 	err = leaderServer.Stop()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
PCP #1830 

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
new feature : PCP: Accelerate the speed of the load region

### What is changed and how it works?
- add a method of storage.go : LoadRegionsOnce
- in the cluster.go : the calling method changes to when load regions
- in the region_syncer/client.go: When the follower synchronizes the regions, it will first determine whether it has been loaded from storage and will update the cache synchronously for the changed regions

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

