### PR TITLE
client: supports to add gRPC dial options

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -206,15 +206,18 @@ func (c *client) updateURLs(members []*pdpb.Member) {
 	for _, url := range urls {
 		urlsMap[url] = struct{}{}
 	}
-	needUpdate := false
+	containsOldURLs := true
 	for _, url := range c.urls {
 		if _, ok := urlsMap[url]; !ok {
-			needUpdate = true
+			containsOldURLs = false
 		}
 	}
-	if !needUpdate {
+
+	// the url list is same.
+	if len(urls) == len(c.urls) && containsOldURLs {
 		return
 	}
+
 	log.Info("[pd] update member urls", zap.Strings("old-urls", c.urls), zap.Strings("new-urls", urls))
 	c.urls = urls
 }

--- a/client/client.go
+++ b/client/client.go
@@ -15,6 +15,8 @@ package pd
 
 import (
 	"context"
+	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -199,23 +201,13 @@ func NewClientWithContext(ctx context.Context, pdAddrs []string, security Securi
 
 func (c *client) updateURLs(members []*pdpb.Member) {
 	urls := make([]string, 0, len(members))
-	urlsMap := make(map[string]struct{})
 	for _, m := range members {
 		urls = append(urls, m.GetClientUrls()...)
 	}
-	for _, url := range urls {
-		urlsMap[url] = struct{}{}
-	}
-	containsOldURLs := true
-	for _, url := range c.urls {
-		if _, ok := urlsMap[url]; !ok {
-			containsOldURLs = false
-			break
-		}
-	}
 
+	sort.Strings(urls)
 	// the url list is same.
-	if len(urls) == len(c.urls) && containsOldURLs {
+	if reflect.DeepEqual(c.urls, urls) {
 		return
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -210,6 +210,7 @@ func (c *client) updateURLs(members []*pdpb.Member) {
 	for _, url := range c.urls {
 		if _, ok := urlsMap[url]; !ok {
 			containsOldURLs = false
+			break
 		}
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -135,7 +135,8 @@ type client struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	security SecurityOption
+	security        SecurityOption
+	gRPCDialOptions []grpc.DialOption
 }
 
 // SecurityOption records options about tls
@@ -145,13 +146,23 @@ type SecurityOption struct {
 	KeyPath  string
 }
 
+// ClientOption configures client.
+type ClientOption func(c *client)
+
+// WithGRPCDialOptions configures the client with gRPC dial options.
+func WithGRPCDialOptions(opts ...grpc.DialOption) ClientOption {
+	return func(c *client) {
+		c.gRPCDialOptions = append(c.gRPCDialOptions, opts...)
+	}
+}
+
 // NewClient creates a PD client.
-func NewClient(pdAddrs []string, security SecurityOption) (Client, error) {
-	return NewClientWithContext(context.Background(), pdAddrs, security)
+func NewClient(pdAddrs []string, security SecurityOption, opts ...ClientOption) (Client, error) {
+	return NewClientWithContext(context.Background(), pdAddrs, security, opts...)
 }
 
 // NewClientWithContext creates a PD client with context.
-func NewClientWithContext(ctx context.Context, pdAddrs []string, security SecurityOption) (Client, error) {
+func NewClientWithContext(ctx context.Context, pdAddrs []string, security SecurityOption, opts ...ClientOption) (Client, error) {
 	log.Info("[pd] create pd client with endpoints", zap.Strings("pd-address", pdAddrs))
 	ctx1, cancel := context.WithCancel(ctx)
 	c := &client{
@@ -164,6 +175,9 @@ func NewClientWithContext(ctx context.Context, pdAddrs []string, security Securi
 		security:      security,
 	}
 	c.connMu.clientConns = make(map[string]*grpc.ClientConn)
+	for _, opt := range opts {
+		opt(c)
+	}
 
 	if err := c.initRetry(c.initClusterID); err != nil {
 		cancel()
@@ -185,9 +199,23 @@ func NewClientWithContext(ctx context.Context, pdAddrs []string, security Securi
 
 func (c *client) updateURLs(members []*pdpb.Member) {
 	urls := make([]string, 0, len(members))
+	urlsMap := make(map[string]struct{})
 	for _, m := range members {
 		urls = append(urls, m.GetClientUrls()...)
 	}
+	for _, url := range urls {
+		urlsMap[url] = struct{}{}
+	}
+	needUpdate := false
+	for _, url := range c.urls {
+		if _, ok := urlsMap[url]; !ok {
+			needUpdate = true
+		}
+	}
+	if !needUpdate {
+		return
+	}
+	log.Info("[pd] update member urls", zap.Strings("old-urls", c.urls), zap.Strings("new-urls", urls))
 	c.urls = urls
 }
 
@@ -228,7 +256,7 @@ func (c *client) updateLeader() error {
 		ctx, cancel := context.WithTimeout(c.ctx, updateLeaderTimeout)
 		members, err := c.getMembers(ctx, u)
 		if err != nil {
-			log.Warn("cannot update leader", zap.String("address", u), zap.Error(err))
+			log.Warn("[pd] cannot update leader", zap.String("address", u), zap.Error(err))
 		}
 		cancel()
 		if err != nil || members.GetLeader() == nil || len(members.GetLeader().GetClientUrls()) == 0 {
@@ -289,7 +317,7 @@ func (c *client) getOrCreateGRPCConn(addr string) (*grpc.ClientConn, error) {
 		return conn, nil
 	}
 
-	cc, err := grpcutil.GetClientConn(addr, c.security.CAPath, c.security.CertPath, c.security.KeyPath)
+	cc, err := grpcutil.GetClientConn(addr, c.security.CAPath, c.security.CertPath, c.security.KeyPath, c.gRPCDialOptions...)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -471,6 +471,28 @@ func (s *testClientSuite) TestScatterRegion(c *C) {
 	c.Succeed()
 }
 
+func (s *testClientSuite) TestUpdateURLs(c *C) {
+	members := []*pdpb.Member{
+		{Name: "pd4", ClientUrls: []string{"tmp//pd4"}},
+		{Name: "pd1", ClientUrls: []string{"tmp//pd1"}},
+		{Name: "pd3", ClientUrls: []string{"tmp//pd3"}},
+		{Name: "pd2", ClientUrls: []string{"tmp//pd2"}},
+	}
+	getUrls := func(ms []*pdpb.Member) (urls []string) {
+		for _, m := range ms {
+			urls = append(urls, m.GetClientUrls()[0])
+		}
+		return
+	}
+	cli := &client{}
+	cli.updateURLs(members[1:])
+	c.Assert(cli.urls, DeepEquals, getUrls([]*pdpb.Member{members[1], members[3], members[2]}))
+	cli.updateURLs(members[1:])
+	c.Assert(cli.urls, DeepEquals, getUrls([]*pdpb.Member{members[1], members[3], members[2]}))
+	cli.updateURLs(members)
+	c.Assert(cli.urls, DeepEquals, getUrls([]*pdpb.Member{members[1], members[3], members[2], members[0]}))
+}
+
 func (s *testClientSuite) TestTsLessEqual(c *C) {
 	c.Assert(tsLessEqual(9, 9, 9, 9), IsTrue)
 	c.Assert(tsLessEqual(8, 9, 9, 8), IsTrue)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -478,7 +478,7 @@ func (s *testClientSuite) TestUpdateURLs(c *C) {
 		{Name: "pd3", ClientUrls: []string{"tmp//pd3"}},
 		{Name: "pd2", ClientUrls: []string{"tmp//pd2"}},
 	}
-	getUrls := func(ms []*pdpb.Member) (urls []string) {
+	getURLs := func(ms []*pdpb.Member) (urls []string) {
 		for _, m := range ms {
 			urls = append(urls, m.GetClientUrls()[0])
 		}
@@ -486,11 +486,11 @@ func (s *testClientSuite) TestUpdateURLs(c *C) {
 	}
 	cli := &client{}
 	cli.updateURLs(members[1:])
-	c.Assert(cli.urls, DeepEquals, getUrls([]*pdpb.Member{members[1], members[3], members[2]}))
+	c.Assert(cli.urls, DeepEquals, getURLs([]*pdpb.Member{members[1], members[3], members[2]}))
 	cli.updateURLs(members[1:])
-	c.Assert(cli.urls, DeepEquals, getUrls([]*pdpb.Member{members[1], members[3], members[2]}))
+	c.Assert(cli.urls, DeepEquals, getURLs([]*pdpb.Member{members[1], members[3], members[2]}))
 	cli.updateURLs(members)
-	c.Assert(cli.urls, DeepEquals, getUrls([]*pdpb.Member{members[1], members[3], members[2], members[0]}))
+	c.Assert(cli.urls, DeepEquals, getURLs([]*pdpb.Member{members[1], members[3], members[2], members[0]}))
 }
 
 func (s *testClientSuite) TestTsLessEqual(c *C) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -500,6 +500,7 @@ func (s *testClientDialOptionSuite) TestGRPCDialOption(c *C) {
 	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.TODO(), 100*time.Millisecond)
 	defer cancel()
+	// nolint
 	_, err := NewClientWithContext(ctx, []string{"localhost:8080"}, SecurityOption{}, WithGRPCDialOptions(grpc.WithBlock(), grpc.WithTimeout(time.Second)))
 	c.Assert(err, NotNil)
 	c.Assert(time.Since(start), Greater, 800*time.Millisecond)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/pd/server"
 	"github.com/pingcap/pd/server/core"
 	"go.uber.org/goleak"
+	"google.golang.org/grpc"
 )
 
 func TestClient(t *testing.T) {
@@ -489,4 +490,17 @@ func (s *testClientCtxSuite) TestClientCtx(c *C) {
 	_, err := NewClientWithContext(ctx, []string{"localhost:8080"}, SecurityOption{})
 	c.Assert(err, NotNil)
 	c.Assert(time.Since(start), Less, time.Second*4)
+}
+
+var _ = Suite(&testClientDialOptionSuite{})
+
+type testClientDialOptionSuite struct{}
+
+func (s *testClientDialOptionSuite) TestGRPCDialOption(c *C) {
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.TODO(), 100*time.Millisecond)
+	defer cancel()
+	_, err := NewClientWithContext(ctx, []string{"localhost:8080"}, SecurityOption{}, WithGRPCDialOptions(grpc.WithBlock(), grpc.WithTimeout(time.Second)))
+	c.Assert(err, NotNil)
+	c.Assert(time.Since(start), Greater, 800*time.Millisecond)
 }


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
we test 
After all 3 instances of PD are killed in AWS(k8s environment), it takes a long time (15 minutes) for TiDB server instances to reconnect to new PD instances. and we found the stale TCP connection after all pod IP is changed. 
```
 we see the connection is still establish, and that ip does not exist after kill.
10.0.48.116 is not exist, but the tcp is establisted.

Tue Dec 17 12:54:36 UTC 2019
tcp        0      1 10.0.38.181:53424       172.20.62.78:2379       SYN_SENT    1/tidb-server
tcp        0      0 10.0.38.181:53302       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53304       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53300       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:37554       10.0.46.225:2379        ESTABLISHED 1/tidb-server
tcp        0   1140 10.0.38.181:35378       10.0.48.116:2379        ESTABLISHED 1/tidb-server
Tue Dec 17 12:54:37 UTC 2019
tcp        0      1 10.0.38.181:53424       172.20.62.78:2379       SYN_SENT    1/tidb-server
tcp        0      0 10.0.38.181:53302       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53304       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53300       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:37554       10.0.46.225:2379        ESTABLISHED 1/tidb-server
tcp        0   1153 10.0.38.181:35378       10.0.48.116:2379        ESTABLISHED 1/tidb-server
Tue Dec 17 12:54:37 UTC 2019
tcp        0      0 10.0.38.181:53302       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53304       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53488       172.20.62.78:2379       ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53300       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:37554       10.0.46.225:2379        ESTABLISHED 1/tidb-server
tcp        0   1153 10.0.38.181:35378       10.0.48.116:2379        ESTABLISHED 1/tidb-server

....

Tue Dec 17 13:07:15 UTC 2019
tcp        0      0 10.0.38.181:53302       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53304       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53488       172.20.62.78:2379       ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53300       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:37554       10.0.46.225:2379        ESTABLISHED 1/tidb-server
tcp        0  26868 10.0.38.181:35378       10.0.48.116:2379        ESTABLISHED 1/tidb-server
Tue Dec 17 13:07:16 UTC 2019
tcp        0      0 10.0.38.181:53302       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53304       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53488       172.20.62.78:2379       ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53300       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:37554       10.0.46.225:2379        ESTABLISHED 1/tidb-server
tcp        0  26868 10.0.38.181:35378       10.0.48.116:2379        ESTABLISHED 1/tidb-server
Tue Dec 17 13:07:16 UTC 2019
tcp        0      0 10.0.38.181:53302       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53304       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53488       172.20.62.78:2379       ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53300       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:37554       10.0.46.225:2379        ESTABLISHED 1/tidb-server
tcp        0  26868 10.0.38.181:35378       10.0.48.116:2379        ESTABLISHED 1/tidb-server
Tue Dec 17 13:07:17 UTC 2019
tcp        0      0 10.0.38.181:53302       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53304       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53488       172.20.62.78:2379       ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:53300       10.0.22.167:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:37554       10.0.46.225:2379        ESTABLISHED 1/tidb-server
tcp        0      0 10.0.38.181:41754       10.0.55.94:2379         ESTABLISHED 1/tidb-server
```
This problem same as https://github.com/pingcap/tidb/pull/7099. may k8s CNI dropping all packets send to the removed  node(Indeterminate),  that cause a stall conneciton, until kernel TCP retransmission times out and closes the connection.

### What is changed and how it works?
supports add gRPC dial options and setting gRPC `KeepAlive` in tidb's pd client, this problem fixed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test