### PR TITLE
*: disable transferRegion and offline warning when enable placement rules

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1005,7 +1005,8 @@ func (c *RaftCluster) checkStores() {
 		return
 	}
 
-	if upStoreCount < c.GetMaxReplicas() {
+	// When placement rules feature is enabled. It is hard to determine required replica count precisely.
+	if !c.IsPlacementRulesEnabled() && upStoreCount < c.GetMaxReplicas() {
 		for _, offlineStore := range offlineStores {
 			log.Warn("store may not turn into Tombstone, there are no extra up store has enough space to accommodate the extra replica", zap.Stringer("store", offlineStore))
 		}

--- a/server/handler.go
+++ b/server/handler.go
@@ -480,6 +480,11 @@ func (h *Handler) AddTransferRegionOperator(regionID uint64, storeIDs map[uint64
 		return err
 	}
 
+	if c.IsPlacementRulesEnabled() {
+		// Cannot determine role when placement rules enabled. Not supported now.
+		return errors.New("transfer region is not supported when placement rules enabled")
+	}
+
 	region := c.GetRegion(regionID)
 	if region == nil {
 		return ErrRegionNotFound(regionID)

--- a/tests/pdctl/operator/operator_test.go
+++ b/tests/pdctl/operator/operator_test.go
@@ -206,4 +206,10 @@ func (s *operatorTestSuite) TestOperator(c *C) {
 	c.Assert(strings.Contains(echo, "Success!"), IsTrue)
 	echo = pdctl.GetEcho([]string{"-u", pdAddr, "operator", "remove", "1"})
 	c.Assert(strings.Contains(echo, "Success!"), IsFalse)
+
+	_, _, err = pdctl.ExecuteCommandC(cmd, "config", "set", "enable-placement-rules", "true")
+	c.Assert(err, IsNil)
+	_, output, err = pdctl.ExecuteCommandC(cmd, "operator", "add", "transfer-region", "1", "2", "3")
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "not supported"), IsTrue)
 }


### PR DESCRIPTION

Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Some feature cannot work as expected when enable placement rules.

### What is changed and how it works?
disable them.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test