### PR TITLE
config: tiny fix config item

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -494,7 +494,7 @@ type ScheduleConfig struct {
 	// LeaderScheduleLimit is the max coexist leader schedules.
 	LeaderScheduleLimit uint64 `toml:"leader-schedule-limit" json:"leader-schedule-limit"`
 	// LeaderScheduleStrategy is the option to balance leader, there are some strategics supported: ["count", "size"], default: "count"
-	LeaderScheduleStrategy string `toml:"leader-schedule-strategy" json:"leader-schedule-strategy,string"`
+	LeaderScheduleStrategy string `toml:"leader-schedule-strategy" json:"leader-schedule-strategy"`
 	// RegionScheduleLimit is the max coexist region schedules.
 	RegionScheduleLimit uint64 `toml:"region-schedule-limit" json:"region-schedule-limit"`
 	// ReplicaScheduleLimit is the max coexist replica schedules.

--- a/tools/pd-ctl/README.md
+++ b/tools/pd-ctl/README.md
@@ -112,7 +112,7 @@ Usage:
     "hot-region-cache-hits-threshold": 3,
     "hot-region-schedule-limit": 4,
     "leader-schedule-limit": 4,
-    "leader-schedule-strategy": "\"count\"",
+    "leader-schedule-strategy": "count",
     "low-space-ratio": 0.8,
     "max-merge-region-keys": 200000,
     "max-merge-region-size": 20,


### PR DESCRIPTION
# What problem does this PR solve? <!--add the issue link with summary if it exists-->
when using pd-ctl config show:
before:
```
...
"leader-schedule-strategy": "\"count\"",
...
```
After:
```
...
"leader-schedule-strategy": "count",
...
```

### What is changed and how it works?
This PR removes the "string" tag for `LeaderScheduleStrategy`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test
