### PR TITLE
server: fix placement rules panic

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -681,8 +681,12 @@ func (s *Server) SetReplicationConfig(cfg config.ReplicationConfig) error {
 		return err
 	}
 	if cfg.EnablePlacementRules {
+		raftCluster := s.GetRaftCluster()
+		if raftCluster == nil {
+			return errors.WithStack(cluster.ErrNotBootstrapped)
+		}
 		// initialize rule manager.
-		if err := s.GetRaftCluster().GetRuleManager().Initialize(int(cfg.MaxReplicas), cfg.LocationLabels); err != nil {
+		if err := raftCluster.GetRuleManager().Initialize(int(cfg.MaxReplicas), cfg.LocationLabels); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fix https://github.com/pingcap/pd/issues/2069

### What is changed and how it works?
Check if bootstrapped.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)
when not bootstrapped:

```bash
./bin/pd-ctl config set enable-placement-rules true
Failed to set config: [500] "TiKV cluster not bootstrapped, please start TiKV first"
```