### PR TITLE
server/*: refactor AllocPeer

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -55,7 +55,8 @@ func NewCluster(opt *mockoption.ScheduleOptions) *Cluster {
 	}
 }
 
-func (mc *Cluster) allocID() (uint64, error) {
+// AllocID allocs a new unique ID.
+func (mc *Cluster) AllocID() (uint64, error) {
 	return mc.Alloc()
 }
 
@@ -112,7 +113,7 @@ func (mc *Cluster) RandHotRegionFromStore(store uint64, kind statistics.FlowKind
 
 // AllocPeer allocs a new peer on a store.
 func (mc *Cluster) AllocPeer(storeID uint64) (*metapb.Peer, error) {
-	peerID, err := mc.allocID()
+	peerID, err := mc.AllocID()
 	if err != nil {
 		log.Error("failed to alloc peer", zap.Error(err))
 		return nil, err

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1150,20 +1150,6 @@ func (c *RaftCluster) AllocID() (uint64, error) {
 	return c.id.Alloc()
 }
 
-// AllocPeer allocs a new peer on a store.
-func (c *RaftCluster) AllocPeer(storeID uint64) (*metapb.Peer, error) {
-	peerID, err := c.AllocID()
-	if err != nil {
-		log.Error("failed to alloc peer", zap.Error(err))
-		return nil, err
-	}
-	peer := &metapb.Peer{
-		Id:      peerID,
-		StoreId: storeID,
-	}
-	return peer, nil
-}
-
 // OnStoreVersionChange changes the version of the cluster when needed.
 func (c *RaftCluster) OnStoreVersionChange() {
 	c.RLock()

--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -41,6 +41,14 @@ func newTestOperator(regionID uint64, regionEpoch *metapb.RegionEpoch, kind oper
 	return operator.NewOperator("test", "test", regionID, regionEpoch, kind, steps...)
 }
 
+func (c *testCluster) AllocPeer(storeID uint64) (*metapb.Peer, error) {
+	id, err := c.AllocID()
+	if err != nil {
+		return nil, err
+	}
+	return &metapb.Peer{Id: id, StoreId: storeID}, nil
+}
+
 func (c *testCluster) addRegionStore(storeID uint64, regionCount int, regionSizes ...uint64) error {
 	var regionSize uint64
 	if len(regionSizes) == 0 {

--- a/server/handler.go
+++ b/server/handler.go
@@ -546,11 +546,7 @@ func (h *Handler) AddTransferPeerOperator(regionID uint64, fromStoreID, toStoreI
 		return errcode.Op("operator.add").AddTo(core.StoreTombstonedErr{StoreID: toStoreID})
 	}
 
-	newPeer, err := c.AllocPeer(toStoreID)
-	if err != nil {
-		return err
-	}
-
+	newPeer := &metapb.Peer{StoreId: toStoreID, IsLearner: oldPeer.GetIsLearner()}
 	op, err := operator.CreateMovePeerOperator("admin-move-peer", c, region, operator.OpAdmin, fromStoreID, newPeer)
 	if err != nil {
 		log.Debug("fail to create move peer operator", zap.Error(err))
@@ -596,11 +592,7 @@ func (h *Handler) AddAddPeerOperator(regionID uint64, toStoreID uint64) error {
 		return err
 	}
 
-	newPeer, err := c.AllocPeer(toStoreID)
-	if err != nil {
-		return err
-	}
-
+	newPeer := &metapb.Peer{StoreId: toStoreID}
 	op, err := operator.CreateAddPeerOperator("admin-add-peer", c, region, newPeer, operator.OpAdmin)
 	if err != nil {
 		log.Debug("fail to create add peer operator", zap.Error(err))
@@ -619,11 +611,10 @@ func (h *Handler) AddAddLearnerOperator(regionID uint64, toStoreID uint64) error
 		return err
 	}
 
-	newPeer, err := c.AllocPeer(toStoreID)
-	if err != nil {
-		return err
+	newPeer := &metapb.Peer{
+		StoreId:   toStoreID,
+		IsLearner: true,
 	}
-	newPeer.IsLearner = true
 
 	op, err := operator.CreateAddPeerOperator("admin-add-learner", c, region, newPeer, operator.OpAdmin)
 	if err != nil {

--- a/server/schedule/checker/replica_checker.go
+++ b/server/schedule/checker/replica_checker.go
@@ -131,11 +131,7 @@ func (r *ReplicaChecker) selectBestPeerToAddReplica(region *core.RegionInfo, fil
 		log.Debug("no best store to add replica", zap.Uint64("region-id", region.GetID()))
 		return nil, 0
 	}
-	newPeer, err := r.cluster.AllocPeer(storeID)
-	if err != nil {
-		return nil, 0
-	}
-	return newPeer, score
+	return &metapb.Peer{StoreId: storeID}, score
 }
 
 // selectBestStoreToAddReplica returns the store to add a replica.
@@ -244,10 +240,7 @@ func (r *ReplicaChecker) checkBestReplacement(region *core.RegionInfo) *operator
 		checkerCounter.WithLabelValues("replica_checker", "not-better").Inc()
 		return nil
 	}
-	newPeer, err := r.cluster.AllocPeer(storeID)
-	if err != nil {
-		return nil
-	}
+	newPeer := &metapb.Peer{StoreId: storeID}
 	op, err := operator.CreateMovePeerOperator("move-to-better-location", r.cluster, region, operator.OpReplica, oldPeer.GetStoreId(), newPeer)
 	if err != nil {
 		checkerCounter.WithLabelValues("replica_checker", "create-operator-fail").Inc()
@@ -277,11 +270,7 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, peer *metapb.Peer, sta
 		log.Debug("no best store to add replica", zap.Uint64("region-id", region.GetID()))
 		return nil
 	}
-	newPeer, err := r.cluster.AllocPeer(storeID)
-	if err != nil {
-		return nil
-	}
-
+	newPeer := &metapb.Peer{StoreId: storeID}
 	replace := fmt.Sprintf("replace-%s-replica", status)
 	op, err := operator.CreateMovePeerOperator(replace, r.cluster, region, operator.OpReplica, peer.GetStoreId(), newPeer)
 	if err != nil {

--- a/server/schedule/operator/builder.go
+++ b/server/schedule/operator/builder.go
@@ -232,11 +232,11 @@ func (b *Builder) prepareBuild() (string, error) {
 			// old peer not exists, or target is learner while old one is voter.
 			if n.GetId() == 0 {
 				// Allocate peer ID if need.
-				t, err := b.cluster.AllocPeer(0)
+				id, err := b.cluster.AllocID()
 				if err != nil {
 					return "", err
 				}
-				n.Id = t.Id
+				n.Id = id
 			}
 			b.toAdd.Set(n)
 		}

--- a/server/schedule/operator/operator.go
+++ b/server/schedule/operator/operator.go
@@ -42,7 +42,7 @@ const (
 type Cluster interface {
 	opt.Options
 	GetStore(id uint64) *core.StoreInfo
-	AllocPeer(storeID uint64) (*metapb.Peer, error)
+	AllocID() (uint64, error)
 	FitRegion(region *core.RegionInfo) *placement.RegionFit
 }
 

--- a/server/schedule/opt/opts.go
+++ b/server/schedule/opt/opts.go
@@ -85,10 +85,7 @@ type Cluster interface {
 	statistics.StoreStatInformer
 	Options
 
-	// TODO: it should be removed. Schedulers don't need to know anything
-	// about peers.
-	AllocPeer(storeID uint64) (*metapb.Peer, error)
-
+	AllocID() (uint64, error)
 	FitRegion(*core.RegionInfo) *placement.RegionFit
 }
 

--- a/server/schedule/region_scatterer.go
+++ b/server/schedule/region_scatterer.go
@@ -162,12 +162,10 @@ func (r *RegionScatterer) selectPeerToReplace(stores map[uint64]*core.StoreInfo,
 	}
 
 	target := candidates[rand.Intn(len(candidates))]
-	newPeer, err := r.cluster.AllocPeer(target.GetID())
-	if err != nil {
-		return nil
+	return &metapb.Peer{
+		StoreId:   target.GetID(),
+		IsLearner: oldPeer.GetIsLearner(),
 	}
-	newPeer.IsLearner = oldPeer.GetIsLearner()
-	return newPeer
 }
 
 func (r *RegionScatterer) collectAvailableStores(region *core.RegionInfo) map[uint64]*core.StoreInfo {

--- a/server/schedulers/adjacent_region.go
+++ b/server/schedulers/adjacent_region.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/server/schedule"
@@ -338,15 +339,7 @@ func (l *balanceAdjacentRegionScheduler) dispersePeer(cluster opt.Cluster, regio
 	if target == nil {
 		return nil
 	}
-	newPeer, err := cluster.AllocPeer(target.GetID())
-	if err != nil {
-		return nil
-	}
-	if newPeer == nil {
-		schedulerCounter.WithLabelValues(l.GetName(), "no-peer").Inc()
-		return nil
-	}
-
+	newPeer := &metapb.Peer{StoreId: target.GetID()}
 	// record the store id and exclude it in next time
 	l.cacheRegions.assignedStoreIds = append(l.cacheRegions.assignedStoreIds, newPeer.GetStoreId())
 

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -437,14 +437,7 @@ func (h *balanceHotRegionsScheduler) balanceByPeer(cluster opt.Cluster, storesSt
 				return nil, nil, nil, Influence{}
 			}
 
-			// When the target store is decided, we allocate a peer ID to hold the source region,
-			// because it doesn't exist in the system right now.
-			destPeer, err := cluster.AllocPeer(destStoreID)
-			if err != nil {
-				log.Error("failed to allocate peer", zap.Error(err))
-				return nil, nil, nil, Influence{}
-			}
-
+			destPeer := &metapb.Peer{StoreId: destStoreID, IsLearner: srcPeer.IsLearner}
 			return srcRegion, srcPeer, destPeer, Influence{ByteRate: rs.GetBytesRate()}
 		}
 	}

--- a/server/schedulers/shuffle_hot_region.go
+++ b/server/schedulers/shuffle_hot_region.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/server/schedule"
@@ -180,11 +181,7 @@ func (s *shuffleHotRegionScheduler) randomSchedule(cluster opt.Cluster, storeSta
 		if srcPeer == nil {
 			return nil
 		}
-		destPeer, err := cluster.AllocPeer(destStoreID)
-		if err != nil {
-			log.Error("failed to allocate peer", zap.Error(err))
-			return nil
-		}
+		destPeer := &metapb.Peer{StoreId: destStoreID}
 		op, err := operator.CreateMoveLeaderOperator("random-move-hot-leader", cluster, srcRegion, operator.OpRegion|operator.OpLeader, srcStoreID, destPeer)
 		if err != nil {
 			log.Debug("fail to create move leader operator", zap.Error(err))

--- a/server/schedulers/shuffle_region.go
+++ b/server/schedulers/shuffle_region.go
@@ -15,7 +15,6 @@ package schedulers
 
 import (
 	"github.com/pingcap/kvproto/pkg/metapb"
-	"github.com/pingcap/log"
 	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/server/schedule"
 	"github.com/pingcap/pd/server/schedule/filter"
@@ -23,7 +22,6 @@ import (
 	"github.com/pingcap/pd/server/schedule/opt"
 	"github.com/pingcap/pd/server/schedule/selector"
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
 )
 
 const (
@@ -152,12 +150,5 @@ func (s *shuffleRegionScheduler) scheduleAddPeer(cluster opt.Cluster, filter fil
 	if target == nil {
 		return nil
 	}
-
-	newPeer, err := cluster.AllocPeer(target.GetID())
-	if err != nil {
-		log.Error("failed to allocate peer", zap.Error(err))
-		return nil
-	}
-
-	return newPeer
+	return &metapb.Peer{StoreId: target.GetID()}
 }


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
IDs may be wasted because `AllocPeer` is called too early. See https://github.com/pingcap/pd/issues/1924

Now we use `operator.Builder` to create operators. Since it supports [allocating ID automatically](https://github.com/pingcap/pd/blob/ea974c9488b8d304a72916d8cc50962f5ab99c5d/server/schedule/operator/builder.go#L233-L239), we can defer ID allocation to Builder.

### What is changed and how it works?
- allocate IDs in builder
- change cluster.AllocPeer to cluster.AllocID. (some tests keeps using AllocPeer)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test
