### PR TITLE
placement: add exclusive label

### DIFF
--- a/server/schedule/placement/label_constraint.go
+++ b/server/schedule/placement/label_constraint.go
@@ -66,7 +66,7 @@ func (c *LabelConstraint) MatchStore(store *core.StoreInfo) bool {
 // If a store has exclusiveLabels, it can only be selected when the label is
 // exciplitly specified in constraints.
 // TODO: move it to config.
-var exclusiveLabels = []string{"engine"}
+var exclusiveLabels = []string{"engine", "exclusive"}
 
 // MatchLabelConstraints checks if a store matches label constraints list.
 func MatchLabelConstraints(store *core.StoreInfo, constraints []LabelConstraint) bool {


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
[online restore](https://github.com/pingcap/br/pull/114) use label `exclusive` to mark some stores used to import data only.

### What is changed and how it works?
add exclusive labels

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test with online restore
