### PR TITLE
api: fix remove scheduler output

### DIFF
--- a/server/api/operator_test.go
+++ b/server/api/operator_test.go
@@ -80,7 +80,7 @@ func (s *testOperatorSuite) TestAddRemovePeer(c *C) {
 	c.Assert(strings.Contains(operator, "add learner peer 1 on store 3"), IsTrue)
 	c.Assert(strings.Contains(operator, "RUNNING"), IsTrue)
 
-	err = doDelete(regionURL)
+	_, err = doDelete(regionURL)
 	c.Assert(err, IsNil)
 
 	err = postJSON(fmt.Sprintf("%s/operators", s.urlPrefix), []byte(`{"name":"remove-peer", "region_id": 1, "store_id": 2}`))
@@ -89,7 +89,7 @@ func (s *testOperatorSuite) TestAddRemovePeer(c *C) {
 	c.Assert(strings.Contains(operator, "RUNNING"), IsTrue)
 	c.Assert(strings.Contains(operator, "remove peer on store 2"), IsTrue)
 
-	err = doDelete(regionURL)
+	_, err = doDelete(regionURL)
 	c.Assert(err, IsNil)
 
 	mustPutStore(c, s.svr, 4, metapb.StoreState_Up, nil)

--- a/server/api/scheduler.go
+++ b/server/api/scheduler.go
@@ -228,7 +228,10 @@ func (h *schedulerHandler) redirectSchedulerDelete(name, schedulerName string) e
 	args := strings.Split(name, "-")
 	args = args[len(args)-1:]
 	url := fmt.Sprintf("%s/%s/%s/delete/%s", h.GetAddr(), schedulerConfigPrefix, schedulerName, args[0])
-	err := doDelete(url)
+	resp, err := doDelete(url)
+	if resp.StatusCode != 200 {
+		return cluster.ErrSchedulerNotFound
+	}
 	if err != nil {
 		return err
 	}

--- a/server/api/scheduler_test.go
+++ b/server/api/scheduler_test.go
@@ -69,13 +69,15 @@ func (s *testScheduleSuite) TestOriginAPI(c *C) {
 	c.Assert(readJSON(listURL, &resp), IsNil)
 	c.Assert(resp["store-id-ranges"], HasLen, 2)
 	deleteURL := fmt.Sprintf("%s/%s", s.urlPrefix, "evict-leader-scheduler-1")
-	c.Assert(doDelete(deleteURL), IsNil)
+	_, err = doDelete(deleteURL)
+	c.Assert(err, IsNil)
 	c.Assert(rc.GetSchedulers(), HasLen, 1)
 	resp1 := make(map[string]interface{})
 	c.Assert(readJSON(listURL, &resp1), IsNil)
 	c.Assert(resp1["store-id-ranges"], HasLen, 1)
 	deleteURL = fmt.Sprintf("%s/%s", s.urlPrefix, "evict-leader-scheduler-2")
-	c.Assert(doDelete(deleteURL), IsNil)
+	_, err = doDelete(deleteURL)
+	c.Assert(err, IsNil)
 	c.Assert(rc.GetSchedulers(), HasLen, 0)
 	resp2 := make(map[string]interface{})
 	c.Assert(readJSON(listURL, &resp2), NotNil)
@@ -124,7 +126,8 @@ func (s *testScheduleSuite) TestAPI(c *C) {
 
 				// using /pd/v1/schedule-config/grant-leader-scheduler/config to delete exists store from grant-leader-scheduler
 				deleteURL := fmt.Sprintf("%s%s%s/%s/delete/%s", s.svr.GetAddr(), apiPrefix, server.SchedulerConfigHandlerPath, name, "2")
-				c.Assert(doDelete(deleteURL), IsNil)
+				_, err = doDelete(deleteURL)
+				c.Assert(err, IsNil)
 				resp = make(map[string]interface{})
 				c.Assert(readJSON(listURL, &resp), IsNil)
 				delete(exceptMap, "2")
@@ -184,7 +187,8 @@ func (s *testScheduleSuite) TestAPI(c *C) {
 
 				// using /pd/v1/schedule-config/evict-leader-scheduler/config to delete exist store from evict-leader-scheduler
 				deleteURL := fmt.Sprintf("%s%s%s/%s/delete/%s", s.svr.GetAddr(), apiPrefix, server.SchedulerConfigHandlerPath, name, "2")
-				c.Assert(doDelete(deleteURL), IsNil)
+				_, err = doDelete(deleteURL)
+				c.Assert(err, IsNil)
 				resp = make(map[string]interface{})
 				c.Assert(readJSON(listURL, &resp), IsNil)
 				delete(exceptMap, "2")
@@ -297,7 +301,7 @@ func (s *testScheduleSuite) addScheduler(name, createdName string, body []byte, 
 
 func (s *testScheduleSuite) deleteScheduler(createdName string, c *C) {
 	deleteURL := fmt.Sprintf("%s/%s", s.urlPrefix, createdName)
-	err := doDelete(deleteURL)
+	_, err := doDelete(deleteURL)
 	c.Assert(err, IsNil)
 }
 

--- a/server/api/scheduler_test.go
+++ b/server/api/scheduler_test.go
@@ -81,6 +81,9 @@ func (s *testScheduleSuite) TestOriginAPI(c *C) {
 	c.Assert(rc.GetSchedulers(), HasLen, 0)
 	resp2 := make(map[string]interface{})
 	c.Assert(readJSON(listURL, &resp2), NotNil)
+
+	r, _ := doDelete(deleteURL)
+	c.Assert(r.StatusCode, Equals, 500)
 }
 
 func (s *testScheduleSuite) TestAPI(c *C) {

--- a/server/api/util.go
+++ b/server/api/util.go
@@ -103,15 +103,15 @@ func postJSON(url string, data []byte, checkOpts ...func([]byte, int)) error {
 	return nil
 }
 
-func doDelete(url string) error {
+func doDelete(url string) (*http.Response, error) {
 	req, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	res, err := dialClient.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	res.Body.Close()
-	return nil
+	return res, nil
 }

--- a/server/cluster/cluster_worker.go
+++ b/server/cluster/cluster_worker.go
@@ -109,7 +109,7 @@ func (c *RaftCluster) HandleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*
 	for i := 0; i < int(splitCount); i++ {
 		newRegionID, err := c.id.Alloc()
 		if err != nil {
-			return nil, errSchedulerNotFound
+			return nil, ErrSchedulerNotFound
 		}
 
 		peerIDs := make([]uint64, len(request.Region.Peers))

--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -51,7 +51,8 @@ var (
 	// ErrNotBootstrapped is error info for cluster not bootstrapped.
 	ErrNotBootstrapped = errors.New("TiKV cluster not bootstrapped, please start TiKV first")
 	// ErrSchedulerExisted is error info for scheduler has already existed.
-	ErrSchedulerExisted  = errors.New("scheduler existed")
+	ErrSchedulerExisted = errors.New("scheduler existed")
+	// ErrSchedulerNotFound is error info for scheduler is not found.
 	ErrSchedulerNotFound = errors.New("scheduler not found")
 )
 

--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -52,7 +52,7 @@ var (
 	ErrNotBootstrapped = errors.New("TiKV cluster not bootstrapped, please start TiKV first")
 	// ErrSchedulerExisted is error info for scheduler has already existed.
 	ErrSchedulerExisted  = errors.New("scheduler existed")
-	errSchedulerNotFound = errors.New("scheduler not found")
+	ErrSchedulerNotFound = errors.New("scheduler not found")
 )
 
 // coordinator is used to manage all schedulers and checkers to decide if the region needs to be scheduled.
@@ -492,7 +492,7 @@ func (c *coordinator) removeScheduler(name string) error {
 	}
 	s, ok := c.schedulers[name]
 	if !ok {
-		return errSchedulerNotFound
+		return ErrSchedulerNotFound
 	}
 
 	s.Stop()
@@ -524,7 +524,7 @@ func (c *coordinator) pauseOrResumeScheduler(name string, t int64) error {
 	if name != "all" {
 		sc, ok := c.schedulers[name]
 		if !ok {
-			return errSchedulerNotFound
+			return ErrSchedulerNotFound
 		}
 		s = append(s, sc)
 	} else {


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fixes pingcap/tidb-ansible#1052.

### What is changed and how it works?
This PR makes the output of removing a nonexistent scheduler be consistent with the original API.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test

before:
```
>> curl -X DELETE http://127.0.0.1:2379/pd/api/v1/schedulers/evict-leader-scheduler-1
null
```
after:
```
>> curl -X DELETE http://127.0.0.1:2379/pd/api/v1/schedulers/evict-leader-scheduler-1
"scheduler not found"
```