### PR TITLE
scheduler: add trend monitor to avoid redundant scheduler

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -77,6 +77,11 @@ func (mc *Cluster) GetStoresStats() *statistics.StoresStats {
 	return mc.StoresStats
 }
 
+// IsTrendDiff returns whether region size and store used size are consistent.
+func (mc *Cluster) IsTrendDiff(storeID uint64) bool {
+	return false
+}
+
 // GetStoreRegionCount gets region count with a given store.
 func (mc *Cluster) GetStoreRegionCount(storeID uint64) int {
 	return mc.Regions.GetStoreRegionCount(storeID)

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -77,9 +77,9 @@ func (mc *Cluster) GetStoresStats() *statistics.StoresStats {
 	return mc.StoresStats
 }
 
-// IsTrendDiff returns whether region size and store used size are consistent.
-func (mc *Cluster) IsTrendDiff(storeID uint64) bool {
-	return false
+// GetTrend gets stores trend.
+func (mc *Cluster) GetTrend(kind statistics.MonitorKind, storeID uint64) statistics.CompareKind {
+	return statistics.Unsure
 }
 
 // GetStoreRegionCount gets region count with a given store.

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -77,9 +77,9 @@ func (mc *Cluster) GetStoresStats() *statistics.StoresStats {
 	return mc.StoresStats
 }
 
-// GetTrend gets stores trend.
-func (mc *Cluster) GetTrend(kind statistics.MonitorKind, storeID uint64) statistics.CompareKind {
-	return statistics.Unsure
+// GetTrendSpeed gets stores trend.
+func (mc *Cluster) GetTrendSpeed(kind statistics.MonitorKind, storeID uint64) float64 {
+	return 0
 }
 
 // GetStoreRegionCount gets region count with a given store.

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -719,9 +719,9 @@ func (c *RaftCluster) GetStoresStats() *statistics.StoresStats {
 	return c.storesStats
 }
 
-// GetTrend returns stores' trend from cluster.
-func (c *RaftCluster) GetTrend(kind statistics.MonitorKind, storeID uint64) statistics.CompareKind {
-	return c.trendMonitorHub.GetStatus(kind, storeID)
+// GetTrendSpeed returns stores' trend from cluster.
+func (c *RaftCluster) GetTrendSpeed(kind statistics.MonitorKind, storeID uint64) float64 {
+	return c.trendMonitorHub.GetTrendSpeed(kind, storeID)
 }
 
 // DropCacheRegion removes a region from the cache.

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -225,6 +225,17 @@ func (s *balanceRegionScheduler) transferPeer(cluster opt.Cluster, region *core.
 			continue
 		}
 
+		if cluster.IsTrendDiff(sourceID) {
+			label := strconv.FormatUint(sourceID, 10)
+			schedulerCounter.WithLabelValues(s.GetName(), "trend"+label).Inc()
+			continue
+		}
+		if cluster.IsTrendDiff(targetID) {
+			label := strconv.FormatUint(targetID, 10)
+			schedulerCounter.WithLabelValues(s.GetName(), "trend"+label).Inc()
+			continue
+		}
+
 		newPeer := &metapb.Peer{StoreId: target.GetID(), IsLearner: oldPeer.IsLearner}
 		op, err := operator.CreateMovePeerOperator("balance-region", cluster, region, operator.OpBalance, oldPeer.GetStoreId(), newPeer)
 		if err != nil {

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -220,19 +220,13 @@ func (s *balanceRegionScheduler) transferPeer(cluster opt.Cluster, region *core.
 
 		opInfluence := s.opController.GetOpInfluence(cluster)
 		kind := core.NewScheduleKind(core.RegionKind, core.BySize)
-		if !shouldBalance(cluster, source, target, region, kind, opInfluence, s.GetName()) {
+		scheduleName := s.GetName()
+		if !shouldBalance(cluster, source, target, region, kind, opInfluence, scheduleName) {
 			schedulerCounter.WithLabelValues(s.GetName(), "skip").Inc()
 			continue
 		}
 
-		if cluster.IsTrendDiff(sourceID) {
-			label := strconv.FormatUint(sourceID, 10)
-			schedulerCounter.WithLabelValues(s.GetName(), "trend-"+label).Inc()
-			continue
-		}
-		if cluster.IsTrendDiff(targetID) {
-			label := strconv.FormatUint(targetID, 10)
-			schedulerCounter.WithLabelValues(s.GetName(), "trend-"+label).Inc()
+		if isTrendDiff(cluster, scheduleName, sourceID) || isTrendDiff(cluster, scheduleName, targetID) {
 			continue
 		}
 

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -227,12 +227,12 @@ func (s *balanceRegionScheduler) transferPeer(cluster opt.Cluster, region *core.
 
 		if cluster.IsTrendDiff(sourceID) {
 			label := strconv.FormatUint(sourceID, 10)
-			schedulerCounter.WithLabelValues(s.GetName(), "trend"+label).Inc()
+			schedulerCounter.WithLabelValues(s.GetName(), "trend-"+label).Inc()
 			continue
 		}
 		if cluster.IsTrendDiff(targetID) {
 			label := strconv.FormatUint(targetID, 10)
-			schedulerCounter.WithLabelValues(s.GetName(), "trend"+label).Inc()
+			schedulerCounter.WithLabelValues(s.GetName(), "trend-"+label).Inc()
 			continue
 		}
 

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -14,7 +14,6 @@
 package schedulers
 
 import (
-	"github.com/pingcap/pd/server/statistics"
 	"math"
 	"net/url"
 	"sort"
@@ -26,6 +25,7 @@ import (
 	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/server/schedule/operator"
 	"github.com/pingcap/pd/server/schedule/opt"
+	"github.com/pingcap/pd/server/statistics"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -142,14 +142,16 @@ func adjustBalanceLimit(cluster opt.Cluster, kind core.ResourceKind) uint64 {
 	return maxUint64(1, uint64(limit))
 }
 
+const threshold = 0.03
+
 func isTrendDiff(cluster opt.Cluster, schedulerName string, storeID uint64) bool {
-	regionSizeStatus := cluster.GetTrend(statistics.RegionSize, storeID)
-	usedSizeStatus := cluster.GetTrend(statistics.UsedSize, storeID)
-	if regionSizeStatus == statistics.Unsure || usedSizeStatus == statistics.Unsure {
+	regionSizeStatus := cluster.GetTrendSpeed(statistics.RegionSize, storeID)
+	usedSizeStatus := cluster.GetTrendSpeed(statistics.UsedSize, storeID)
+	if regionSizeStatus == 0 || usedSizeStatus == 0 {
 		return false
 	}
 
-	if regionSizeStatus != usedSizeStatus {
+	if math.Abs(regionSizeStatus-usedSizeStatus) > threshold {
 		label := strconv.FormatUint(storeID, 10)
 		schedulerCounter.WithLabelValues(schedulerName, "trend-"+label).Inc()
 		return true

--- a/server/statistics/store.go
+++ b/server/statistics/store.go
@@ -445,6 +445,15 @@ func (m *TrendMonitor) Put(num uint64) {
 	}
 }
 
+const factor = 0.975
+
+func isRealGreater(a, b uint64) bool {
+	if a > b && float64(a)*factor > float64(b) {
+		return true
+	}
+	return false
+}
+
 // GetStatus is used to get trend status
 func (m *TrendMonitor) GetStatus() CompareKind {
 	if m.l.Len() < m.capacity {
@@ -452,9 +461,9 @@ func (m *TrendMonitor) GetStatus() CompareKind {
 	}
 	head := m.l.Front().Value.(*trendNode)
 	tail := m.l.Back().Value.(*trendNode)
-	if tail.num > head.num {
+	if isRealGreater(tail.num, head.num) {
 		return greater
-	} else if tail.num < head.num {
+	} else if isRealGreater(head.num, tail.num) {
 		return less
 	} else {
 		return equal

--- a/server/statistics/store.go
+++ b/server/statistics/store.go
@@ -444,19 +444,19 @@ func (m *trendMonitor) getTrendSpeed() float64 {
 	}
 
 	i, sum, weight := 0, 0.0, 1.0
-	tail := m.nums.Back().Value.(*trendNode).num
+	tail := float64(m.nums.Back().Value.(*trendNode).num)
 	next := tail
 
 	for e := m.nums.Back().Prev(); e != nil; e = e.Prev() {
-		i += 1
+		i++
 		if i%m.batch == 0 {
 			weight /= 2
-			cur := e.Value.(*trendNode).num
-			sum += (float64(next) - float64(cur)) * weight
+			cur := float64(e.Value.(*trendNode).num)
+			sum += (next - cur) * weight
 			next = cur
 		}
 	}
-	return sum / float64(tail)
+	return sum / tail
 }
 
 // MonitorKind is the monitor kind

--- a/server/statistics/store.go
+++ b/server/statistics/store.go
@@ -447,6 +447,9 @@ func (m *TrendMonitor) Put(num uint64) {
 
 const factor = 0.975
 
+// It was observed that  the slowly decreasing store used size, while the region size continues to decrease due to
+// move out of the region.So we need to ensure the bigger one is big enough to avoid the trend monitor cannot work
+// properly in such a situation.
 func isRealGreater(a, b uint64) bool {
 	if a > b && float64(a)*factor > float64(b) {
 		return true

--- a/server/statistics/store_stat_informer.go
+++ b/server/statistics/store_stat_informer.go
@@ -16,5 +16,5 @@ package statistics
 // StoreStatInformer provides access to a shared informer of statistics.
 type StoreStatInformer interface {
 	GetStoresStats() *StoresStats
-	IsTrendDiff(storeID uint64) bool
+	GetTrend(kind MonitorKind, storeID uint64) CompareKind
 }

--- a/server/statistics/store_stat_informer.go
+++ b/server/statistics/store_stat_informer.go
@@ -16,4 +16,5 @@ package statistics
 // StoreStatInformer provides access to a shared informer of statistics.
 type StoreStatInformer interface {
 	GetStoresStats() *StoresStats
+	IsTrendDiff(storeID uint64) bool
 }

--- a/server/statistics/store_stat_informer.go
+++ b/server/statistics/store_stat_informer.go
@@ -16,5 +16,5 @@ package statistics
 // StoreStatInformer provides access to a shared informer of statistics.
 type StoreStatInformer interface {
 	GetStoresStats() *StoresStats
-	GetTrend(kind MonitorKind, storeID uint64) CompareKind
+	GetTrendSpeed(kind MonitorKind, storeID uint64) float64
 }

--- a/server/statistics/store_test.go
+++ b/server/statistics/store_test.go
@@ -19,20 +19,19 @@ func newTestTrendCase(result float64, nums ...uint64) *testTrendCase {
 	t := &testTrendCase{
 		result: result,
 	}
-	for _, num := range nums {
-		t.nums = append(t.nums, num)
-	}
+	t.nums = append(t.nums, nums...)
 	return t
 }
 
 func (s *testTopNSuite) TestGet(c *C) {
 	m := newTrendMonitor()
 
-	testCases := make([]*testTrendCase, 0)
-	testCases = append(testCases, newTestTrendCase(-0.0146875, 209, 208, 205, 205, 200))
-	testCases = append(testCases, newTestTrendCase(0.01875, 230, 235, 240, 245, 250))
-	testCases = append(testCases, newTestTrendCase(0.015, 227, 235, 243, 248, 250))
-	testCases = append(testCases, newTestTrendCase(-0.0359375, 220, 215, 214, 213, 200))
+	testCases := []*testTrendCase{
+		newTestTrendCase(-0.0146875, 209, 208, 205, 205, 200),
+		newTestTrendCase(0.01875, 230, 235, 240, 245, 250),
+		newTestTrendCase(0.015, 227, 235, 243, 248, 250),
+		newTestTrendCase(-0.0359375, 220, 215, 214, 213, 200),
+	}
 
 	for _, testCase := range testCases {
 		nums := make([]uint64, m.capacity)

--- a/server/statistics/store_test.go
+++ b/server/statistics/store_test.go
@@ -1,0 +1,51 @@
+package statistics
+
+import (
+	. "github.com/pingcap/check"
+	"math"
+	"time"
+)
+
+var _ = Suite(&testTrendSuite{})
+
+type testTrendSuite struct{}
+
+type testTrendCase struct {
+	nums   []uint64
+	result float64
+}
+
+func newTestTrendCase(result float64, nums ...uint64) *testTrendCase {
+	t := &testTrendCase{
+		result: result,
+	}
+	for _, num := range nums {
+		t.nums = append(t.nums, num)
+	}
+	return t
+}
+
+func (s *testTopNSuite) TestGet(c *C) {
+	m := newTrendMonitor()
+
+	testCases := make([]*testTrendCase, 0)
+	testCases = append(testCases, newTestTrendCase(-0.0146875, 209, 208, 205, 205, 200))
+	testCases = append(testCases, newTestTrendCase(0.01875, 230, 235, 240, 245, 250))
+	testCases = append(testCases, newTestTrendCase(0.015, 227, 235, 243, 248, 250))
+	testCases = append(testCases, newTestTrendCase(-0.0359375, 220, 215, 214, 213, 200))
+
+	for _, testCase := range testCases {
+		nums := make([]uint64, m.capacity)
+		for i := 0; i < m.capacity; i += 10 {
+			nums[i] = testCase.nums[i/10]
+		}
+		m.interval = time.Duration(0)
+		for _, num := range nums {
+			m.put(num)
+		}
+
+		result := m.getTrendSpeed()
+		c.Assert(math.Abs(result-testCase.result), LessEqual, 1e-7)
+		m.gc()
+	}
+}


### PR DESCRIPTION
Signed-off-by: lhy1024 <admin@liudos.us>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

it will try to solve #2071 and #2002 at the same time.

### What is changed and how it works?
![image](https://user-images.githubusercontent.com/19542290/72526250-f421cc80-38a0-11ea-9b7a-6c161c7a8f11.png)
It is common when the store used size increases, and at this time the region size is decreasing, and it is constantly moving out. We should avoid this situation, so the `trend monitor` is added, and scheduling is allowed only when the two trends are the same.

- [ ] test
- [ ] unit test and refactor

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test