### PR TITLE
api: fix the problem that enable-placement-rules cannot be set twice

### DIFF
--- a/server/api/config.go
+++ b/server/api/config.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"reflect"
+	"strings"
 
 	"github.com/pingcap/errcode"
 	"github.com/pingcap/pd/pkg/apiutil"
@@ -122,7 +123,11 @@ func (h *confHandler) mergeConfig(v interface{}, data []byte) (updated bool, fou
 	}
 	t := reflect.TypeOf(v).Elem()
 	for i := 0; i < t.NumField(); i++ {
-		if _, ok := m[t.Field(i).Tag.Get("json")]; ok {
+		jsonTag := t.Field(i).Tag.Get("json")
+		if i := strings.Index(jsonTag, ","); i != -1 { // trim 'foobar,string' to 'foobar'
+			jsonTag = jsonTag[:i]
+		}
+		if _, ok := m[jsonTag]; ok {
 			return false, true, nil
 		}
 	}

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -194,4 +194,12 @@ func (s *configTestSuite) TestConfig(c *C) {
 	_, output, err = pdctl.ExecuteCommandC(cmd, args1...)
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "already been deprecated"), IsTrue)
+
+	// set enable-placement-rules twice, make sure it does not return error.
+	args1 = []string{"-u", pdAddr, "config", "set", "enable-placement-rules", "true"}
+	_, _, err = pdctl.ExecuteCommandC(cmd, args1...)
+	c.Assert(err, IsNil)
+	args1 = []string{"-u", pdAddr, "config", "set", "enable-placement-rules", "true"}
+	_, _, err = pdctl.ExecuteCommandC(cmd, args1...)
+	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
run `pd-ctl config set enable-placement-rules true` twice, it reports `config item not found`

### What is changed and how it works?
My previous fix (https://github.com/pingcap/pd/pull/1960) has a bug: it use json tag to check if the config item exists, while the json tag can be declared as `foobar,string`, we need trim tailing `,string`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test
 - Manual test (add detailed scripts or steps below)
