### PR TITLE
dashboard: do not build dashboard-ui on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,9 @@ tools: pd-tso-bench pd-recover pd-analysis pd-heartbeat-bench
 pd-server: export GO111MODULE=on
 ifeq ("$(WITH_RACE)", "1")
 pd-server:
+ifneq ($(OS),Windows_NT)
 	./scripts/embed-dashboard-ui.sh
+endif
 	CGO_ENABLED=1 go build -race -gcflags '$(GCFLAGS)' -ldflags '$(LDFLAGS)' -o bin/pd-server cmd/pd-server/main.go
 else ifeq ("$(PD_WEB)", "1")
 pd-server: retool-setup
@@ -62,7 +64,9 @@ pd-server: retool-setup
 	CGO_ENABLED=0 go build -gcflags '$(GCFLAGS)' -ldflags '$(LDFLAGS)' -tags web -o bin/pd-server cmd/pd-server/main.go
 else
 pd-server:
+ifneq ($(OS),Windows_NT)
 	./scripts/embed-dashboard-ui.sh
+endif
 	CGO_ENABLED=0 go build -gcflags '$(GCFLAGS)' -ldflags '$(LDFLAGS)' -o bin/pd-server cmd/pd-server/main.go
 endif
 

--- a/pkg/dashboard/uiserver/empty_assets_handler_windows.go
+++ b/pkg/dashboard/uiserver/empty_assets_handler_windows.go
@@ -14,19 +14,9 @@
 package uiserver
 
 import (
-	"io"
-	"net/http"
+	assetfs "github.com/elazarl/go-bindata-assetfs"
 )
 
-// Handler returns an http.Handler that serves the dashboard UI.
-func Handler() http.Handler {
-	fs := assetFS()
-	if fs != nil {
-		fileServer := http.FileServer(fs)
-		return fileServer
-	}
-
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.WriteString(w, "Dashboard UI is not built.\n")
-	})
+func assetFS() *assetfs.AssetFS {
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: hundundm <hundundm@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

Cannot compile pd-server in Windows.

### What is changed and how it works?

Determine the OS in the Makefile. If it is Windows, skip the process of building Dashboard-UI and use empty_assets_handler.go instead.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
    - Just `make` in Windows