### PR TITLE
test: make TestFailedAndDeletedPDJoinsPreviousCluster stable

### DIFF
--- a/tests/server/join/join_test.go
+++ b/tests/server/join/join_test.go
@@ -46,7 +46,7 @@ type joinTestSuite struct {
 func (s *joinTestSuite) SetUpSuite(c *C) {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	server.EnableZap = true
-	server.EtcdStartTimeout = 5 * time.Second
+	server.EtcdStartTimeout = 10 * time.Second
 }
 
 func (s *joinTestSuite) TearDownSuite(c *C) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Before #1948 we manually call cancel function to exit `startEtcd`. #1948 changes it by using a timeout. But 5 seconds maybe short for starting etcd which will make the test failed sometimes. Closes #2059. 

### What is changed and how it works?
This PR enlarges `EtcdStartTimeout` to 10 seconds in order to make test more stable.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
