### PR TITLE
build: fix ci build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ MAINTAINER siddontang
 
 RUN apk add --no-cache \
     make \
-    git
+    git \
+    bash
 
 # Install jq for pd-ctl
 RUN cd / && \


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

Docker build failed:

```
...
Step 11/17 : RUN make
 ---> Running in 355e290172b1
./scripts/embed-dashboard-ui.sh
env: can't execute 'bash': No such file or directory
make: *** [Makefile:68: pd-server] Error 127
The command '/bin/sh -c make' returned a non-zero code: 2
```

### What is changed and how it works?

Add bash in Dockerfile.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below): `docker build -t pd:test .`
