### PR TITLE
config: rename EnableConfigManager to EnableDynamicConfig

### DIFF
--- a/server/api/config.go
+++ b/server/api/config.go
@@ -50,7 +50,7 @@ func (h *confHandler) Get(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *confHandler) Post(w http.ResponseWriter, r *http.Request) {
-	if h.svr.GetConfig().EnableConfigManager {
+	if h.svr.GetConfig().EnableDynamicConfig {
 		client := h.svr.GetConfigClient()
 		if client == nil {
 			h.rd.JSON(w, http.StatusServiceUnavailable, "no leader")
@@ -164,7 +164,7 @@ func (h *confHandler) GetSchedule(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *confHandler) SetSchedule(w http.ResponseWriter, r *http.Request) {
-	if h.svr.GetConfig().EnableConfigManager {
+	if h.svr.GetConfig().EnableDynamicConfig {
 		client := h.svr.GetConfigClient()
 		if client == nil {
 			h.rd.JSON(w, http.StatusServiceUnavailable, "no leader")
@@ -202,7 +202,7 @@ func (h *confHandler) GetReplication(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *confHandler) SetReplication(w http.ResponseWriter, r *http.Request) {
-	if h.svr.GetConfig().EnableConfigManager {
+	if h.svr.GetConfig().EnableDynamicConfig {
 		client := h.svr.GetConfigClient()
 		if client == nil {
 			h.rd.JSON(w, http.StatusServiceUnavailable, "no leader")
@@ -245,7 +245,7 @@ func (h *confHandler) SetLabelProperty(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if h.svr.GetConfig().EnableConfigManager {
+	if h.svr.GetConfig().EnableDynamicConfig {
 		client := h.svr.GetConfigClient()
 		if client == nil {
 			h.rd.JSON(w, http.StatusServiceUnavailable, "no leader")
@@ -322,7 +322,7 @@ func (h *confHandler) SetClusterVersion(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if h.svr.GetConfig().EnableConfigManager {
+	if h.svr.GetConfig().EnableDynamicConfig {
 		kind := &configpb.ConfigKind{Kind: &configpb.ConfigKind_Global{Global: &configpb.Global{Component: server.Component}}}
 		v := &configpb.Version{Global: h.svr.GetConfigManager().GlobalCfgs[server.Component].GetVersion()}
 		entry := &configpb.ConfigEntry{Name: "cluster-version", Value: version}

--- a/server/api/config_test.go
+++ b/server/api/config_test.go
@@ -33,7 +33,7 @@ type testConfigSuite struct {
 
 func (s *testConfigSuite) SetUpSuite(c *C) {
 	server.ConfigCheckInterval = 10 * time.Millisecond
-	s.svr, s.cleanup = mustNewServer(c, func(cfg *config.Config) { cfg.EnableConfigManager = true })
+	s.svr, s.cleanup = mustNewServer(c, func(cfg *config.Config) { cfg.EnableDynamicConfig = true })
 	mustWaitLeader(c, []*server.Server{s.svr})
 
 	addr := s.svr.GetAddr()

--- a/server/api/label_test.go
+++ b/server/api/label_test.go
@@ -111,7 +111,7 @@ func (s *testLabelsStoreSuite) SetUpSuite(c *C) {
 	server.ConfigCheckInterval = 10 * time.Millisecond
 	s.svr, s.cleanup = mustNewServer(c, func(cfg *config.Config) {
 		cfg.Replication.StrictlyMatchLabel = false
-		cfg.EnableConfigManager = true
+		cfg.EnableDynamicConfig = true
 	})
 	mustWaitLeader(c, []*server.Server{s.svr})
 
@@ -194,7 +194,7 @@ func (s *testStrictlyLabelsStoreSuite) SetUpSuite(c *C) {
 	s.svr, s.cleanup = mustNewServer(c, func(cfg *config.Config) {
 		cfg.Replication.LocationLabels = []string{"zone", "disk"}
 		cfg.Replication.StrictlyMatchLabel = true
-		cfg.EnableConfigManager = true
+		cfg.EnableDynamicConfig = true
 	})
 	mustWaitLeader(c, []*server.Server{s.svr})
 

--- a/server/api/log.go
+++ b/server/api/log.go
@@ -38,7 +38,7 @@ func newlogHandler(svr *server.Server, rd *render.Render) *logHandler {
 }
 
 func (h *logHandler) Handle(w http.ResponseWriter, r *http.Request) {
-	if h.svr.GetConfig().EnableConfigManager {
+	if h.svr.GetConfig().EnableDynamicConfig {
 		client := h.svr.GetConfigClient()
 		if client == nil {
 			h.rd.JSON(w, http.StatusServiceUnavailable, "no leader")

--- a/server/api/store_test.go
+++ b/server/api/store_test.go
@@ -84,7 +84,7 @@ func (s *testStoreSuite) SetUpSuite(c *C) {
 		},
 	}
 	server.ConfigCheckInterval = 10 * time.Millisecond
-	s.svr, s.cleanup = mustNewServer(c, func(cfg *config.Config) { cfg.EnableConfigManager = true })
+	s.svr, s.cleanup = mustNewServer(c, func(cfg *config.Config) { cfg.EnableDynamicConfig = true })
 	mustWaitLeader(c, []*server.Server{s.svr})
 
 	addr := s.svr.GetAddr()

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -129,7 +129,7 @@ type Config struct {
 	logger   *zap.Logger
 	logProps *log.ZapProperties
 
-	EnableConfigManager bool
+	EnableDynamicConfig bool
 
 	EnableDashboard bool
 }
@@ -165,7 +165,7 @@ func NewConfig() *Config {
 	fs.StringVar(&cfg.Security.KeyPath, "key", "", "Path of file that contains X509 key in PEM format")
 	fs.BoolVar(&cfg.ForceNewCluster, "force-new-cluster", false, "Force to create a new one-member cluster")
 
-	fs.BoolVar(&cfg.EnableConfigManager, "enable-config-manager", false, "Enable configuration manager")
+	fs.BoolVar(&cfg.EnableDynamicConfig, "enable-dynamic-config", false, "Enable dynamic configuration change")
 
 	fs.BoolVar(&cfg.EnableDashboard, "enable-dashboard", true, "Enable Dashboard API and UI on this node")
 

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -229,7 +229,7 @@ func (s *Server) PutStore(ctx context.Context, request *pdpb.PutStoreRequest) (*
 
 	log.Info("put store ok", zap.Stringer("store", store))
 	v := rc.OnStoreVersionChange()
-	if s.GetConfig().EnableConfigManager && v != nil {
+	if s.GetConfig().EnableDynamicConfig && v != nil {
 		status := s.updateConfigManager("cluster-version", v.String())
 		if status.GetCode() != configpb.StatusCode_OK {
 			log.Error("failed to update the cluster version", zap.Error(errors.New(status.GetMessage())))

--- a/server/server.go
+++ b/server/server.go
@@ -49,7 +49,7 @@ import (
 	"github.com/pingcap/pd/pkg/typeutil"
 	"github.com/pingcap/pd/server/cluster"
 	"github.com/pingcap/pd/server/config"
-	"github.com/pingcap/pd/server/config_manager"
+	configmanager "github.com/pingcap/pd/server/config_manager"
 	"github.com/pingcap/pd/server/core"
 	"github.com/pingcap/pd/server/id"
 	"github.com/pingcap/pd/server/kv"
@@ -243,7 +243,7 @@ func CreateServer(ctx context.Context, cfg *config.Config, apiBuilders ...Handle
 		pdpb.RegisterPDServer(gs, s)
 		diagnosticspb.RegisterDiagnosticsServer(gs, s)
 
-		if cfg.EnableConfigManager {
+		if cfg.EnableDynamicConfig {
 			configpb.RegisterConfigServer(gs, s.cfgManager)
 		}
 	}
@@ -447,7 +447,7 @@ func (s *Server) startServerLoop(ctx context.Context) {
 	go s.leaderLoop()
 	go s.etcdLeaderLoop()
 	go s.serverMetricsLoop()
-	if s.cfg.EnableConfigManager {
+	if s.cfg.EnableDynamicConfig {
 		s.serverLoopWg.Add(1)
 		go s.configCheckLoop()
 	}
@@ -1250,7 +1250,7 @@ func (s *Server) reloadConfigFromKV() error {
 
 	// The request only valid when there is a leader.
 	// And before the a PD becomes a leader it will firstly reload the config.
-	if s.cfg.EnableConfigManager {
+	if s.cfg.EnableDynamicConfig {
 		err = s.cfgManager.Reload(s.storage)
 		return err
 	}

--- a/tests/client/config_client_test.go
+++ b/tests/client/config_client_test.go
@@ -48,7 +48,7 @@ func (s *configClientTestSuite) TearDownSuite(c *C) {
 }
 
 func (s *configClientTestSuite) TestUpdateWrongEntry(c *C) {
-	cluster, err := tests.NewTestCluster(s.ctx, 1, func(cfg *config.Config) { cfg.EnableConfigManager = true })
+	cluster, err := tests.NewTestCluster(s.ctx, 1, func(cfg *config.Config) { cfg.EnableDynamicConfig = true })
 	c.Assert(err, IsNil)
 	defer cluster.Destroy()
 
@@ -105,7 +105,7 @@ func (s *configClientTestSuite) TestUpdateWrongEntry(c *C) {
 }
 
 func (s *configClientTestSuite) TestClientLeaderChange(c *C) {
-	cluster, err := tests.NewTestCluster(s.ctx, 3, func(cfg *config.Config) { cfg.EnableConfigManager = true })
+	cluster, err := tests.NewTestCluster(s.ctx, 3, func(cfg *config.Config) { cfg.EnableDynamicConfig = true })
 	c.Assert(err, IsNil)
 	defer cluster.Destroy()
 
@@ -196,7 +196,7 @@ func (s *configClientTestSuite) TestClientLeaderChange(c *C) {
 }
 
 func (s *configClientTestSuite) TestLeaderTransfer(c *C) {
-	cluster, err := tests.NewTestCluster(s.ctx, 2, func(cfg *config.Config) { cfg.EnableConfigManager = true })
+	cluster, err := tests.NewTestCluster(s.ctx, 2, func(cfg *config.Config) { cfg.EnableDynamicConfig = true })
 	c.Assert(err, IsNil)
 	defer cluster.Destroy()
 

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -533,7 +533,7 @@ func (s *clusterTestSuite) TestConcurrentHandleRegion(c *C) {
 }
 
 func (s *clusterTestSuite) TestSetScheduleOpt(c *C) {
-	tc, err := tests.NewTestCluster(s.ctx, 1, func(cfg *config.Config) { cfg.EnableConfigManager = true })
+	tc, err := tests.NewTestCluster(s.ctx, 1, func(cfg *config.Config) { cfg.EnableDynamicConfig = true })
 	defer tc.Destroy()
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
To keep consistent with other components' naming style.

### What is changed and how it works?
This PR rename `EnableConfigManager` to `EnableDynamicConfig`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
