### PR TITLE
checker: fix rule checker panic

### DIFF
--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -182,6 +182,10 @@ func (c *RuleChecker) fixBetterLocation(region *core.RegionInfo, fit *placement.
 	}
 	oldPeer := region.GetStorePeer(oldPeerStore.GetID())
 	newPeerStore := SelectStoreToReplacePeerByRule("rule-checker", c.cluster, region, fit, rf, oldPeer)
+	if newPeerStore == nil {
+		log.Debug("no replacement store", zap.Uint64("region-id", region.GetID()))
+		return nil, nil
+	}
 	stores = getRuleFitStores(c.cluster, removePeerFromRuleFit(rf, oldPeer))
 	oldScore := core.DistinctScore(rf.Rule.LocationLabels, stores, oldPeerStore)
 	newScore := core.DistinctScore(rf.Rule.LocationLabels, stores, newPeerStore)

--- a/server/schedule/checker/rule_checker_test.go
+++ b/server/schedule/checker/rule_checker_test.go
@@ -15,6 +15,7 @@ package checker
 
 import (
 	"encoding/hex"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
@@ -177,5 +178,23 @@ func (s *testRuleCheckerSuite) TestBetterReplacement(c *C) {
 	c.Assert(op.Step(0).(operator.AddLearner).ToStore, Equals, uint64(4))
 	s.cluster.AddLeaderRegionWithRange(1, "", "", 1, 3, 4)
 	op = s.rc.Check(s.cluster.GetRegion(1))
+	c.Assert(op, IsNil)
+}
+
+func (s *testRuleCheckerSuite) TestNoBetterReplacement(c *C) {
+	s.cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+	s.cluster.AddLabelsStore(2, 1, map[string]string{"host": "host1"})
+	s.cluster.AddLabelsStore(3, 1, map[string]string{"host": "host2"})
+	s.cluster.AddLeaderRegionWithRange(1, "", "", 1, 2, 3)
+	s.ruleManager.SetRule(&placement.Rule{
+		GroupID:        "pd",
+		ID:             "test",
+		Index:          100,
+		Override:       true,
+		Role:           placement.Voter,
+		Count:          3,
+		LocationLabels: []string{"host"},
+	})
+	op := s.rc.Check(s.cluster.GetRegion(1))
 	c.Assert(op, IsNil)
 }


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
when no more store to replace, it panics:
```
[2020/02/26 11:46:45.244 +08:00] [FATAL] [log.go:294] [panic] [recover="\"invalid memory address or nil pointer dereference\""] [stack="github.com/pingcap/log.Fatal\n\t/home/birdstorm/go/pkg/mod/github.com/pingcap/log@v0.0.0-2020011      7041106-d28c14d3b1cd/global.go:59\ngithub.com/pingcap/pd/v3/pkg/logutil.LogPanic\n\t/home/birdstorm/go/src/github.com/pingcap/pd/pkg/logutil/log.go:294\nruntime.gopanic\n\t/usr/local/go/src/runtime/panic.go:679\nruntime.panicmem\n\t      /usr/local/go/src/runtime/panic.go:199\nruntime.sigpanic\n\t/usr/local/go/src/runtime/signal_unix.go:394\ngithub.com/pingcap/kvproto/pkg/metapb.(*Store).GetId\n\t/home/birdstorm/go/pkg/mod/github.com/pingcap/kvproto@v0.0.0-202002130      74014-83e827908584/pkg/metapb/metapb.pb.go:221\ngithub.com/pingcap/pd/v3/server/core.DistinctScore\n\t/home/birdstorm/go/src/github.com/pingcap/pd/server/core/store.go:453\ngithub.com/pingcap/pd/v3/server/schedule/checker.(*RuleChec      ker).fixBetterLocation\n\t/home/birdstorm/go/src/github.com/pingcap/pd/server/schedule/checker/rule_checker.go:187\ngithub.com/pingcap/pd/v3/server/schedule/checker.(*RuleChecker).fixRulePeer\n\t/home/birdstorm/go/src/github.com/pin      gcap/pd/server/schedule/checker/rule_checker.go:110\ngithub.com/pingcap/pd/v3/server/schedule/checker.(*RuleChecker).Check\n\t/home/birdstorm/go/src/github.com/pingcap/pd/server/schedule/checker/rule_checker.go:59\ngithub.com/pingca      p/pd/v3/server/schedule.(*CheckerController).CheckRegion\n\t/home/birdstorm/go/src/github.com/pingcap/pd/server/schedule/checker_controller.go:58\ngithub.com/pingcap/pd/v3/server/cluster.(*coordinator).patrolRegions\n\t/home/birdsto      rm/go/src/github.com/pingcap/pd/server/cluster/coordinator.go:125"]
```

### What is changed and how it works?
- check nil
- add unit test

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test

Related changes
 - Need to cherry-pick to the release branch (release-3.1)
