### PR TITLE
api: make  api/version and release version consistent

### DIFF
--- a/server/api/status.go
+++ b/server/api/status.go
@@ -27,6 +27,7 @@ type statusHandler struct {
 
 type status struct {
 	BuildTS        string `json:"build_ts"`
+	Version        string `json:"version"`
 	GitHash        string `json:"git_hash"`
 	StartTimestamp int64  `json:"start_timestamp"`
 }
@@ -42,6 +43,7 @@ func (h *statusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	version := status{
 		BuildTS:        server.PDBuildTS,
 		GitHash:        server.PDGitHash,
+		Version:        server.PDReleaseVersion,
 		StartTimestamp: h.svr.StartTimestamp(),
 	}
 

--- a/server/api/status_test.go
+++ b/server/api/status_test.go
@@ -30,6 +30,7 @@ func checkStatusResponse(c *C, body []byte) {
 	c.Assert(json.Unmarshal(body, &got), IsNil)
 	c.Assert(got.BuildTS, Equals, server.PDBuildTS)
 	c.Assert(got.GitHash, Equals, server.PDGitHash)
+	c.Assert(got.Version, Equals, server.PDReleaseVersion)
 }
 
 func (s *testStatusAPISuite) TestStatus(c *C) {

--- a/server/api/version.go
+++ b/server/api/version.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 
+	"github.com/pingcap/pd/v4/server"
 	"github.com/unrolled/render"
 )
 
@@ -22,7 +23,7 @@ func newVersionHandler(rd *render.Render) *versionHandler {
 
 func (h *versionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	version := &version{
-		Version: "1.0.0",
+		Version: server.PDReleaseVersion,
 	}
 	h.rd.JSON(w, http.StatusOK, version)
 }


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fix problem
```
curl http://pd-ip:2379/api/v1/version

got:  1.0.0
```


### What is changed and how it works?
consistent with the release version.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
