### PR TITLE
tools: fix pipeline of pd-ctl

### DIFF
--- a/tools/pd-ctl/main.go
+++ b/tools/pd-ctl/main.go
@@ -51,7 +51,6 @@ func main() {
 	var input []string
 	stat, _ := os.Stdin.Stat()
 	if (stat.Mode() & os.ModeCharDevice) == 0 {
-		os.Args = append(os.Args, "-d")
 		b, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
 			fmt.Println(err)


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Introduced by #2187, which will cause `unknown shorthand flag: 'd' in -d` error when using pipeline.

### What is changed and how it works?
Since the default mode is `detach`, we don't need to set the `detach` flag.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test 
1. start pd server
2. run `echo "--pd 127.0.0.1:2379 config set region-schedule-limit 1" | /path/to/pd-ctl`