### PR TITLE
tools: use golangci-lint in the officially recommended way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ default*
 *.bak
 .vscode/
 /.dashboard_asset_cache
+/.tools/bin

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+run:
+  deadline: 120s
+linters:
+  enable:
+    - misspell
+  disable:
+    - errcheck

--- a/scripts/retool-install.sh
+++ b/scripts/retool-install.sh
@@ -12,7 +12,6 @@ command -v retool >/dev/null || go get github.com/twitchtv/retool
 ./scripts/retool add gopkg.in/alecthomas/gometalinter.v2 v2.0.5
 # linter
 ./scripts/retool add github.com/mgechev/revive 7773f47324c2bf1c8f7a5500aff2b6c01d3ed73b
-./scripts/retool add github.com/golangci/golangci-lint/cmd/golangci-lint 4ba2155996359eabd8800d1fbf3e3a9777c80490
 # go fail
 ./scripts/retool add github.com/pingcap/failpoint/failpoint-ctl master
 # deadlock detection

--- a/tools.json
+++ b/tools.json
@@ -13,10 +13,6 @@
       "Commit": "22ec1a223b7c9a2e56355bd500b539cba3784238"
     },
     {
-      "Repository": "github.com/golangci/golangci-lint/cmd/golangci-lint",
-      "Commit": "4ba2155996359eabd8800d1fbf3e3a9777c80490"
-    },
-    {
       "Repository": "golang.org/x/tools/cmd/goimports",
       "Commit": "04b5d21e00f1f47bd824a6ade581e7189bacde87"
     },


### PR DESCRIPTION
UCP #2181
Signed-off-by: Poytr1 <pooytr1@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

Resolve: https://github.com/pingcap/pd/issues/2181
Currently, golangci-lint is installed in retool, which is not an officially recommended installation method. We need to change to the officially recommended way and add the .golangci.yml configuration file.

### What is changed and how it works?

- Delete `golangci-lint` in the `retool-install.sh` as well as `tool.json`
- Add a new task in Makefile called `golangci-lint-setup` to download `golangci-lint` binary into *$GOPATH/bin/golangci-lint* as https://github.com/golangci/golangci-lint#install suggests.
- Add a `.golangci.yml` file which has same config with the command line option.
- Update the command to call `golangci-lint` using the new config file.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Run `make check`, then the `golangci-lint` will be downloaded and ran with the config file `.golangci.yml`.

Code changes

 - Has configuration change

Side effects
N/A

Related changes

 - Need to update the documentation
