### PR TITLE
pdctl: improve scheduler config commands

### DIFF
--- a/tests/pdctl/scheduler/scheduler_test.go
+++ b/tests/pdctl/scheduler/scheduler_test.go
@@ -89,7 +89,7 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 			_, _, err = pdctl.ExecuteCommandC(cmd, args...)
 			c.Assert(err, IsNil)
 		}
-		args = []string{"-u", pdAddr, "scheduler", "config", "show", schedulerName}
+		args = []string{"-u", pdAddr, "scheduler", "config", schedulerName}
 		_, output, err := pdctl.ExecuteCommandC(cmd, args...)
 		c.Assert(err, IsNil)
 		configInfo := make(map[string]interface{})
@@ -147,7 +147,7 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 		checkSchedulerConfigCommand(nil, expectedConfig, schedulers[idx])
 
 		// scheduler config update command
-		args = []string{"-u", pdAddr, "scheduler", "config", "update", schedulers[idx], "3"}
+		args = []string{"-u", pdAddr, "scheduler", "config", schedulers[idx], "add-store", "3"}
 		expected = map[string]bool{
 			"balance-leader-scheduler":     true,
 			"balance-hot-region-scheduler": true,


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Currently, on server side, schedulers can define their own http handlers to read/write configuration. However, pd-ctl side does not reflect the same logical structure. Specifically, it uses fixed `show`, `update`, `delete` sub commands to manipulate configurations.
It seems the better way is to allow schedulers to define their own sub commands

old:
```
scheduler config show evict-leader-scheduler
scheduler config update evict-leader-scheduler 1
scheduler config delete grant-leader-scheduler 2
```

new:
```
scheduler config evict-leader-scheduler
scheduler config evict-leader-scheduler add-store 1
scheduler config grant-leader-scheduler delete-store 2
```

### What is changed and how it works?
- change command/subcommand structure
- some refactor to eliminate command Use resets

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test

Side effects
 - Breaking backward compatibility (may affects utils that relies on `pd-ctl`)
