### PR TITLE
api: fix register handler leak

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -166,10 +166,14 @@ type lazyHandler struct {
 	engine  *negroni.Negroni
 }
 
+var once sync.Once
+
 func (lazy *lazyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	for _, f := range lazy.options {
-		f()
-	}
+	once.Do(func() {
+		for _, f := range lazy.options {
+			f()
+		}
+	})
 
 	lazy.engine.ServeHTTP(w, r)
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
After #2204. we enable dynamic config by default. When we use HTTP API, the `lazyHandler` will be called. The handler will call `RegisterConfigHandlerFromEndpoint` which creates a goroutine to handle the stop logic. In this case, once we call API multiple times, goroutines will be leaked.

### What is changed and how it works?
This PR fixes this by using `sync.Once` to prevent calling `RegisterConfigHandlerFromEndpoint` multiple time.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test 

1. start a cluster
2. call API multiple times
3. check `http://127.0.0.1:2379/debug/pprof/goroutine?debug=1` for the number of goroutines
