### PR TITLE
schedulers: add sanity check for random-merge (#2212)

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -130,6 +130,11 @@ func (mc *Cluster) FitRegion(region *core.RegionInfo) *placement.RegionFit {
 	return mc.RuleManager.FitRegion(mc.BasicCluster, region)
 }
 
+// GetRuleManager returns the ruleManager of the cluster.
+func (mc *Cluster) GetRuleManager() *placement.RuleManager {
+	return mc.RuleManager
+}
+
 // SetStoreUp sets store state to be up.
 func (mc *Cluster) SetStoreUp(storeID uint64) {
 	store := mc.GetStore(storeID)

--- a/server/schedule/checker/merge_checker_test.go
+++ b/server/schedule/checker/merge_checker_test.go
@@ -129,7 +129,7 @@ func (s *testMergeCheckerSuite) SetUpTest(c *C) {
 		s.cluster.PutRegion(region)
 	}
 	s.ctx, s.cancel = context.WithCancel(context.Background())
-	s.mc = NewMergeChecker(s.ctx, s.cluster, s.cluster.RuleManager)
+	s.mc = NewMergeChecker(s.ctx, s.cluster)
 }
 
 func (s *testMergeCheckerSuite) TearDownTest(c *C) {
@@ -168,7 +168,7 @@ func (s *testMergeCheckerSuite) TestBasic(c *C) {
 
 	// merge cannot across rule key.
 	s.cluster.EnablePlacementRules = true
-	s.mc.ruleManager.SetRule(&placement.Rule{
+	s.cluster.RuleManager.SetRule(&placement.Rule{
 		GroupID:     "pd",
 		ID:          "test",
 		Index:       1,
@@ -183,7 +183,7 @@ func (s *testMergeCheckerSuite) TestBasic(c *C) {
 	c.Assert(ops, NotNil)
 	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())
 	c.Assert(ops[1].RegionID(), Equals, s.regions[1].GetID())
-	s.mc.ruleManager.DeleteRule("test", "test")
+	s.cluster.RuleManager.DeleteRule("test", "test")
 
 	// Skip recently split regions.
 	s.cluster.ScheduleOptions.SplitMergeInterval = time.Hour
@@ -463,7 +463,7 @@ func (s *testMergeCheckerSuite) TestCache(c *C) {
 		s.cluster.PutRegion(region)
 	}
 
-	s.mc = NewMergeChecker(s.ctx, s.cluster, s.cluster.RuleManager)
+	s.mc = NewMergeChecker(s.ctx, s.cluster)
 
 	ops := s.mc.Check(s.regions[1])
 	c.Assert(ops, IsNil)

--- a/server/schedule/checker_controller.go
+++ b/server/schedule/checker_controller.go
@@ -42,7 +42,7 @@ func NewCheckerController(ctx context.Context, cluster opt.Cluster, ruleManager 
 		learnerChecker: checker.NewLearnerChecker(cluster),
 		replicaChecker: checker.NewReplicaChecker(cluster),
 		ruleChecker:    checker.NewRuleChecker(cluster, ruleManager),
-		mergeChecker:   checker.NewMergeChecker(ctx, cluster, ruleManager),
+		mergeChecker:   checker.NewMergeChecker(ctx, cluster),
 	}
 }
 

--- a/server/schedule/operator_controller_test.go
+++ b/server/schedule/operator_controller_test.go
@@ -522,7 +522,7 @@ func (t *testOperatorControllerSuite) TestStoreLimitWithMerge(c *C) {
 		tc.PutRegion(region)
 	}
 
-	mc := checker.NewMergeChecker(t.ctx, tc, tc.RuleManager)
+	mc := checker.NewMergeChecker(t.ctx, tc)
 	oc := NewOperatorController(t.ctx, tc, mockhbstream.NewHeartbeatStream())
 
 	cfg.StoreBalanceRate = 60

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -1152,6 +1152,10 @@ func (s *testRandomMergeSchedulerSuite) TestMerge(c *C) {
 
 	c.Assert(mb.IsScheduleAllowed(tc), IsTrue)
 	ops := mb.Schedule(tc)
+	c.Assert(ops, HasLen, 0) // regions are not fully replicated
+
+	opt.MaxReplicas = 1
+	ops = mb.Schedule(tc)
 	c.Assert(ops, HasLen, 2)
 	c.Assert(ops[0].Kind()&operator.OpMerge, Not(Equals), 0)
 	c.Assert(ops[1].Kind()&operator.OpMerge, Not(Equals), 0)

--- a/server/schedulers/random_merge.go
+++ b/server/schedulers/random_merge.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/pd/v3/server/core"
 	"github.com/pingcap/pd/v3/server/schedule"
+	"github.com/pingcap/pd/v3/server/schedule/checker"
 	"github.com/pingcap/pd/v3/server/schedule/filter"
 	"github.com/pingcap/pd/v3/server/schedule/operator"
 	"github.com/pingcap/pd/v3/server/schedule/opt"
@@ -124,6 +125,11 @@ func (s *randomMergeScheduler) Schedule(cluster opt.Cluster) []*operator.Operato
 		return nil
 	}
 
+	if !s.allowMerge(cluster, region, target) {
+		schedulerCounter.WithLabelValues(s.GetName(), "not-allowed").Inc()
+		return nil
+	}
+
 	ops, err := operator.CreateMergeRegionOperator(RandomMergeType, cluster, region, target, operator.OpAdmin)
 	if err != nil {
 		log.Debug("fail to create merge region operator", zap.Error(err))
@@ -131,4 +137,17 @@ func (s *randomMergeScheduler) Schedule(cluster opt.Cluster) []*operator.Operato
 	}
 	ops[0].Counters = append(ops[0].Counters, schedulerCounter.WithLabelValues(s.GetName(), "new-operator"))
 	return ops
+}
+
+func (s *randomMergeScheduler) allowMerge(cluster opt.Cluster, region, target *core.RegionInfo) bool {
+	if !opt.IsRegionHealthy(cluster, region) || !opt.IsRegionHealthy(cluster, target) {
+		return false
+	}
+	if !opt.IsRegionReplicated(cluster, region) || !opt.IsRegionReplicated(cluster, target) {
+		return false
+	}
+	if cluster.IsRegionHot(region) || cluster.IsRegionHot(target) {
+		return false
+	}
+	return checker.AllowMerge(cluster, region, target)
 }


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
cherry-pick #2212 to resolve #2210

### What is changed and how it works?
- port merge checks from mergeChecker to random-merge-scheduler
- minor refactor: remove `mergeChecker.ruleManager` and get it from `cluster`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test