### PR TITLE
placement: use id as store key (#2205)

### DIFF
--- a/server/core/storage.go
+++ b/server/core/storage.go
@@ -237,7 +237,7 @@ func (s *Storage) DeleteRule(ruleKey string) error {
 }
 
 // LoadRules loads placement rules from storage.
-func (s *Storage) LoadRules(f func(v string) error) (bool, error) {
+func (s *Storage) LoadRules(f func(k, v string)) (bool, error) {
 	// Range is ['rule/\x00', 'rule0'). 'rule0' is the upper bound of all rules because '0' is next char of '/' in
 	// ascii order.
 	nextKey := path.Join(rulesPath, "\x00")
@@ -247,15 +247,13 @@ func (s *Storage) LoadRules(f func(v string) error) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		if len(values) == 0 {
+		if len(keys) == 0 {
 			return false, nil
 		}
-		for _, v := range values {
-			if err := f(v); err != nil {
-				return true, err
-			}
+		for i := range keys {
+			f(strings.TrimPrefix(keys[i], rulesPath+"/"), values[i])
 		}
-		if len(values) < minKVRangeLimit {
+		if len(keys) < minKVRangeLimit {
 			return true, nil
 		}
 		nextKey = keys[len(keys)-1] + "\x00"

--- a/server/schedule/placement/rule.go
+++ b/server/schedule/placement/rule.go
@@ -13,7 +13,10 @@
 
 package placement
 
-import "sort"
+import (
+	"encoding/hex"
+	"sort"
+)
 
 // PeerRoleType is the expected peer type of the placement rule.
 type PeerRoleType string
@@ -58,7 +61,7 @@ func (r Rule) Key() [2]string {
 
 // StoreKey returns the rule's key for persistent store.
 func (r Rule) StoreKey() string {
-	return r.StartKeyHex + "-" + r.EndKeyHex
+	return hex.EncodeToString([]byte(r.GroupID)) + "-" + hex.EncodeToString([]byte(r.ID))
 }
 
 // Rules are ordered by (GroupID, Index, ID).

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -19,8 +19,10 @@ import (
 	"encoding/json"
 	"sync"
 
+	"github.com/pingcap/log"
 	"github.com/pingcap/pd/v3/server/core"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 )
 
 // RuleManager is responsible for the lifecycle of all placement Rules.
@@ -50,19 +52,10 @@ func (m *RuleManager) Initialize(maxReplica int, locationLabels []string) error 
 		return nil
 	}
 
-	var rules []*Rule
-	ok, err := m.store.LoadRules(func(v string) error {
-		var r Rule
-		if err := json.Unmarshal([]byte(v), &r); err != nil {
-			return err
-		}
-		rules = append(rules, &r)
-		return nil
-	})
-	if err != nil {
+	if err := m.loadRules(); err != nil {
 		return err
 	}
-	if !ok {
+	if len(m.rules) == 0 {
 		// migrate from old config.
 		defaultRule := &Rule{
 			GroupID:        "pd",
@@ -74,16 +67,53 @@ func (m *RuleManager) Initialize(maxReplica int, locationLabels []string) error 
 		if err := m.store.SaveRule(defaultRule.StoreKey(), defaultRule); err != nil {
 			return err
 		}
-		rules = append(rules, defaultRule)
-	}
-	for _, r := range rules {
-		if err = m.adjustRule(r); err != nil {
-			return err
-		}
-		m.rules[r.Key()] = r
+		m.rules[defaultRule.Key()] = defaultRule
 	}
 	m.ruleList = buildRuleList(m.rules)
 	m.initialized = true
+	return nil
+}
+
+func (m *RuleManager) loadRules() error {
+	var toSave []*Rule
+	var toDelete []string
+	_, err := m.store.LoadRules(func(k, v string) {
+		var r Rule
+		if err := json.Unmarshal([]byte(v), &r); err != nil {
+			log.Error("failed to unmarshal rule value", zap.String("rule-key", k), zap.String("rule-value", v))
+			toDelete = append(toDelete, k)
+			return
+		}
+		if err := m.adjustRule(&r); err != nil {
+			log.Error("rule is in bad format", zap.Error(err), zap.String("rule-key", k), zap.String("rule-value", v))
+			toDelete = append(toDelete, k)
+			return
+		}
+		if _, ok := m.rules[r.Key()]; ok {
+			log.Error("duplicated rule key", zap.String("rule-key", k), zap.String("rule-value", v))
+			toDelete = append(toDelete, k)
+			return
+		}
+		if k != r.StoreKey() {
+			log.Error("mismatch data key, need to restore", zap.String("rule-key", k), zap.String("rule-value", v))
+			toDelete = append(toDelete, k)
+			toSave = append(toSave, &r)
+		}
+		m.rules[r.Key()] = &r
+	})
+	if err != nil {
+		return err
+	}
+	for _, s := range toSave {
+		if err = m.store.SaveRule(s.StoreKey(), s); err != nil {
+			return err
+		}
+	}
+	for _, d := range toDelete {
+		if err = m.store.DeleteRule(d); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/server/schedule/placement/rule_manager_test.go
+++ b/server/schedule/placement/rule_manager_test.go
@@ -74,6 +74,7 @@ func (s *testManagerSuite) TestSaveLoad(c *C) {
 	rules := []*Rule{
 		{GroupID: "pd", ID: "default", Role: "voter", Count: 5},
 		{GroupID: "foo", ID: "bar", StartKeyHex: "", EndKeyHex: "abcd", Role: "learner", Count: 1},
+		{GroupID: "foo", ID: "baz", Role: "voter", Count: 1},
 	}
 	for _, r := range rules {
 		s.manager.SetRule(r)
@@ -81,9 +82,10 @@ func (s *testManagerSuite) TestSaveLoad(c *C) {
 	m2 := NewRuleManager(s.store)
 	err := m2.Initialize(3, []string{"no", "labels"})
 	c.Assert(err, IsNil)
-	c.Assert(m2.GetAllRules(), HasLen, 2)
+	c.Assert(m2.GetAllRules(), HasLen, 3)
 	c.Assert(m2.GetRule("pd", "default"), DeepEquals, rules[0])
 	c.Assert(m2.GetRule("foo", "bar"), DeepEquals, rules[1])
+	c.Assert(m2.GetRule("foo", "baz"), DeepEquals, rules[2])
 }
 
 func (s *testManagerSuite) TestKeys(c *C) {


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
cherry-pick #2205 to resolve #2203

### What is changed and how it works?
- startKey and endKey can be duplicated, use groupID+ID instead
- check data consistency and recover when load rules

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test
 - Manual test (add detailed scripts or steps below)
    - insert some rules with same key, make sure it won't be over written
    - use old pd to write some rules, then start new pd, the wrong key are recovered

Code changes
 - Has persistent data change
