### PR TITLE
server: unify the solutions to etcd race problem

### DIFF
--- a/pkg/dashboard/apiserver/apiserver.go
+++ b/pkg/dashboard/apiserver/apiserver.go
@@ -53,7 +53,7 @@ func (p *PdEtcdProvider) GetEtcdClient() *clientv3.Client {
 }
 
 // NewService returns an http.Handler that serves the dashboard API
-func NewService(ctx context.Context, srv *server.Server) (http.Handler, server.ServiceGroup, func()) {
+func NewService(ctx context.Context, srv *server.Server) (http.Handler, server.ServiceGroup) {
 	cfg := srv.GetConfig()
 	etcdCfg, err := cfg.GenEmbedEtcdConfig()
 	if err != nil {
@@ -107,5 +107,5 @@ func NewService(ctx context.Context, srv *server.Server) (http.Handler, server.S
 	)
 
 	log.Info("Enabled Dashboard API", zap.String("path", serviceGroup.PathPrefix))
-	return handler, serviceGroup, nil
+	return handler, serviceGroup
 }

--- a/pkg/dashboard/uiserver/uiserver.go
+++ b/pkg/dashboard/uiserver/uiserver.go
@@ -31,16 +31,16 @@ var serviceGroup = server.ServiceGroup{
 }
 
 // NewService returns an http.Handler that serves the dashboard UI
-func NewService(ctx context.Context, srv *server.Server) (http.Handler, server.ServiceGroup, func()) {
+func NewService(ctx context.Context, srv *server.Server) (http.Handler, server.ServiceGroup) {
 	fs := assetFS()
 	if fs != nil {
 		fileServer := http.StripPrefix(serviceGroup.PathPrefix, http.FileServer(fs))
 		log.Info("Enabled Dashboard UI", zap.String("path", serviceGroup.PathPrefix))
-		return fileServer, serviceGroup, nil
+		return fileServer, serviceGroup
 	}
 
 	emptyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.WriteString(w, "Dashboard UI is not built.\n")
 	})
-	return emptyHandler, serviceGroup, nil
+	return emptyHandler, serviceGroup
 }

--- a/server/api/server.go
+++ b/server/api/server.go
@@ -26,7 +26,7 @@ import (
 const apiPrefix = "/pd"
 
 // NewHandler creates a HTTP handler for API.
-func NewHandler(ctx context.Context, svr *server.Server) (http.Handler, server.ServiceGroup, func()) {
+func NewHandler(ctx context.Context, svr *server.Server) (http.Handler, server.ServiceGroup) {
 	group := server.ServiceGroup{
 		Name:   "core",
 		IsCore: true,
@@ -38,6 +38,7 @@ func NewHandler(ctx context.Context, svr *server.Server) (http.Handler, server.S
 		serverapi.NewRedirector(svr),
 		negroni.Wrap(r)),
 	)
+	svr.AddStartCallback(f)
 
-	return router, group, f
+	return router, group
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -190,7 +190,7 @@ var _ = Suite(&testServerHandlerSuite{})
 type testServerHandlerSuite struct{}
 
 func (s *testServerHandlerSuite) TestRegisterServerHandler(c *C) {
-	mokHandler := func(ctx context.Context, s *Server) (http.Handler, ServiceGroup, func()) {
+	mokHandler := func(ctx context.Context, s *Server) (http.Handler, ServiceGroup) {
 		mux := http.NewServeMux()
 		mux.HandleFunc("/pd/apis/mok/v1/hello", func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintln(w, "Hello World")
@@ -199,7 +199,7 @@ func (s *testServerHandlerSuite) TestRegisterServerHandler(c *C) {
 			Name:    "mok",
 			Version: "v1",
 		}
-		return mux, info, nil
+		return mux, info
 	}
 	cfg := NewTestSingleConfig(c)
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Signed-off-by: Zheng Xiangsheng <hundundm@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

Currently, there are different solutions in PD to solve etcd race problem. One of the solutions has the following problem:

After #2204. we enable dynamic config by default. When we use HTTP API, the `lazyHandler` will be called. The handler will call `RegisterConfigHandlerFromEndpoint` which creates a goroutine to handle the stop logic. In this case, once we call API multiple times, goroutines will be leaked.

### What is changed and how it works?

Removed `lazyHandler` and used a unified solution to solve etcd race problem.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test 

1. start a cluster
2. call API multiple times
3. check `http://127.0.0.1:2379/debug/pprof/goroutine?debug=1` for the number of goroutines
