### PR TITLE
config: fix output of GET method of component API

### DIFF
--- a/tests/config.go
+++ b/tests/config.go
@@ -107,6 +107,14 @@ func (c *clusterConfig) GetJoinAddr() string {
 	return c.InitialServers[0].PeerURLs
 }
 
-func (c *clusterConfig) GetClientURLs() string {
+func (c *clusterConfig) GetClientURL() string {
 	return c.InitialServers[0].ClientURLs
+}
+
+func (c *clusterConfig) GetClientURLs() []string {
+	var urls []string
+	for _, svr := range c.InitialServers {
+		urls = append(urls, svr.ClientURLs)
+	}
+	return urls
 }

--- a/tests/pdbackup/backup_test.go
+++ b/tests/pdbackup/backup_test.go
@@ -48,7 +48,7 @@ func (s *backupTestSuite) TestBackup(c *C) {
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.GetConfig().GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURL()
 	urls := strings.Split(pdAddr, ",")
 	defer cluster.Destroy()
 	client, err := clientv3.New(clientv3.Config{

--- a/tests/pdctl/cluster/cluster_test.go
+++ b/tests/pdctl/cluster/cluster_test.go
@@ -46,7 +46,7 @@ func (s *clusterTestSuite) TestClusterAndPing(c *C) {
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.GetConfig().GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURL()
 	i := strings.Index(pdAddr, "//")
 	pdAddr = pdAddr[i+2:]
 	cmd := pdctl.InitCommand()

--- a/tests/pdctl/component/component_test.go
+++ b/tests/pdctl/component/component_test.go
@@ -1,0 +1,104 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package componenttest
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/pd/v4/server"
+	"github.com/pingcap/pd/v4/tests"
+	"github.com/pingcap/pd/v4/tests/pdctl"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&componentTestSuite{})
+
+type componentTestSuite struct{}
+
+func (s *componentTestSuite) SetUpSuite(c *C) {
+	server.EnableZap = true
+	server.ConfigCheckInterval = 10 * time.Millisecond
+}
+
+func (s *componentTestSuite) TestComponent(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster, err := tests.NewTestCluster(ctx, 2)
+	c.Assert(err, IsNil)
+	err = cluster.RunInitialServers()
+	c.Assert(err, IsNil)
+	cluster.WaitLeader()
+	pdAddrs := cluster.GetConfig().GetClientURLs()
+	cmd := pdctl.InitCommand()
+
+	store := metapb.Store{
+		Id:    1,
+		State: metapb.StoreState_Up,
+	}
+	leaderServer := cluster.GetServer(cluster.GetLeader())
+	c.Assert(leaderServer.BootstrapCluster(), IsNil)
+	svr := leaderServer.GetServer()
+	pdctl.MustPutStore(c, svr, store.Id, store.State, store.Labels)
+	defer cluster.Destroy()
+
+	// component ids
+	args := []string{"-u", pdAddrs[0], "component", "ids", "pd"}
+	_, output, err := pdctl.ExecuteCommandC(cmd, args...)
+	c.Assert(err, IsNil)
+	obtain := string(output)
+	c.Assert(strings.Contains(obtain, pdAddrs[0][7:]), IsTrue)
+	c.Assert(strings.Contains(obtain, pdAddrs[1][7:]), IsTrue)
+
+	// component show
+	for i := 0; i < len(pdAddrs); i++ {
+		args = []string{"-u", pdAddrs[0], "component", "show", pdAddrs[i][7:]}
+		_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+		c.Assert(err, IsNil)
+		obtain := string(output)
+		c.Assert(strings.Contains(obtain, "region-schedule-limit = 2048"), IsTrue)
+		c.Assert(strings.Contains(obtain, "location-labels = []"), IsTrue)
+		c.Assert(strings.Contains(obtain, `level = ""`), IsTrue)
+	}
+
+	// component set
+	args = []string{"-u", pdAddrs[0], "component", "set", "pd", "schedule.region-schedule-limit", "1"}
+	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	c.Assert(err, IsNil)
+	args = []string{"-u", pdAddrs[0], "component", "set", "pd", "replication.location-labels", "zone,rack"}
+	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	c.Assert(err, IsNil)
+	args = []string{"-u", pdAddrs[0], "component", "set", "pd", "log.level", "warn"}
+	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	c.Assert(err, IsNil)
+	time.Sleep(20 * time.Millisecond)
+
+	// component show
+	for i := 0; i < len(pdAddrs); i++ {
+		args = []string{"-u", pdAddrs[0], "component", "show", pdAddrs[i][7:]}
+		_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+		c.Assert(err, IsNil)
+		obtain := string(output)
+		c.Assert(strings.Contains(obtain, "region-schedule-limit = 1"), IsTrue)
+		c.Assert(strings.Contains(obtain, `location-labels = ["zone", "rack"]`), IsTrue)
+		c.Assert(strings.Contains(obtain, `level = "warn"`), IsTrue)
+	}
+}

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -65,7 +65,7 @@ func (s *configTestSuite) TestConfig(c *C) {
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.GetConfig().GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURL()
 	cmd := pdctl.InitCommand()
 
 	store := metapb.Store{

--- a/tests/pdctl/health/health_test.go
+++ b/tests/pdctl/health/health_test.go
@@ -48,7 +48,7 @@ func (s *healthTestSuite) TestHealth(c *C) {
 	tc.WaitLeader()
 	leaderServer := tc.GetServer(tc.GetLeader())
 	c.Assert(leaderServer.BootstrapCluster(), IsNil)
-	pdAddr := tc.GetConfig().GetClientURLs()
+	pdAddr := tc.GetConfig().GetClientURL()
 	cmd := pdctl.InitCommand()
 	defer tc.Destroy()
 

--- a/tests/pdctl/helper.go
+++ b/tests/pdctl/helper.go
@@ -62,6 +62,7 @@ func InitCommand() *cobra.Command {
 		command.NewHealthCommand(),
 		command.NewLogCommand(),
 		command.NewPluginCommand(),
+		command.NewComponentCommand(),
 	)
 	return rootCmd
 }

--- a/tests/pdctl/hot/hot_test.go
+++ b/tests/pdctl/hot/hot_test.go
@@ -52,7 +52,7 @@ func (s *hotTestSuite) TestHot(c *C) {
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.GetConfig().GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURL()
 	cmd := pdctl.InitCommand()
 
 	store := metapb.Store{

--- a/tests/pdctl/label/label_test.go
+++ b/tests/pdctl/label/label_test.go
@@ -50,7 +50,7 @@ func (s *labelTestSuite) TestLabel(c *C) {
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.GetConfig().GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURL()
 	cmd := pdctl.InitCommand()
 
 	stores := []*metapb.Store{

--- a/tests/pdctl/log/log_test.go
+++ b/tests/pdctl/log/log_test.go
@@ -46,7 +46,7 @@ func (s *logTestSuite) TestLog(c *C) {
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.GetConfig().GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURL()
 	cmd := pdctl.InitCommand()
 
 	store := metapb.Store{

--- a/tests/pdctl/member/member_test.go
+++ b/tests/pdctl/member/member_test.go
@@ -50,7 +50,7 @@ func (s *memberTestSuite) TestMember(c *C) {
 	cluster.WaitLeader()
 	leaderServer := cluster.GetServer(cluster.GetLeader())
 	c.Assert(leaderServer.BootstrapCluster(), IsNil)
-	pdAddr := cluster.GetConfig().GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURL()
 	c.Assert(err, IsNil)
 	cmd := pdctl.InitCommand()
 	svr := cluster.GetServer("pd2")

--- a/tests/pdctl/operator/operator_test.go
+++ b/tests/pdctl/operator/operator_test.go
@@ -56,7 +56,7 @@ func (s *operatorTestSuite) TestOperator(c *C) {
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.GetConfig().GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURL()
 	cmd := pdctl.InitCommand()
 
 	stores := []*metapb.Store{

--- a/tests/pdctl/region/region_test.go
+++ b/tests/pdctl/region/region_test.go
@@ -49,7 +49,7 @@ func (s *regionTestSuite) TestRegionKeyFormat(c *C) {
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	url := cluster.GetConfig().GetClientURLs()
+	url := cluster.GetConfig().GetClientURL()
 	store := metapb.Store{
 		Id:    1,
 		State: metapb.StoreState_Up,
@@ -70,7 +70,7 @@ func (s *regionTestSuite) TestRegion(c *C) {
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.GetConfig().GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURL()
 	cmd := pdctl.InitCommand()
 
 	store := metapb.Store{

--- a/tests/pdctl/scheduler/scheduler_test.go
+++ b/tests/pdctl/scheduler/scheduler_test.go
@@ -47,7 +47,7 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.GetConfig().GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURL()
 	cmd := pdctl.InitCommand()
 
 	stores := []*metapb.Store{

--- a/tests/pdctl/store/store_test.go
+++ b/tests/pdctl/store/store_test.go
@@ -48,7 +48,7 @@ func (s *storeTestSuite) TestStore(c *C) {
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
-	pdAddr := cluster.GetConfig().GetClientURLs()
+	pdAddr := cluster.GetConfig().GetClientURL()
 	cmd := pdctl.InitCommand()
 
 	stores := []*metapb.Store{

--- a/tools/pd-ctl/pdctl/command/component_command.go
+++ b/tools/pd-ctl/pdctl/command/component_command.go
@@ -28,8 +28,8 @@ var (
 	componentConfigPrefix = "pd/api/v1/component"
 )
 
-// NewComponentConfigCommand returns a component subcommand of rootCmd
-func NewComponentConfigCommand() *cobra.Command {
+// NewComponentCommand returns a component subcommand of rootCmd
+func NewComponentCommand() *cobra.Command {
 	conf := &cobra.Command{
 		Use:   "component <subcommand>",
 		Short: "manipulate components' configs",
@@ -88,7 +88,7 @@ func showComponentConfigCommandFunc(cmd *cobra.Command, args []string) {
 	}
 
 	prefix := path.Join(componentConfigPrefix, args[0])
-	r, err := doRequest(cmd, prefix, http.MethodGet, WithAccept("application/toml"))
+	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
 		cmd.Printf("Failed to get component config: %s\n", err)
 		return

--- a/tools/pd-ctl/pdctl/command/global.go
+++ b/tools/pd-ctl/pdctl/command/global.go
@@ -56,7 +56,6 @@ func InitHTTPSClient(CAPath, CertPath, KeyPath string) error {
 
 type bodyOption struct {
 	contentType string
-	accept      string
 	body        io.Reader
 }
 
@@ -68,13 +67,6 @@ func WithBody(contentType string, body io.Reader) BodyOption {
 	return func(bo *bodyOption) {
 		bo.contentType = contentType
 		bo.body = body
-	}
-}
-
-// WithAccept returns a BodyOption
-func WithAccept(accept string) BodyOption {
-	return func(bo *bodyOption) {
-		bo.accept = accept
 	}
 }
 
@@ -101,10 +93,6 @@ func doRequest(cmd *cobra.Command, prefix string, method string,
 		}
 		if b.contentType != "" {
 			req.Header.Set("Content-Type", b.contentType)
-		}
-
-		if b.accept != "" {
-			req.Header.Set("Accept", b.accept)
 		}
 		// the resp would be returned by the outer function
 		resp, err = dial(req)

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -85,7 +85,7 @@ func getBasicCmd() *cobra.Command {
 		command.NewHealthCommand(),
 		command.NewLogCommand(),
 		command.NewPluginCommand(),
-		command.NewComponentConfigCommand(),
+		command.NewComponentCommand(),
 	)
 
 	rootCmd.Flags().ParseErrorsWhitelist.UnknownFlags = true


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with a summary if it exists-->
When using `curl http://127.0.0.1:2379/pd/api/v1/component/127.0.0.1:2379`, it will print results both in `json` and `toml` format.

### What is changed and how it works?
This PR fixes it. Besides, this PR adds some basic tests for component command of `pd-ctl`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test

1. start a server 
2. run `curl http://127.0.0.1:2379/pd/api/v1/component/127.0.0.1:2379`