### PR TITLE
server: prevent misoperation when there are tiflash nodes

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -773,24 +773,27 @@ func (s *Server) SetReplicationConfig(cfg config.ReplicationConfig) error {
 	if err := cfg.Validate(); err != nil {
 		return err
 	}
-	raftCluster := s.GetRaftCluster()
-	if raftCluster == nil {
-		return errors.WithStack(cluster.ErrNotBootstrapped)
-	}
-	if cfg.EnablePlacementRules {
-		// initialize rule manager.
-		if err := raftCluster.GetRuleManager().Initialize(int(cfg.MaxReplicas), cfg.LocationLabels); err != nil {
-			return err
+	old := s.scheduleOpt.GetReplication().Load()
+	if cfg.EnablePlacementRules != old.EnablePlacementRules {
+		raftCluster := s.GetRaftCluster()
+		if raftCluster == nil {
+			return errors.WithStack(cluster.ErrNotBootstrapped)
 		}
-	} else {
-		// NOTE: can be removed after placement rules feature is enabled by default.
-		for _, s := range raftCluster.GetStores() {
-			if !s.IsTombstone() && isTiFlashStore(s.GetMeta()) {
-				return errors.New("cannot disable placement rules with TiFlash nodes")
+		if cfg.EnablePlacementRules {
+			// initialize rule manager.
+			if err := raftCluster.GetRuleManager().Initialize(int(cfg.MaxReplicas), cfg.LocationLabels); err != nil {
+				return err
+			}
+		} else {
+			// NOTE: can be removed after placement rules feature is enabled by default.
+			for _, s := range raftCluster.GetStores() {
+				if !s.IsTombstone() && isTiFlashStore(s.GetMeta()) {
+					return errors.New("cannot disable placement rules with TiFlash nodes")
+				}
 			}
 		}
 	}
-	old := s.scheduleOpt.GetReplication().Load()
+
 	s.scheduleOpt.GetReplication().Store(&cfg)
 	if err := s.scheduleOpt.Persist(s.storage); err != nil {
 		s.scheduleOpt.GetReplication().Store(old)

--- a/server/util.go
+++ b/server/util.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/pd/v4/pkg/etcdutil"
@@ -196,4 +197,13 @@ func checkBootstrapRequest(clusterID uint64, req *pdpb.BootstrapRequest) error {
 	}
 
 	return nil
+}
+
+func isTiFlashStore(store *metapb.Store) bool {
+	for _, l := range store.GetLabels() {
+		if l.GetKey() == "engine" && l.GetValue() == "tiflash" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fix #2237

### What is changed and how it works?
- When placement rules not enabled, don't allow add tiflash node.
- When the cluster has tiFlash nodes, don't allow disable placement rules.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test

Related changes
 - Need to cherry-pick to the release branch