### PR TITLE
api: fix the compatibility about schedulers item in config

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -82,9 +82,6 @@ type Config struct {
 
 	Schedule ScheduleConfig `toml:"schedule" json:"schedule"`
 
-	// Only used to display
-	SchedulersPayload map[string]string `toml:"schedulers-payload" json:"schedulers-payload"`
-
 	Replication ReplicationConfig `toml:"replication" json:"replication"`
 
 	PDServerCfg PDServerConfig `toml:"pd-server" json:"pd-server"`
@@ -583,6 +580,9 @@ type ScheduleConfig struct {
 
 	// Schedulers support for loading customized schedulers
 	Schedulers SchedulerConfigs `toml:"schedulers" json:"schedulers-v2"` // json v2 is for the sake of compatible upgrade
+
+	// Only used to display
+	SchedulersPayload map[string]string `toml:"schedulers-payload" json:"schedulers-payload"`
 
 	// StoreLimitMode can be auto or manual, when set to auto,
 	// PD tries to change the store limit values according to

--- a/server/server.go
+++ b/server/server.go
@@ -728,7 +728,7 @@ func (s *Server) GetConfig() *config.Config {
 	for i, sche := range sches {
 		payload[sche] = configs[i]
 	}
-	cfg.SchedulersPayload = payload
+	cfg.Schedule.SchedulersPayload = payload
 	return cfg
 }
 

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -86,6 +86,7 @@ func (s *configTestSuite) TestConfig(c *C) {
 	c.Assert(json.Unmarshal(output, &cfg), IsNil)
 	scheduleConfig := svr.GetScheduleConfig()
 	scheduleConfig.Schedulers = nil
+	scheduleConfig.SchedulersPayload = nil
 	c.Assert(&cfg.Schedule, DeepEquals, scheduleConfig)
 	c.Assert(&cfg.Replication, DeepEquals, svr.GetReplicationConfig())
 

--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -188,6 +188,7 @@ func showConfigCommandFunc(cmd *cobra.Command, args []string) {
 	}
 
 	delete(scheduleConfig, "schedulers-v2")
+	delete(scheduleConfig, "schedulers-payload")
 	data["schedule"] = scheduleConfig
 	r, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
after the https://github.com/pingcap/pd/pull/2188
the position of the `scheduler-payload` is changed, which causes the `tidb-operator`  failed to upgrade the cluster. the operator needs to know which store is being offline.

### What is changed and how it works?
move to the back.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual Test