### PR TITLE
*: add a new method `GetAll` to the config manager

### DIFF
--- a/client/config_client.go
+++ b/client/config_client.go
@@ -29,6 +29,7 @@ import (
 type ConfigClient interface {
 	GetClusterID(ctx context.Context) uint64
 	Create(ctx context.Context, v *configpb.Version, component, componentID, config string) (*configpb.Status, *configpb.Version, string, error)
+	GetAll(ctx context.Context) (*configpb.Status, []*configpb.LocalConfig, []*configpb.GlobalConfigEntry, error)
 	Get(ctx context.Context, v *configpb.Version, component, componentID string) (*configpb.Status, *configpb.Version, string, error)
 	Update(ctx context.Context, v *configpb.Version, kind *configpb.ConfigKind, entries []*configpb.ConfigEntry) (*configpb.Status, *configpb.Version, error)
 	Delete(ctx context.Context, v *configpb.Version, kind *configpb.ConfigKind) (*configpb.Status, error)
@@ -102,6 +103,30 @@ func (c *configClient) Create(ctx context.Context, v *configpb.Version, componen
 	}
 
 	return resp.GetStatus(), resp.GetVersion(), resp.GetConfig(), nil
+}
+
+func (c *configClient) GetAll(ctx context.Context) (*configpb.Status, []*configpb.LocalConfig, []*configpb.GlobalConfigEntry, error) {
+	if span := opentracing.SpanFromContext(ctx); span != nil {
+		span = opentracing.StartSpan("configclient.GetAll", opentracing.ChildOf(span.Context()))
+		defer span.Finish()
+	}
+
+	start := time.Now()
+	defer func() { configCmdDurationGetAll.Observe(time.Since(start).Seconds()) }()
+
+	ctx, cancel := context.WithTimeout(ctx, pdTimeout)
+	resp, err := c.leaderClient().GetAll(ctx, &configpb.GetAllRequest{
+		Header: c.requestHeader(),
+	})
+	cancel()
+
+	if err != nil {
+		configCmdFailDurationGetAll.Observe(time.Since(start).Seconds())
+		c.ScheduleCheckLeader()
+		return nil, nil, nil, errors.WithStack(err)
+	}
+
+	return resp.GetStatus(), resp.GetLocalConfigs(), resp.GetGlobalEntries(), nil
 }
 
 func (c *configClient) Get(ctx context.Context, v *configpb.Version, component, componentID string) (*configpb.Status, *configpb.Version, string, error) {

--- a/client/config_client.go
+++ b/client/config_client.go
@@ -29,7 +29,7 @@ import (
 type ConfigClient interface {
 	GetClusterID(ctx context.Context) uint64
 	Create(ctx context.Context, v *configpb.Version, component, componentID, config string) (*configpb.Status, *configpb.Version, string, error)
-	GetAll(ctx context.Context) (*configpb.Status, []*configpb.LocalConfig, []*configpb.GlobalConfigEntry, error)
+	GetAll(ctx context.Context) (*configpb.Status, []*configpb.LocalConfig, error)
 	Get(ctx context.Context, v *configpb.Version, component, componentID string) (*configpb.Status, *configpb.Version, string, error)
 	Update(ctx context.Context, v *configpb.Version, kind *configpb.ConfigKind, entries []*configpb.ConfigEntry) (*configpb.Status, *configpb.Version, error)
 	Delete(ctx context.Context, v *configpb.Version, kind *configpb.ConfigKind) (*configpb.Status, error)
@@ -105,7 +105,7 @@ func (c *configClient) Create(ctx context.Context, v *configpb.Version, componen
 	return resp.GetStatus(), resp.GetVersion(), resp.GetConfig(), nil
 }
 
-func (c *configClient) GetAll(ctx context.Context) (*configpb.Status, []*configpb.LocalConfig, []*configpb.GlobalConfigEntry, error) {
+func (c *configClient) GetAll(ctx context.Context) (*configpb.Status, []*configpb.LocalConfig, error) {
 	if span := opentracing.SpanFromContext(ctx); span != nil {
 		span = opentracing.StartSpan("configclient.GetAll", opentracing.ChildOf(span.Context()))
 		defer span.Finish()
@@ -123,10 +123,10 @@ func (c *configClient) GetAll(ctx context.Context) (*configpb.Status, []*configp
 	if err != nil {
 		configCmdFailDurationGetAll.Observe(time.Since(start).Seconds())
 		c.ScheduleCheckLeader()
-		return nil, nil, nil, errors.WithStack(err)
+		return nil, nil, errors.WithStack(err)
 	}
 
-	return resp.GetStatus(), resp.GetLocalConfigs(), resp.GetGlobalEntries(), nil
+	return resp.GetStatus(), resp.GetLocalConfigs(), nil
 }
 
 func (c *configClient) Get(ctx context.Context, v *configpb.Version, component, componentID string) (*configpb.Status, *configpb.Version, string, error) {

--- a/client/metrics.go
+++ b/client/metrics.go
@@ -98,11 +98,13 @@ var (
 
 	// config
 	configCmdDurationCreate = configCmdDuration.WithLabelValues("create")
+	configCmdDurationGetAll = configCmdDuration.WithLabelValues("get_all")
 	configCmdDurationGet    = configCmdDuration.WithLabelValues("get")
 	configCmdDurationUpdate = configCmdDuration.WithLabelValues("update")
 	configCmdDurationDelete = configCmdDuration.WithLabelValues("delete")
 
 	configCmdFailDurationCreate = configCmdFailedDuration.WithLabelValues("create")
+	configCmdFailDurationGetAll = configCmdFailedDuration.WithLabelValues("get_all")
 	configCmdFailDurationGet    = configCmdFailedDuration.WithLabelValues("get")
 	configCmdFailDurationUpdate = configCmdFailedDuration.WithLabelValues("update")
 	configCmdFailDurationDelete = configCmdFailedDuration.WithLabelValues("delete")

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12
 	github.com/pingcap/errcode v0.0.0-20180921232412-a1a7271709d9
 	github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d
-	github.com/pingcap/kvproto v0.0.0-20200309104453-fb581f7a8e3b
+	github.com/pingcap/kvproto v0.0.0-20200317095539-c42a1d8db7d3
 	github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd
 	github.com/pingcap/sysutil v0.0.0-20200309085538-962fd285f3bb
 	github.com/pkg/errors v0.9.1
@@ -62,5 +62,3 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
-
-replace github.com/pingcap/kvproto => /Users/zhangyuanjia/Workspace/go/src/github.com/pingcap/kvproto

--- a/go.mod
+++ b/go.mod
@@ -62,3 +62,5 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
+
+replace github.com/pingcap/kvproto => /Users/zhangyuanjia/Workspace/go/src/github.com/pingcap/kvproto

--- a/go.sum
+++ b/go.sum
@@ -281,6 +281,8 @@ github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO
 github.com/pingcap/kvproto v0.0.0-20200214064158-62d31900d88e/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/kvproto v0.0.0-20200309104453-fb581f7a8e3b h1:B6AomPfSDsSHZwOil8+cOSIEmH1HXg3nx5p9StLbR4M=
 github.com/pingcap/kvproto v0.0.0-20200309104453-fb581f7a8e3b/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20200317095539-c42a1d8db7d3 h1:aRfgw090yofwdscLNN2IZ90pnNPVtpbctgQP+KWmOHs=
+github.com/pingcap/kvproto v0.0.0-20200317095539-c42a1d8db7d3/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9 h1:AJD9pZYm72vMgPcQDww9rkZ1DnWfl0pXV3BOWlkYIjA=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd h1:CV3VsP3Z02MVtdpTMfEgRJ4T9NGgGTxdHpJerent7rM=

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,6 @@ github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d h1:F8vp38kTAckN+
 github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d/go.mod h1:DNS3Qg7bEDhU6EXNHF+XSv/PGznQaMJ5FWvctpm6pQI=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/kvproto v0.0.0-20200214064158-62d31900d88e/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20200309104453-fb581f7a8e3b h1:B6AomPfSDsSHZwOil8+cOSIEmH1HXg3nx5p9StLbR4M=
-github.com/pingcap/kvproto v0.0.0-20200309104453-fb581f7a8e3b/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/kvproto v0.0.0-20200317095539-c42a1d8db7d3 h1:aRfgw090yofwdscLNN2IZ90pnNPVtpbctgQP+KWmOHs=
 github.com/pingcap/kvproto v0.0.0-20200317095539-c42a1d8db7d3/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9 h1:AJD9pZYm72vMgPcQDww9rkZ1DnWfl0pXV3BOWlkYIjA=

--- a/server/config_manager/config_manager.go
+++ b/server/config_manager/config_manager.go
@@ -122,6 +122,7 @@ func (c *ConfigManager) GetComponent(id string) string {
 	return ""
 }
 
+// GetAllConfig returns all configs in the config manager.
 func (c *ConfigManager) GetAllConfig(ctx context.Context) ([]*configpb.LocalConfig, []*configpb.GlobalConfigEntry, *configpb.Status) {
 	c.RLock()
 	defer c.RUnlock()

--- a/server/config_manager/config_manager.go
+++ b/server/config_manager/config_manager.go
@@ -123,7 +123,7 @@ func (c *ConfigManager) GetComponent(id string) string {
 }
 
 // GetAllConfig returns all configs in the config manager.
-func (c *ConfigManager) GetAllConfig(ctx context.Context) ([]*configpb.LocalConfig, []*configpb.GlobalConfigEntry, *configpb.Status) {
+func (c *ConfigManager) GetAllConfig(ctx context.Context) ([]*configpb.LocalConfig, *configpb.Status) {
 	c.RLock()
 	defer c.RUnlock()
 	localConfigs := make([]*configpb.LocalConfig, 0, 8)
@@ -131,7 +131,7 @@ func (c *ConfigManager) GetAllConfig(ctx context.Context) ([]*configpb.LocalConf
 		for componentID, cfg := range localCfg {
 			config, err := encodeConfigs(cfg.getConfigs())
 			if err != nil {
-				return nil, nil, &configpb.Status{
+				return nil, &configpb.Status{
 					Code:    configpb.StatusCode_UNKNOWN,
 					Message: errEncode(err),
 				}
@@ -145,19 +145,7 @@ func (c *ConfigManager) GetAllConfig(ctx context.Context) ([]*configpb.LocalConf
 		}
 	}
 
-	globalEntries := make([]*configpb.GlobalConfigEntry, 0, len(c.GlobalCfgs))
-	for component, cfg := range c.GlobalCfgs {
-		for _, v := range cfg.GetConfigEntries() {
-			globalEntries = append(globalEntries, &configpb.GlobalConfigEntry{
-				Version:   cfg.GetVersion(),
-				Component: component,
-				Name:      v.GetName(),
-				Value:     v.GetValue(),
-			})
-		}
-	}
-
-	return localConfigs, globalEntries, &configpb.Status{Code: configpb.StatusCode_OK}
+	return localConfigs, &configpb.Status{Code: configpb.StatusCode_OK}
 }
 
 // GetConfig returns config and the latest version.

--- a/server/config_manager/config_manager.go
+++ b/server/config_manager/config_manager.go
@@ -15,6 +15,7 @@ package configmanager
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -119,6 +120,43 @@ func (c *ConfigManager) GetComponent(id string) string {
 		}
 	}
 	return ""
+}
+
+func (c *ConfigManager) GetAllConfig(ctx context.Context) ([]*configpb.LocalConfig, []*configpb.GlobalConfigEntry, *configpb.Status) {
+	c.RLock()
+	defer c.RUnlock()
+	localConfigs := make([]*configpb.LocalConfig, 0, 8)
+	for component, localCfg := range c.LocalCfgs {
+		for componentID, cfg := range localCfg {
+			config, err := encodeConfigs(cfg.getConfigs())
+			if err != nil {
+				return nil, nil, &configpb.Status{
+					Code:    configpb.StatusCode_UNKNOWN,
+					Message: errEncode(err),
+				}
+			}
+			localConfigs = append(localConfigs, &configpb.LocalConfig{
+				Version:     cfg.GetVersion(),
+				Component:   component,
+				ComponentId: componentID,
+				Config:      config,
+			})
+		}
+	}
+
+	globalEntries := make([]*configpb.GlobalConfigEntry, 0, len(c.GlobalCfgs))
+	for component, cfg := range c.GlobalCfgs {
+		for _, v := range cfg.GetConfigEntries() {
+			globalEntries = append(globalEntries, &configpb.GlobalConfigEntry{
+				Version:   cfg.GetVersion(),
+				Component: component,
+				Name:      v.GetName(),
+				Value:     v.GetValue(),
+			})
+		}
+	}
+
+	return localConfigs, globalEntries, &configpb.Status{Code: configpb.StatusCode_OK}
 }
 
 // GetConfig returns config and the latest version.

--- a/server/config_manager/config_manager_test.go
+++ b/server/config_manager/config_manager_test.go
@@ -14,6 +14,7 @@
 package configmanager
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -431,6 +432,33 @@ log-level = "debug"
 	v, status = cfg.UpdateConfig(nil, nil, nil)
 	c.Assert(v, DeepEquals, &configpb.Version{Global: 0, Local: 0})
 	c.Assert(status.GetCode(), Equals, configpb.StatusCode_UNKNOWN)
+}
+
+func (s *testComponentsConfigSuite) TestGetAll(c *C) {
+	cfgData := `
+log-level = "debug"
+`
+	cfg := NewConfigManager(nil)
+	v, config, status := cfg.CreateConfig(&configpb.Version{Global: 0, Local: 0}, "tikv", "tikv1", cfgData)
+	c.Assert(v, DeepEquals, &configpb.Version{Global: 0, Local: 0})
+	c.Assert(status.GetCode(), Equals, configpb.StatusCode_OK)
+	expect := `log-level = "debug"
+`
+	c.Assert(config, Equals, expect)
+
+	_, status = cfg.UpdateGlobal("tidb", &configpb.Version{Global: 0, Local: 0}, []*configpb.ConfigEntry{{Name: "log-level", Value: "info"}})
+	c.Assert(status.GetCode(), Equals, configpb.StatusCode_OK)
+	
+	local, global, status := cfg.GetAllConfig(context.Background())
+	c.Assert(status.GetCode(), Equals, configpb.StatusCode_OK)
+	c.Assert(len(local), Equals, 1)
+	c.Assert(local[0].Component, Equals, "tikv")
+	c.Assert(local[0].ComponentId, Equals, "tikv1")
+	c.Assert(local[0].Config, Equals, expect)
+	c.Assert(len(global), Equals, 1)
+	c.Assert(global[0].Component, Equals, "tidb")
+	c.Assert(global[0].Name, Equals, "log-level")
+	c.Assert(global[0].Value, Equals, "info")
 }
 
 func (s *testComponentsConfigSuite) TestGet(c *C) {

--- a/server/config_manager/grpc_service.go
+++ b/server/config_manager/grpc_service.go
@@ -52,12 +52,11 @@ func (c *ConfigManager) GetAll(ctx context.Context, request *configpb.GetAllRequ
 		return nil, err
 	}
 
-	localConfigs, globalEntries, status := c.GetAllConfig(ctx)
+	localConfigs, status := c.GetAllConfig(ctx)
 	return &configpb.GetAllResponse{
 		Header:        c.componentHeader(),
 		Status:        status,
 		LocalConfigs:  localConfigs,
-		GlobalEntries: globalEntries,
 	}, nil
 }
 

--- a/server/config_manager/grpc_service.go
+++ b/server/config_manager/grpc_service.go
@@ -46,6 +46,21 @@ func (c *ConfigManager) Create(ctx context.Context, request *configpb.CreateRequ
 	}, nil
 }
 
+// GetAll implements gRPC PDServer.
+func (c *ConfigManager) GetAll(ctx context.Context, request *configpb.GetAllRequest) (*configpb.GetAllResponse, error) {
+	if err := c.validateComponentRequest(request.GetHeader()); err != nil {
+		return nil, err
+	}
+
+	localConfigs, globalEntries, status := c.GetAllConfig(ctx)
+	return &configpb.GetAllResponse{
+		Header:        c.componentHeader(),
+		Status:        status,
+		LocalConfigs:  localConfigs,
+		GlobalEntries: globalEntries,
+	}, nil
+}
+
 // Get implements gRPC PDServer.
 func (c *ConfigManager) Get(ctx context.Context, request *configpb.GetRequest) (*configpb.GetResponse, error) {
 	if err := c.validateComponentRequest(request.GetHeader()); err != nil {

--- a/server/config_manager/grpc_service.go
+++ b/server/config_manager/grpc_service.go
@@ -54,9 +54,9 @@ func (c *ConfigManager) GetAll(ctx context.Context, request *configpb.GetAllRequ
 
 	localConfigs, status := c.GetAllConfig(ctx)
 	return &configpb.GetAllResponse{
-		Header:        c.componentHeader(),
-		Status:        status,
-		LocalConfigs:  localConfigs,
+		Header:       c.componentHeader(),
+		Status:       status,
+		LocalConfigs: localConfigs,
 	}, nil
 }
 


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Wait for https://github.com/pingcap/kvproto/pull/579.
Add a new method `GetAll` to the config manager to let the `TiDB` get all configs from `PD`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test