### PR TITLE
config: let the cert-allowed-cn same with other components

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -27,6 +27,8 @@ cert-path = ""
 ## Path of file that contains X509 key in PEM format.
 key-path = ""
 
+cert-allowed-cn = ["example.com"]
+
 [log]
 level = "info"
 

--- a/pkg/grpcutil/grpcutil.go
+++ b/pkg/grpcutil/grpcutil.go
@@ -33,7 +33,8 @@ type SecurityConfig struct {
 	// KeyPath is the path of file that contains X509 key in PEM format.
 	KeyPath        string `toml:"key-path" json:"key-path"`
 	ClientCertAuth bool   `toml:"client-cert-auth" json:"client-cert-auth"`
-	CertAllowedCN  string `toml:"cert-allowed-cn" json:"cert-allowed-cn"`
+	// CertAllowedCN is a CN which must be provided by a client
+	CertAllowedCN []string `toml:"cert-allowed-cn" json:"cert-allowed-cn"`
 }
 
 // ToTLSConfig generatres tls config.
@@ -41,18 +42,35 @@ func (s SecurityConfig) ToTLSConfig() (*tls.Config, error) {
 	if len(s.CertPath) == 0 && len(s.KeyPath) == 0 {
 		return nil, nil
 	}
+	allowedCN, err := s.GetOneAllowedCN()
+	if err != nil {
+		return nil, err
+	}
 	tlsInfo := transport.TLSInfo{
 		CertFile:       s.CertPath,
 		KeyFile:        s.KeyPath,
 		TrustedCAFile:  s.CAPath,
 		ClientCertAuth: s.ClientCertAuth,
-		AllowedCN:      s.CertAllowedCN,
+		AllowedCN:      allowedCN,
 	}
 	tlsConfig, err := tlsInfo.ClientConfig()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	return tlsConfig, nil
+}
+
+func (s SecurityConfig) GetOneAllowedCN() (string, error) {
+	allowedCN := ""
+	i := len(s.CertAllowedCN)
+	switch {
+	case i > 1:
+		return "", errors.New("Currently only supports one CN")
+	case i == 1:
+		allowedCN = s.CertAllowedCN[0]
+	default:
+	}
+	return allowedCN, nil
 }
 
 // GetClientConn returns a gRPC client connection.

--- a/pkg/grpcutil/grpcutil.go
+++ b/pkg/grpcutil/grpcutil.go
@@ -62,16 +62,14 @@ func (s SecurityConfig) ToTLSConfig() (*tls.Config, error) {
 
 // GetOneAllowedCN only gets the first one CN.
 func (s SecurityConfig) GetOneAllowedCN() (string, error) {
-	allowedCN := ""
-	i := len(s.CertAllowedCN)
-	switch {
-	case i > 1:
-		return "", errors.New("Currently only supports one CN")
-	case i == 1:
-		allowedCN = s.CertAllowedCN[0]
+	switch len(s.CertAllowedCN) {
+	case 1:
+		return s.CertAllowedCN[0], nil
+	case 0:
+		return "", nil
 	default:
+		return "", errors.New("Currently only supports one CN")
 	}
-	return allowedCN, nil
 }
 
 // GetClientConn returns a gRPC client connection.

--- a/pkg/grpcutil/grpcutil.go
+++ b/pkg/grpcutil/grpcutil.go
@@ -60,6 +60,7 @@ func (s SecurityConfig) ToTLSConfig() (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
+// GetOneAllowedCN only gets the first one CN.
 func (s SecurityConfig) GetOneAllowedCN() (string, error) {
 	allowedCN := ""
 	i := len(s.CertAllowedCN)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1045,16 +1045,20 @@ func (c *Config) GenEmbedEtcdConfig() (*embed.Config, error) {
 	cfg.AutoCompactionRetention = c.AutoCompactionRetention
 	cfg.QuotaBackendBytes = int64(c.QuotaBackendBytes)
 
+	allowedCN, serr := c.Security.GetOneAllowedCN()
+	if serr != nil {
+		return nil, serr
+	}
 	cfg.ClientTLSInfo.ClientCertAuth = len(c.Security.CAPath) != 0
 	cfg.ClientTLSInfo.TrustedCAFile = c.Security.CAPath
 	cfg.ClientTLSInfo.CertFile = c.Security.CertPath
 	cfg.ClientTLSInfo.KeyFile = c.Security.KeyPath
-	cfg.ClientTLSInfo.AllowedCN = c.Security.CertAllowedCN
+	cfg.ClientTLSInfo.AllowedCN = allowedCN
 	cfg.PeerTLSInfo.ClientCertAuth = len(c.Security.CAPath) != 0
 	cfg.PeerTLSInfo.TrustedCAFile = c.Security.CAPath
 	cfg.PeerTLSInfo.CertFile = c.Security.CertPath
 	cfg.PeerTLSInfo.KeyFile = c.Security.KeyPath
-	cfg.PeerTLSInfo.AllowedCN = c.Security.CertAllowedCN
+	cfg.PeerTLSInfo.AllowedCN = allowedCN
 	cfg.ForceNewCluster = c.ForceNewCluster
 	cfg.ZapLoggerBuilder = embed.NewZapCoreLoggerBuilder(c.logger, c.logger.Core(), c.logProps.Syncer)
 	cfg.EnableGRPCGateway = c.EnableGRPCGateway


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
TiDB, TiKV Supports multiple CNs, but we depend on etcd, let the config be consisted firstly.

### What is changed and how it works?
changed config items.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test 