### PR TITLE
syncer: fix panic problem when upgrading

### DIFF
--- a/server/region_syncer/client.go
+++ b/server/region_syncer/client.go
@@ -184,12 +184,18 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 				}
 				stats := resp.GetRegionStats()
 				for i, r := range resp.GetRegions() {
-					region := core.NewRegionInfo(r, nil,
-						core.SetWrittenBytes(stats[i].BytesWritten),
-						core.SetWrittenKeys(stats[i].KeysWritten),
-						core.SetReadBytes(stats[i].BytesRead),
-						core.SetReadKeys(stats[i].KeysRead),
-					)
+					var region *core.RegionInfo
+					if stats == nil || len(stats) == 0 {
+						region = core.NewRegionInfo(r, nil)
+					} else {
+						region = core.NewRegionInfo(r, nil,
+							core.SetWrittenBytes(stats[i].BytesWritten),
+							core.SetWrittenKeys(stats[i].KeysWritten),
+							core.SetReadBytes(stats[i].BytesRead),
+							core.SetReadKeys(stats[i].KeysRead),
+						)
+					}
+
 					s.server.GetBasicCluster().CheckAndPutRegion(region)
 					err = s.server.GetStorage().SaveRegion(r)
 					if err == nil {

--- a/server/region_syncer/client.go
+++ b/server/region_syncer/client.go
@@ -183,17 +183,19 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 					s.history.ResetWithIndex(resp.GetStartIndex())
 				}
 				stats := resp.GetRegionStats()
-				for i, r := range resp.GetRegions() {
+				regions := resp.GetRegions()
+				hasStats := len(stats) == len(regions)
+				for i, r := range regions {
 					var region *core.RegionInfo
-					if stats == nil || len(stats) == 0 {
-						region = core.NewRegionInfo(r, nil)
-					} else {
+					if hasStats {
 						region = core.NewRegionInfo(r, nil,
 							core.SetWrittenBytes(stats[i].BytesWritten),
 							core.SetWrittenKeys(stats[i].KeysWritten),
 							core.SetReadBytes(stats[i].BytesRead),
 							core.SetReadKeys(stats[i].KeysRead),
 						)
+					} else {
+						region = core.NewRegionInfo(r, nil)
 					}
 
 					s.server.GetBasicCluster().CheckAndPutRegion(region)


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
When we upgrade the cluster, the leader may be in a low version, which doesn't sync the statistics. In this case, the follower in the high version will panic.

### What is changed and how it works?
This PR adds if statement to avoid this case.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test