### PR TITLE
config: let PD to control the dynamic config

### DIFF
--- a/server/api/server.go
+++ b/server/api/server.go
@@ -38,7 +38,9 @@ func NewHandler(ctx context.Context, svr *server.Server) (http.Handler, server.S
 		serverapi.NewRedirector(svr),
 		negroni.Wrap(r)),
 	)
-	svr.AddStartCallback(f)
+	if f != nil {
+		svr.AddStartCallback(f)
+	}
 
 	return router, group, nil
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -210,7 +210,7 @@ const (
 	defaultEnableGRPCGateway   = true
 	defaultDisableErrorVerbose = true
 
-	defaultEnableDynamicConfig = true
+	defaultEnableDynamicConfig = false
 )
 
 var (

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -210,7 +210,7 @@ const (
 	defaultEnableGRPCGateway   = true
 	defaultDisableErrorVerbose = true
 
-	defaultEnableDynamicConfig = false
+	defaultEnableDynamicConfig = true
 )
 
 var (

--- a/server/config_manager/config_manager.go
+++ b/server/config_manager/config_manager.go
@@ -189,6 +189,7 @@ func (c *ConfigManager) GetConfig(version *configpb.Version, component, componen
 func (c *ConfigManager) CreateConfig(version *configpb.Version, component, componentID, cfg string) (*configpb.Version, string, *configpb.Status) {
 	c.Lock()
 	defer c.Unlock()
+
 	var status *configpb.Status
 	latestVersion := c.GetLatestVersion(component, componentID)
 	initVersion := &configpb.Version{Local: 0, Global: 0}

--- a/server/config_manager/config_manager.go
+++ b/server/config_manager/config_manager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/pingcap/kvproto/pkg/configpb"
 	"github.com/pingcap/pd/v4/server/cluster"
+	"github.com/pingcap/pd/v4/server/config"
 	"github.com/pingcap/pd/v4/server/core"
 	"github.com/pingcap/pd/v4/server/member"
 	"github.com/pkg/errors"
@@ -50,6 +51,7 @@ var (
 type Server interface {
 	IsClosed() bool
 	ClusterID() uint64
+	GetConfig() *config.Config
 	GetRaftCluster() *cluster.RaftCluster
 	GetStorage() *core.Storage
 	GetMember() *member.Member

--- a/server/config_manager/grpc_service.go
+++ b/server/config_manager/grpc_service.go
@@ -28,6 +28,15 @@ var notLeaderError = status.Errorf(codes.Unavailable, "not leader")
 
 // Create implements gRPC PDServer.
 func (c *ConfigManager) Create(ctx context.Context, request *configpb.CreateRequest) (*configpb.CreateResponse, error) {
+	if !c.svr.GetConfig().EnableDynamicConfig {
+		return &configpb.CreateResponse{
+			Header:  c.componentHeader(),
+			Status:  &configpb.Status{Code: configpb.StatusCode_OK},
+			Version: request.Version,
+			Config:  request.Config,
+		}, nil
+	}
+
 	if err := c.validateComponentRequest(request.GetHeader()); err != nil {
 		return nil, err
 	}
@@ -48,6 +57,13 @@ func (c *ConfigManager) Create(ctx context.Context, request *configpb.CreateRequ
 
 // GetAll implements gRPC PDServer.
 func (c *ConfigManager) GetAll(ctx context.Context, request *configpb.GetAllRequest) (*configpb.GetAllResponse, error) {
+	if !c.svr.GetConfig().EnableDynamicConfig {
+		return &configpb.GetAllResponse{
+			Header: c.componentHeader(),
+			Status: &configpb.Status{Code: configpb.StatusCode_OK},
+		}, nil
+	}
+
 	if err := c.validateComponentRequest(request.GetHeader()); err != nil {
 		return nil, err
 	}
@@ -62,6 +78,13 @@ func (c *ConfigManager) GetAll(ctx context.Context, request *configpb.GetAllRequ
 
 // Get implements gRPC PDServer.
 func (c *ConfigManager) Get(ctx context.Context, request *configpb.GetRequest) (*configpb.GetResponse, error) {
+	if !c.svr.GetConfig().EnableDynamicConfig {
+		return &configpb.GetResponse{
+			Header: c.componentHeader(),
+			Status: &configpb.Status{Code: configpb.StatusCode_OK},
+		}, nil
+	}
+
 	if err := c.validateComponentRequest(request.GetHeader()); err != nil {
 		return nil, err
 	}
@@ -78,6 +101,13 @@ func (c *ConfigManager) Get(ctx context.Context, request *configpb.GetRequest) (
 
 // Update implements gRPC PDServer.
 func (c *ConfigManager) Update(ctx context.Context, request *configpb.UpdateRequest) (*configpb.UpdateResponse, error) {
+	if !c.svr.GetConfig().EnableDynamicConfig {
+		return &configpb.UpdateResponse{
+			Header: c.componentHeader(),
+			Status: &configpb.Status{Code: configpb.StatusCode_OK},
+		}, nil
+	}
+
 	if err := c.validateComponentRequest(request.GetHeader()); err != nil {
 		return nil, err
 	}
@@ -97,6 +127,13 @@ func (c *ConfigManager) Update(ctx context.Context, request *configpb.UpdateRequ
 
 // Delete implements gRPC PDServer.
 func (c *ConfigManager) Delete(ctx context.Context, request *configpb.DeleteRequest) (*configpb.DeleteResponse, error) {
+	if !c.svr.GetConfig().EnableDynamicConfig {
+		return &configpb.DeleteResponse{
+			Header: c.componentHeader(),
+			Status: &configpb.Status{Code: configpb.StatusCode_OK},
+		}, nil
+	}
+
 	if err := c.validateComponentRequest(request.GetHeader()); err != nil {
 		return nil, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -247,10 +247,7 @@ func CreateServer(ctx context.Context, cfg *config.Config, serviceBuilders ...Ha
 	etcdCfg.ServiceRegister = func(gs *grpc.Server) {
 		pdpb.RegisterPDServer(gs, s)
 		diagnosticspb.RegisterDiagnosticsServer(gs, s)
-
-		if cfg.EnableDynamicConfig {
-			configpb.RegisterConfigServer(gs, s.cfgManager)
-		}
+		configpb.RegisterConfigServer(gs, s.cfgManager)
 	}
 	s.etcdCfg = etcdCfg
 	if EnableZap {


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
We have three switches on tikv, tidb, pd repos to control dynamic config which is noisy.

### What is changed and how it works?
This PR tries to control the dynamic config only using pd.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
