### PR TITLE
remove incorrect help message

### DIFF
--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -15,6 +15,7 @@ package pdctl
 
 import (
 	"fmt"
+	"github.com/spf13/pflag"
 	"io"
 	"os"
 
@@ -120,12 +121,13 @@ func getMainCmd(args []string) *cobra.Command {
 	return rootCmd
 }
 
-// Hide the flag in help and usage messages.
+// Hide the flags in help and usage messages.
 func hiddenFlag(cmd *cobra.Command) {
-	err := cmd.Flags().MarkHidden("pd")
-	if err != nil {
-		cmd.Printf("Failed to hidden flags: %s\n", err)
-	}
+	cmd.LocalFlags().VisitAll(func(flag *pflag.Flag) {
+		if flag.Name != "help" {
+			flag.Hidden = true
+		}
+	})
 }
 
 // MainStart start main command

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -100,6 +100,7 @@ func getInteractCmd(args []string) *cobra.Command {
 	rootCmd.SetArgs(args)
 	rootCmd.ParseFlags(args)
 	rootCmd.SetOutput(os.Stdout)
+	hiddenFlag(rootCmd)
 
 	return rootCmd
 }
@@ -117,6 +118,14 @@ func getMainCmd(args []string) *cobra.Command {
 	rootCmd.SetOutput(os.Stdout)
 
 	return rootCmd
+}
+
+// Hide the flag in help and usage messages.
+func hiddenFlag(cmd *cobra.Command) {
+	err := cmd.Flags().MarkHidden("pd")
+	if err != nil {
+		cmd.Printf("Failed to hidden flags: %s\n", err)
+	}
 }
 
 // MainStart start main command

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -15,7 +15,6 @@ package pdctl
 
 import (
 	"fmt"
-	"github.com/spf13/pflag"
 	"io"
 	"os"
 
@@ -64,9 +63,9 @@ func getBasicCmd() *cobra.Command {
 	}
 
 	rootCmd.PersistentFlags().StringVarP(&commandFlags.URL, "pd", "u", "http://127.0.0.1:2379", "Address of pd.")
-	rootCmd.Flags().StringVar(&commandFlags.CAPath, "cacert", "", "Path of file that contains list of trusted SSL CAs.")
-	rootCmd.Flags().StringVar(&commandFlags.CertPath, "cert", "", "Path of file that contains X509 certificate in PEM format.")
-	rootCmd.Flags().StringVar(&commandFlags.KeyPath, "key", "", "Path of file that contains X509 key in PEM format.")
+	rootCmd.PersistentFlags().StringVar(&commandFlags.CAPath, "cacert", "", "Path of file that contains list of trusted SSL CAs.")
+	rootCmd.PersistentFlags().StringVar(&commandFlags.CertPath, "cert", "", "Path of file that contains X509 certificate in PEM format.")
+	rootCmd.PersistentFlags().StringVar(&commandFlags.KeyPath, "key", "", "Path of file that contains X509 key in PEM format.")
 	rootCmd.PersistentFlags().BoolVarP(&commandFlags.Help, "help", "h", false, "Help message.")
 
 	rootCmd.AddCommand(
@@ -123,11 +122,10 @@ func getMainCmd(args []string) *cobra.Command {
 
 // Hide the flags in help and usage messages.
 func hiddenFlag(cmd *cobra.Command) {
-	cmd.LocalFlags().VisitAll(func(flag *pflag.Flag) {
-		if flag.Name != "help" {
-			flag.Hidden = true
-		}
-	})
+	cmd.LocalFlags().MarkHidden("pd")
+	cmd.LocalFlags().MarkHidden("cacert")
+	cmd.LocalFlags().MarkHidden("cert")
+	cmd.LocalFlags().MarkHidden("key")
 }
 
 // MainStart start main command


### PR DESCRIPTION
UCP: #2259 

Signed-off-by: wq1019 <2013855675@qq.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
It solves the problem of printing useless global flags when we input wrong arguments in interactive mode.

### What is changed and how it works?
Some useless global flags messages are hidden in interactive mode.
```
func getInteractCmd(args []string) *cobra.Command {
	rootCmd := getBasicCmd()

	rootCmd.SetArgs(args)
	rootCmd.ParseFlags(args)
	rootCmd.SetOutput(os.Stdout)
	hiddenFlag(rootCmd)

	return rootCmd
}
func hiddenFlag(cmd *cobra.Command) {
	err := cmd.Flags().MarkHidden("pd")
	if err != nil {
		cmd.Printf("Failed to hidden flags: %s\n", err)
	}
}
```
```
» region key
Usage:
  pd-ctl region key [--format=raw|encode|hex] <key> [flags]

Flags:
      --format string   the key format (default "hex")

Global Flags:
  -h, --help   Help message.

»  
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test