### PR TITLE
show all component ID when using ids

### DIFF
--- a/server/api/router.go
+++ b/server/api/router.go
@@ -205,8 +205,11 @@ func createRouter(ctx context.Context, prefix string, svr *server.Server) (*mux.
 		apiRouter.HandleFunc("/component/ids/{component}", func(w http.ResponseWriter, r *http.Request) {
 			vars := mux.Vars(r)
 			varName := vars["component"]
-			componentIDs := svr.GetConfigManager().GetComponentIDs(varName)
-			rd.JSON(w, http.StatusOK, componentIDs)
+			if varName == "all" {
+				rd.JSON(w, http.StatusOK, svr.GetConfigManager().GetAllComponentIDs())
+			} else {
+				rd.JSON(w, http.StatusOK, svr.GetConfigManager().GetComponentIDs(varName))
+			}
 		}).Methods("GET")
 		return rootRouter, func() { lazyComponentRouter(ctx, svr, apiRouter) }
 	}

--- a/server/config_manager/config_manager.go
+++ b/server/config_manager/config_manager.go
@@ -99,6 +99,19 @@ func (c *ConfigManager) GetComponentIDs(component string) []string {
 	return addresses
 }
 
+// GetAllComponentIDs returns all components.
+func (c *ConfigManager) GetAllComponentIDs() map[string][]string {
+	c.RLock()
+	defer c.RUnlock()
+	var addresses = make(map[string][]string)
+	for component := range c.LocalCfgs {
+		for address := range c.LocalCfgs[component] {
+			addresses[component] = append(addresses[component], address)
+		}
+	}
+	return addresses
+}
+
 // Persist saves the configuration to the storage.
 func (c *ConfigManager) Persist(storage *core.Storage) error {
 	c.Lock()

--- a/tests/pdctl/component/component_test.go
+++ b/tests/pdctl/component/component_test.go
@@ -67,6 +67,13 @@ func (s *componentTestSuite) TestComponent(c *C) {
 	obtain := string(output)
 	c.Assert(strings.Contains(obtain, pdAddrs[0][7:]), IsTrue)
 	c.Assert(strings.Contains(obtain, pdAddrs[1][7:]), IsTrue)
+	// component ids no parameter
+	args = []string{"-u", pdAddrs[0], "component", "ids"}
+	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	c.Assert(err, IsNil)
+	obtain = string(output)
+	c.Assert(strings.Contains(obtain, pdAddrs[0][7:]), IsTrue)
+	c.Assert(strings.Contains(obtain, pdAddrs[1][7:]), IsTrue)
 
 	// component show
 	for i := 0; i < len(pdAddrs); i++ {

--- a/tools/pd-ctl/pdctl/command/component_command.go
+++ b/tools/pd-ctl/pdctl/command/component_command.go
@@ -129,7 +129,7 @@ func getComponentIDCommandFunc(cmd *cobra.Command, args []string) {
 		if argsLen > 0 {
 			cmd.Printf("Failed to get component %s's id: %s\n", args[0], err)
 		} else {
-			cmd.Println("Failed to get all components: %s", err)
+			cmd.Println("Failed to get all components", err)
 		}
 		return
 	}

--- a/tools/pd-ctl/pdctl/command/component_command.go
+++ b/tools/pd-ctl/pdctl/command/component_command.go
@@ -129,7 +129,7 @@ func getComponentIDCommandFunc(cmd *cobra.Command, args []string) {
 		if argsLen > 0 {
 			cmd.Printf("Failed to get component %s's id: %s\n", args[0], err)
 		} else {
-			cmd.Println("Failed to get all components", err)
+			cmd.Printf("Failed to get all components: %s\n", err)
 		}
 		return
 	}

--- a/tools/pd-ctl/pdctl/command/component_command.go
+++ b/tools/pd-ctl/pdctl/command/component_command.go
@@ -129,7 +129,7 @@ func getComponentIDCommandFunc(cmd *cobra.Command, args []string) {
 		if argsLen > 0 {
 			cmd.Printf("Failed to get component %s's id: %s\n", args[0], err)
 		} else {
-			cmd.Printf("Failed to get all components: %s\n", err)
+			cmd.Println("Failed to get all components", err)
 		}
 		return
 	}

--- a/tools/pd-ctl/pdctl/command/component_command.go
+++ b/tools/pd-ctl/pdctl/command/component_command.go
@@ -75,7 +75,7 @@ func NewSetComponentConfigCommand() *cobra.Command {
 func NewGetComponentIDCommand() *cobra.Command {
 	sc := &cobra.Command{
 		Use:   "ids [component]",
-		Short: "get all component IDs or given component names (e.g. tikv)",
+		Short: "get component IDs for all components or with a given component name (e.g. tikv)",
 		Run:   getComponentIDCommandFunc,
 	}
 	return sc
@@ -118,9 +118,7 @@ func getComponentIDCommandFunc(cmd *cobra.Command, args []string) {
 		cmd.Usage()
 		return
 	}
-	var (
-		ids = "all"
-	)
+	ids := "all"
 	if argsLen == 1 {
 		ids = args[0]
 	}
@@ -131,7 +129,7 @@ func getComponentIDCommandFunc(cmd *cobra.Command, args []string) {
 		if argsLen > 0 {
 			cmd.Printf("Failed to get component %s's id: %s\n", args[0], err)
 		} else {
-			cmd.Printf("Failed to get all components: %s\n", err)
+			cmd.Println("Failed to get all components: %s", err)
 		}
 		return
 	}

--- a/tools/pd-ctl/pdctl/command/component_command.go
+++ b/tools/pd-ctl/pdctl/command/component_command.go
@@ -119,18 +119,16 @@ func getComponentIDCommandFunc(cmd *cobra.Command, args []string) {
 		return
 	}
 	var (
-		hasIdsVal = false
-		ids       = "all"
+		ids = "all"
 	)
 	if argsLen == 1 {
-		hasIdsVal = true
 		ids = args[0]
 	}
 	prefix := path.Join(componentConfigPrefix, "ids", ids)
 
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
-		if hasIdsVal {
+		if argsLen > 0 {
 			cmd.Printf("Failed to get component %s's id: %s\n", args[0], err)
 		} else {
 			cmd.Printf("Failed to get all components: %s\n", err)

--- a/tools/pd-ctl/pdctl/command/component_command.go
+++ b/tools/pd-ctl/pdctl/command/component_command.go
@@ -74,8 +74,8 @@ func NewSetComponentConfigCommand() *cobra.Command {
 // NewGetComponentIDCommand returns a id subcommand of componentCmd.
 func NewGetComponentIDCommand() *cobra.Command {
 	sc := &cobra.Command{
-		Use:   "ids <component>",
-		Short: "get all component IDs with a given component (e.g. tikv)",
+		Use:   "ids [component]",
+		Short: "get all component IDs or given component names (e.g. tikv)",
 		Run:   getComponentIDCommandFunc,
 	}
 	return sc
@@ -112,15 +112,29 @@ func deleteComponentConfigCommandFunc(cmd *cobra.Command, args []string) {
 }
 
 func getComponentIDCommandFunc(cmd *cobra.Command, args []string) {
-	if len(args) != 1 {
+	argsLen := len(args)
+	// args too long
+	if argsLen > 1 {
 		cmd.Usage()
 		return
 	}
+	var (
+		hasIdsVal = false
+		ids       = "all"
+	)
+	if argsLen == 1 {
+		hasIdsVal = true
+		ids = args[0]
+	}
+	prefix := path.Join(componentConfigPrefix, "ids", ids)
 
-	prefix := path.Join(componentConfigPrefix, "ids", args[0])
 	r, err := doRequest(cmd, prefix, http.MethodGet)
 	if err != nil {
-		cmd.Printf("Failed to get component %s's id: %s\n", args[0], err)
+		if hasIdsVal {
+			cmd.Printf("Failed to get component %s's id: %s\n", args[0], err)
+		} else {
+			cmd.Printf("Failed to get all components: %s\n", err)
+		}
 		return
 	}
 	cmd.Println(r)


### PR DESCRIPTION
UCP: #2229

Signed-off-by: wq1019 <2013855675@qq.com>

@rleungx 

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
If IDs parameter is empty, all component IDs will be returned.

### What is changed and how it works?
1. When the IDs parameter is ignored, CTL will automatically assemble the URL into`/component/ids/all`and continue to request.
2. Updated `/component/ids/{component}` API, When the parameter passed in is`all`, all component IDS will be returned.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
