### PR TITLE
config: fix the extra config update when starting a new cluster

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -748,6 +748,7 @@ func (s *Server) SetScheduleConfig(cfg config.ScheduleConfig) error {
 		return err
 	}
 	old := s.scheduleOpt.Load()
+	cfg.SchedulersPayload = nil
 	s.scheduleOpt.Store(&cfg)
 	if err := s.scheduleOpt.Persist(s.storage); err != nil {
 		s.scheduleOpt.Store(old)
@@ -1294,38 +1295,36 @@ func (s *Server) updateComponentConfig(cfg string) error {
 		return err
 	}
 	var err error
-	if !reflect.DeepEqual(s.GetScheduleConfig(), &new.Schedule) {
-		if err = new.Schedule.Validate(); err != nil {
-			return err
-		}
+	old := *s.GetConfig()
+	// SchedulersPayload doesn't need to be updated.
+	new.Schedule.SchedulersPayload = nil
+	old.Schedule.SchedulersPayload = nil
+	if !reflect.DeepEqual(old.Schedule, new.Schedule) {
 		err = s.SetScheduleConfig(new.Schedule)
 		saveFile = true
 	}
 
-	if !reflect.DeepEqual(s.GetReplicationConfig(), &new.Replication) {
-		if err = new.Replication.Validate(); err != nil {
-			return err
-		}
+	if !reflect.DeepEqual(old.Replication, new.Replication) {
 		err = s.SetReplicationConfig(new.Replication)
 		saveFile = true
 	}
 
-	if !reflect.DeepEqual(s.GetPDServerConfig(), &new.PDServerCfg) {
+	if !reflect.DeepEqual(old.PDServerCfg, new.PDServerCfg) {
 		err = s.SetPDServerConfig(new.PDServerCfg)
 		saveFile = true
 	}
 
-	if !reflect.DeepEqual(s.GetClusterVersion(), new.ClusterVersion) {
+	if !reflect.DeepEqual(old.ClusterVersion, new.ClusterVersion) {
 		err = s.SetClusterVersion(new.ClusterVersion.String())
 		saveFile = true
 	}
 
-	if !reflect.DeepEqual(s.GetLabelProperty(), new.LabelProperty) {
+	if !reflect.DeepEqual(old.LabelProperty, new.LabelProperty) {
 		err = s.SetLabelPropertyConfig(new.LabelProperty)
 		saveFile = true
 	}
 
-	if !reflect.DeepEqual(s.GetLogConfig(), &new.Log) {
+	if !reflect.DeepEqual(old.Log, new.Log) {
 		err = s.SetLogConfig(new.Log)
 		saveFile = true
 	}


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
When we start a new cluster, it will update config twice due to the change of `SchedulersPayload`. Besides, since `SetXXXConfig` will call validate inside of the function. We don't need to call it outside.

### What is changed and how it works?
This PR removes these extra checks. Besides, this PR doesn't persist the value of `SchedulersPayload` which may cause two extra updates when starting a new cluster.

### Release note <!-- bugfixes or new feature need a release note -->
Fix the extra config update when starting a new cluster

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
