### PR TITLE
store: use fixed size and space ratio to decide space threshold

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -662,7 +662,7 @@ const (
 	defaultStoreBalanceRate       = 15
 	defaultTolerantSizeRatio      = 0
 	defaultLowSpaceRatio          = 0.8
-	defaultHighSpaceRatio         = 0.6
+	defaultHighSpaceRatio         = 0.7
 	// defaultHotRegionCacheHitsThreshold is the low hit number threshold of the
 	// hot region.
 	defaultHotRegionCacheHitsThreshold = 3

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -27,10 +27,12 @@ import (
 	"go.uber.org/zap"
 )
 
-// Interval to save store meta (including heartbeat ts) to etcd.
-const storePersistInterval = 5 * time.Minute
-const lowSpaceThreshold = 100 * (1 << 10)  // 100 GB
-const highSpaceThreshold = 300 * (1 << 10) // 300 GB
+const (
+	// Interval to save store meta (including heartbeat ts) to etcd.
+	storePersistInterval = 5 * time.Minute
+	lowSpaceThreshold    = 100 * (1 << 10) // 100 GB
+	highSpaceThreshold   = 300 * (1 << 10) // 300 GB
+)
 
 // StoreInfo contains information about a store.
 type StoreInfo struct {

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -32,6 +32,7 @@ const (
 	storePersistInterval = 5 * time.Minute
 	lowSpaceThreshold    = 100 * (1 << 10) // 100 GB
 	highSpaceThreshold   = 300 * (1 << 10) // 300 GB
+	mb                   = 1 << 20         // megabyte
 )
 
 // StoreInfo contains information about a store.
@@ -276,8 +277,8 @@ func (s *StoreInfo) LeaderScore(policy SchedulePolicy, delta int64) float64 {
 func (s *StoreInfo) RegionScore(highSpaceRatio, lowSpaceRatio float64, delta int64) float64 {
 	var score float64
 	var amplification float64
-	available := float64(s.GetAvailable()) / (1 << 20)
-	used := float64(s.GetUsedSize()) / (1 << 20)
+	available := float64(s.GetAvailable()) / mb
+	used := float64(s.GetUsedSize()) / mb
 
 	if s.GetRegionSize() == 0 {
 		amplification = 1
@@ -325,7 +326,7 @@ func (s *StoreInfo) StorageSize() uint64 {
 // GetSpaceThreshold returns the threshold of low/high space in MB.
 func (s *StoreInfo) GetSpaceThreshold(spaceRatio, spaceThreshold float64) float64 {
 	var min float64 = spaceThreshold
-	capacity := float64(s.GetCapacity()) / (1 << 20)
+	capacity := float64(s.GetCapacity()) / mb
 	space := capacity * (1.0 - spaceRatio)
 	if min > space {
 		min = space
@@ -335,7 +336,7 @@ func (s *StoreInfo) GetSpaceThreshold(spaceRatio, spaceThreshold float64) float6
 
 // IsLowSpace checks if the store is lack of space.
 func (s *StoreInfo) IsLowSpace(lowSpaceRatio float64) bool {
-	available := float64(s.GetAvailable()) / (1 << 20)
+	available := float64(s.GetAvailable()) / mb
 	return s.GetStoreStats() != nil && available <= s.GetSpaceThreshold(lowSpaceRatio, lowSpaceThreshold)
 }
 

--- a/server/core/store_test.go
+++ b/server/core/store_test.go
@@ -14,11 +14,13 @@
 package core
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
 )
 
 var _ = Suite(&testDistinctScoreSuite{})
@@ -91,4 +93,33 @@ func (s *testConcurrencySuite) TestCloneStore(c *C) {
 		}
 	}()
 	wg.Wait()
+}
+
+var _ = Suite(&testStoreSuite{})
+
+type testStoreSuite struct{}
+
+func (s *testStoreSuite) TestLowSpaceThreshold(c *C) {
+	stats := &pdpb.StoreStats{}
+	stats.Capacity = 10 * (1 << 40) // 10 TB
+	stats.Available = 1 * (1 << 40) // 1 TB
+
+	store := NewStoreInfo(
+		&metapb.Store{Id: 1},
+		SetStoreStats(stats),
+	)
+	threshold := store.GetSpaceThreshold(0.8, lowSpaceThreshold)
+	c.Assert(threshold, Equals, float64(lowSpaceThreshold))
+	c.Assert(store.IsLowSpace(0.8), Equals, false)
+	stats = &pdpb.StoreStats{}
+	stats.Capacity = 100 * (1 << 20) // 100 MB
+	stats.Available = 10 * (1 << 20) // 10 MB
+
+	store = NewStoreInfo(
+		&metapb.Store{Id: 1},
+		SetStoreStats(stats),
+	)
+	threshold = store.GetSpaceThreshold(0.8, lowSpaceThreshold)
+	c.Assert(fmt.Sprintf("%.2f", threshold), Equals, fmt.Sprintf("%.2f", 100*0.2))
+	c.Assert(store.IsLowSpace(0.8), Equals, true)
 }

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -702,7 +702,7 @@ func (s *testBalanceRegionSchedulerSuite) TestBalance1(c *C) {
 	// if the space of store 5 is normal, we can balance region to store 5
 	testutil.CheckTransferPeer(c, sb.Schedule(tc)[0], operator.OpBalance, 1, 5)
 
-	// the used size of  store 5 reach (highSpace, lowSpace)
+	// the used size of store 5 reach (highSpace, lowSpace)
 	origin := tc.GetStore(5)
 	stats := origin.GetStoreStats()
 	stats.Capacity = 50
@@ -713,7 +713,7 @@ func (s *testBalanceRegionSchedulerSuite) TestBalance1(c *C) {
 
 	// the scheduler first picks store 1 as source store,
 	// and store 5 as target store, but cannot pass `shouldBalance`.
-	// Then it will try store4.
+	// Then it will try store 4.
 	testutil.CheckTransferPeer(c, sb.Schedule(tc)[0], operator.OpBalance, 1, 4)
 }
 

--- a/server/schedulers/scheduler_test.go
+++ b/server/schedulers/scheduler_test.go
@@ -565,7 +565,7 @@ func (s *testSpecialUseSuite) TestSpecialUseHotRegion(c *C) {
 	tc.AddRegionStore(2, 4)
 	tc.AddRegionStore(3, 2)
 	tc.AddRegionStore(4, 0)
-	tc.AddRegionStore(5, 0)
+	tc.AddRegionStore(5, 10)
 	tc.AddLeaderRegion(1, 1, 2, 3)
 	tc.AddLeaderRegion(2, 1, 2, 3)
 	tc.AddLeaderRegion(3, 1, 2, 3)


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
We use `low-space-ratio` and `high-space-ratio` to control the calculation of score. But in some cases which the capacity of the store is large enough. These ratios may not reasonable.

### What is changed and how it works?
This PR adds a fixed size for low and high space threshold to help choose a better value compared with the original way.

### Release note <!-- bugfixes or new feature need a release note -->
Use fixed size and space ratio to decide the space threshold.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test