### PR TITLE
config: disable dynamic config by default

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -210,7 +210,7 @@ const (
 	defaultEnableGRPCGateway   = true
 	defaultDisableErrorVerbose = true
 
-	defaultEnableDynamicConfig = true
+	defaultEnableDynamicConfig = false
 )
 
 var (

--- a/server/schedulers/scheduler_test.go
+++ b/server/schedulers/scheduler_test.go
@@ -565,7 +565,7 @@ func (s *testSpecialUseSuite) TestSpecialUseHotRegion(c *C) {
 	tc.AddRegionStore(2, 4)
 	tc.AddRegionStore(3, 2)
 	tc.AddRegionStore(4, 0)
-	tc.AddRegionStore(5, 0)
+	tc.AddRegionStore(5, 10)
 	tc.AddLeaderRegion(1, 1, 2, 3)
 	tc.AddLeaderRegion(2, 1, 2, 3)
 	tc.AddLeaderRegion(3, 1, 2, 3)

--- a/tests/pdctl/component/component_test.go
+++ b/tests/pdctl/component/component_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/v4/server"
+	"github.com/pingcap/pd/v4/server/config"
 	"github.com/pingcap/pd/v4/tests"
 	"github.com/pingcap/pd/v4/tests/pdctl"
 )
@@ -42,7 +43,7 @@ func (s *componentTestSuite) SetUpSuite(c *C) {
 func (s *componentTestSuite) TestComponent(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	cluster, err := tests.NewTestCluster(ctx, 2)
+	cluster, err := tests.NewTestCluster(ctx, 2, func(cfg *config.Config) { cfg.EnableDynamicConfig = true })
 	c.Assert(err, IsNil)
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)

--- a/tests/pdctl/hot/hot_test.go
+++ b/tests/pdctl/hot/hot_test.go
@@ -99,6 +99,7 @@ func (s *hotTestSuite) TestHot(c *C) {
 	args = []string{"-u", pdAddr, "config", "set", "hot-region-cache-hits-threshold", "0"}
 	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
 	c.Assert(err, IsNil)
+	time.Sleep(20 * time.Millisecond)
 
 	testHot := func(hotRegionID, hotStoreID uint64, hotType string) {
 		args = []string{"-u", pdAddr, "hot", hotType}

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -162,7 +162,10 @@ func (s *clusterTestSuite) TestGetPutConfig(c *C) {
 }
 
 func (s *clusterTestSuite) TestReloadConfig(c *C) {
-	tc, err := tests.NewTestCluster(s.ctx, 3, func(conf *config.Config) { conf.PDServerCfg.UseRegionStorage = true })
+	tc, err := tests.NewTestCluster(s.ctx, 3, func(conf *config.Config) {
+		conf.PDServerCfg.UseRegionStorage = true
+		conf.EnableDynamicConfig = true
+	})
 	defer tc.Destroy()
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Disable dynamic config by default.

### What is changed and how it works?
This PR disables dynamic config by default

### Release note <!-- bugfixes or new feature need a release note -->
Disable dynamic configuration change by default

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has configuration change