### PR TITLE
pdctl: add placement rules commands

### DIFF
--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -16,10 +16,13 @@ package command
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"path"
 	"strconv"
 
+	"github.com/pingcap/pd/v4/server/schedule/placement"
 	"github.com/spf13/cobra"
 )
 
@@ -29,6 +32,8 @@ var (
 	replicationPrefix    = "pd/api/v1/config/replicate"
 	labelPropertyPrefix  = "pd/api/v1/config/label-property"
 	clusterVersionPrefix = "pd/api/v1/config/cluster-version"
+	rulesPrefix          = "pd/api/v1/config/rules"
+	rulePrefix           = "pd/api/v1/config/rule"
 )
 
 // NewConfigCommand return a config subcommand of rootCmd
@@ -40,6 +45,7 @@ func NewConfigCommand() *cobra.Command {
 	conf.AddCommand(NewShowConfigCommand())
 	conf.AddCommand(NewSetConfigCommand())
 	conf.AddCommand(NewDeleteConfigCommand())
+	conf.AddCommand(NewPlacementRulesCommand())
 	return conf
 }
 
@@ -309,4 +315,147 @@ func setClusterVersionCommandFunc(cmd *cobra.Command, args []string) {
 		"cluster-version": args[0],
 	}
 	postJSON(cmd, clusterVersionPrefix, input)
+}
+
+// NewPlacementRulesCommand placement rules subcommand
+func NewPlacementRulesCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "placement-rules",
+		Short: "placement rules configuration",
+	}
+	enable := &cobra.Command{
+		Use:   "enable",
+		Short: "enable placement rules",
+		Run:   enablePlacementRulesFunc,
+	}
+	disable := &cobra.Command{
+		Use:   "disable",
+		Short: "disable placement rules",
+		Run:   disablePlacementRulesFunc,
+	}
+	show := &cobra.Command{
+		Use:   "show",
+		Short: "show placement rules",
+	}
+	show.Flags().String("group", "", "group id")
+	show.Flags().String("id", "", "rule id")
+	show.Flags().String("region", "", "region id")
+	load := &cobra.Command{
+		Use:   "load",
+		Short: "load placement rules to a file",
+		Run:   getPlacementRulesFunc,
+	}
+	load.Flags().String("group", "", "group id")
+	load.Flags().String("id", "", "rule id")
+	load.Flags().String("region", "", "region id")
+	load.Flags().String("out", "rules.json", "the filename contains rules")
+	save := &cobra.Command{
+		Use:   "save",
+		Short: "save rules from file",
+		Run:   putPlacementRulesFunc,
+	}
+	save.Flags().String("in", "rules.json", "the filename contains rules")
+	c.AddCommand(enable, disable, show, load, save)
+	return c
+}
+
+func enablePlacementRulesFunc(cmd *cobra.Command, args []string) {
+	err := postConfigDataWithPath(cmd, "enable-placement-rules", "true", configPrefix)
+	if err != nil {
+		cmd.Printf("Failed to set config: %s\n", err)
+		return
+	}
+	cmd.Println("Success!")
+}
+
+func disablePlacementRulesFunc(cmd *cobra.Command, args []string) {
+	err := postConfigDataWithPath(cmd, "enable-placement-rules", "true", configPrefix)
+	if err != nil {
+		cmd.Printf("Failed to set config: %s\n", err)
+		return
+	}
+	cmd.Println("Success!")
+}
+
+func getPlacementRulesFunc(cmd *cobra.Command, args []string) {
+	getFlag := func(key string) string {
+		if f := cmd.Flag(key); f != nil {
+			return f.Value.String()
+		}
+		return ""
+	}
+
+	group, id, region, file := getFlag("group"), getFlag("id"), getFlag("region"), getFlag("in")
+	var reqPath string
+	respIsList := true
+	switch {
+	case region == "" && group == "" && id == "": // all rules
+		reqPath = rulesPrefix
+	case region == "" && group == "" && id != "":
+		fmt.Println(`"id" should be specified along with "group"`)
+		return
+	case region == "" && group != "" && id == "": // all rules in a group
+		reqPath = path.Join(rulesPrefix, group)
+	case region == "" && group != "" && id != "": // single rule
+		reqPath, respIsList = path.Join(rulePrefix, group, id), false
+	case region != "" && group == "" && id == "": // rules matches a region
+		reqPath = path.Join(rulesPrefix, "region", region)
+	default:
+		fmt.Println(`"region" should not be specified with "group" or "id" at the same time`)
+		return
+	}
+	res, err := doRequest(cmd, reqPath, http.MethodGet)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	if file == "" {
+		fmt.Println(res)
+		return
+	}
+	if !respIsList {
+		res = "[\n" + res + "]\n"
+	}
+	err = ioutil.WriteFile(file, []byte(res), 0644)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println("rules saved to file " + file)
+}
+
+func putPlacementRulesFunc(cmd *cobra.Command, args []string) {
+	var file string
+	if f := cmd.Flag("out"); f != nil {
+		file = f.Value.String()
+	}
+	content, err := ioutil.ReadFile(file)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	var rules []*placement.Rule
+	if err = json.Unmarshal(content, &rules); err != nil {
+		fmt.Println(err)
+		return
+	}
+	for _, r := range rules {
+		if r.Count > 0 {
+			b, _ := json.Marshal(r)
+			_, err = doRequest(cmd, rulePrefix, http.MethodPost, WithBody("application/json", bytes.NewBuffer(b)))
+			if err != nil {
+				fmt.Printf("failed to save rule %v: %v\n", r.Key(), err)
+				return
+			}
+			fmt.Printf("saved rule %v", r.Key())
+		} else {
+			_, err = doRequest(cmd, path.Join(rulePrefix, r.GroupID, r.ID), http.MethodDelete)
+			if err != nil {
+				fmt.Printf("failed to delete rule %v: %v\n", r.Key(), err)
+				return
+			}
+			fmt.Printf("deleted rule %v", r.Key())
+		}
+	}
+	fmt.Println("Success!")
 }

--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -393,7 +393,7 @@ func getPlacementRulesFunc(cmd *cobra.Command, args []string) {
 	case region == "" && group == "" && id == "": // all rules
 		reqPath = rulesPrefix
 	case region == "" && group == "" && id != "":
-		fmt.Println(`"id" should be specified along with "group"`)
+		cmd.Println(`"id" should be specified along with "group"`)
 		return
 	case region == "" && group != "" && id == "": // all rules in a group
 		reqPath = path.Join(rulesPrefix, "group", group)
@@ -402,16 +402,16 @@ func getPlacementRulesFunc(cmd *cobra.Command, args []string) {
 	case region != "" && group == "" && id == "": // rules matches a region
 		reqPath = path.Join(rulesPrefix, "region", region)
 	default:
-		fmt.Println(`"region" should not be specified with "group" or "id" at the same time`)
+		cmd.Println(`"region" should not be specified with "group" or "id" at the same time`)
 		return
 	}
 	res, err := doRequest(cmd, reqPath, http.MethodGet)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
 	if file == "" {
-		fmt.Println(res)
+		cmd.Println(res)
 		return
 	}
 	if !respIsList {
@@ -419,10 +419,10 @@ func getPlacementRulesFunc(cmd *cobra.Command, args []string) {
 	}
 	err = ioutil.WriteFile(file, []byte(res), 0644)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
-	fmt.Println("rules saved to file " + file)
+	cmd.Println("rules saved to file " + file)
 }
 
 func putPlacementRulesFunc(cmd *cobra.Command, args []string) {
@@ -432,12 +432,12 @@ func putPlacementRulesFunc(cmd *cobra.Command, args []string) {
 	}
 	content, err := ioutil.ReadFile(file)
 	if err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
 	var rules []*placement.Rule
 	if err = json.Unmarshal(content, &rules); err != nil {
-		fmt.Println(err)
+		cmd.Println(err)
 		return
 	}
 	for _, r := range rules {
@@ -458,5 +458,5 @@ func putPlacementRulesFunc(cmd *cobra.Command, args []string) {
 			fmt.Printf("deleted rule %s/%s\n", r.GroupID, r.ID)
 		}
 	}
-	fmt.Println("Success!")
+	cmd.Println("Success!")
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fix https://github.com/pingcap/pd/issues/2285

### What is changed and how it works?
add commands:
- `pd-ctl config placement-rules enable`, same as `config set enable placement-rules true`
- `pd-ctl config placement-rules disable`, same as `config set enable placement-rules false`
- `pd-ctl config placement-rules show`, show all rules
- `pd-ctl config placement-rules show --group=g1`, show rules in a group
- `pd-ctl config placement-rules show --group=g1 --id=id2`, show a rule
- `pd-ctl config placement-rules show --region=1`, show rules match a region
- `pd-ctl config placement-rules load -out=rules.json`, load all rules to a file
- `pd-ctl config placement-rules save -in=rules.json`, save rules in a file to PD


### Check List <!--REMOVE the items that are not applicable-->
Tests <!-- At least one of them must be included. -->
 - Unit test

Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: TBD