### PR TITLE
scheduelrs: add load expectations for hot scheudler

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -393,14 +393,40 @@ func (mc *Cluster) UpdateStorageRatio(storeID uint64, usedRatio, availableRatio 
 	mc.PutStore(newStore)
 }
 
-// UpdateStorageWrittenBytes updates store written bytes.
-func (mc *Cluster) UpdateStorageWrittenBytes(storeID uint64, bytesWritten uint64, updateSingleOption ...struct{}) {
+// UpdateStorageWrittenStats updates store written bytes.
+func (mc *Cluster) UpdateStorageWrittenStats(storeID, bytesWritten, keysWritten uint64) {
 	store := mc.GetStore(storeID)
 	newStats := proto.Clone(store.GetStoreStats()).(*pdpb.StoreStats)
 	newStats.BytesWritten = bytesWritten
-	if len(updateSingleOption) == 0 {
-		newStats.KeysWritten = bytesWritten / 100
-	}
+	newStats.KeysWritten = keysWritten
+	now := time.Now().Second()
+	interval := &pdpb.TimeInterval{StartTimestamp: uint64(now - statistics.StoreHeartBeatReportInterval), EndTimestamp: uint64(now)}
+	newStats.Interval = interval
+	newStore := store.Clone(core.SetStoreStats(newStats))
+	mc.Set(storeID, newStats)
+	mc.PutStore(newStore)
+}
+
+// UpdateStorageReadStats updates store written bytes.
+func (mc *Cluster) UpdateStorageReadStats(storeID, bytesWritten, keysWritten uint64) {
+	store := mc.GetStore(storeID)
+	newStats := proto.Clone(store.GetStoreStats()).(*pdpb.StoreStats)
+	newStats.BytesRead = bytesWritten
+	newStats.KeysRead = keysWritten
+	now := time.Now().Second()
+	interval := &pdpb.TimeInterval{StartTimestamp: uint64(now - statistics.StoreHeartBeatReportInterval), EndTimestamp: uint64(now)}
+	newStats.Interval = interval
+	newStore := store.Clone(core.SetStoreStats(newStats))
+	mc.Set(storeID, newStats)
+	mc.PutStore(newStore)
+}
+
+// UpdateStorageWrittenBytes updates store written bytes.
+func (mc *Cluster) UpdateStorageWrittenBytes(storeID uint64, bytesWritten uint64) {
+	store := mc.GetStore(storeID)
+	newStats := proto.Clone(store.GetStoreStats()).(*pdpb.StoreStats)
+	newStats.BytesWritten = bytesWritten
+	newStats.KeysWritten = bytesWritten / 100
 	now := time.Now().Second()
 	interval := &pdpb.TimeInterval{StartTimestamp: uint64(now - statistics.StoreHeartBeatReportInterval), EndTimestamp: uint64(now)}
 	newStats.Interval = interval
@@ -410,13 +436,11 @@ func (mc *Cluster) UpdateStorageWrittenBytes(storeID uint64, bytesWritten uint64
 }
 
 // UpdateStorageReadBytes updates store read bytes.
-func (mc *Cluster) UpdateStorageReadBytes(storeID uint64, bytesRead uint64, updateSingleOption ...struct{}) {
+func (mc *Cluster) UpdateStorageReadBytes(storeID uint64, bytesRead uint64) {
 	store := mc.GetStore(storeID)
 	newStats := proto.Clone(store.GetStoreStats()).(*pdpb.StoreStats)
 	newStats.BytesRead = bytesRead
-	if len(updateSingleOption) == 0 {
-		newStats.KeysRead = bytesRead / 100
-	}
+	newStats.KeysRead = bytesRead / 100
 	now := time.Now().Second()
 	interval := &pdpb.TimeInterval{StartTimestamp: uint64(now - statistics.StoreHeartBeatReportInterval), EndTimestamp: uint64(now)}
 	newStats.Interval = interval
@@ -426,13 +450,11 @@ func (mc *Cluster) UpdateStorageReadBytes(storeID uint64, bytesRead uint64, upda
 }
 
 // UpdateStorageWrittenKeys updates store written keys.
-func (mc *Cluster) UpdateStorageWrittenKeys(storeID uint64, keysWritten uint64, updateSingleOption ...struct{}) {
+func (mc *Cluster) UpdateStorageWrittenKeys(storeID uint64, keysWritten uint64) {
 	store := mc.GetStore(storeID)
 	newStats := proto.Clone(store.GetStoreStats()).(*pdpb.StoreStats)
 	newStats.KeysWritten = keysWritten
-	if len(updateSingleOption) == 0 {
-		newStats.BytesWritten = keysWritten * 100
-	}
+	newStats.BytesWritten = keysWritten * 100
 	now := time.Now().Second()
 	interval := &pdpb.TimeInterval{StartTimestamp: uint64(now - statistics.StoreHeartBeatReportInterval), EndTimestamp: uint64(now)}
 	newStats.Interval = interval
@@ -442,13 +464,11 @@ func (mc *Cluster) UpdateStorageWrittenKeys(storeID uint64, keysWritten uint64, 
 }
 
 // UpdateStorageReadKeys updates store read bytes.
-func (mc *Cluster) UpdateStorageReadKeys(storeID uint64, keysRead uint64, updateSingleOption ...struct{}) {
+func (mc *Cluster) UpdateStorageReadKeys(storeID uint64, keysRead uint64) {
 	store := mc.GetStore(storeID)
 	newStats := proto.Clone(store.GetStoreStats()).(*pdpb.StoreStats)
 	newStats.KeysRead = keysRead
-	if len(updateSingleOption) == 0 {
-		newStats.BytesRead = keysRead * 100
-	}
+	newStats.BytesRead = keysRead * 100
 	now := time.Now().Second()
 	interval := &pdpb.TimeInterval{StartTimestamp: uint64(now - statistics.StoreHeartBeatReportInterval), EndTimestamp: uint64(now)}
 	newStats.Interval = interval

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -394,10 +394,13 @@ func (mc *Cluster) UpdateStorageRatio(storeID uint64, usedRatio, availableRatio 
 }
 
 // UpdateStorageWrittenBytes updates store written bytes.
-func (mc *Cluster) UpdateStorageWrittenBytes(storeID uint64, bytesWritten uint64) {
+func (mc *Cluster) UpdateStorageWrittenBytes(storeID uint64, bytesWritten uint64, updateSingleOption ...struct{}) {
 	store := mc.GetStore(storeID)
 	newStats := proto.Clone(store.GetStoreStats()).(*pdpb.StoreStats)
 	newStats.BytesWritten = bytesWritten
+	if len(updateSingleOption) == 0 {
+		newStats.KeysWritten = bytesWritten / 100
+	}
 	now := time.Now().Second()
 	interval := &pdpb.TimeInterval{StartTimestamp: uint64(now - statistics.StoreHeartBeatReportInterval), EndTimestamp: uint64(now)}
 	newStats.Interval = interval
@@ -407,10 +410,13 @@ func (mc *Cluster) UpdateStorageWrittenBytes(storeID uint64, bytesWritten uint64
 }
 
 // UpdateStorageReadBytes updates store read bytes.
-func (mc *Cluster) UpdateStorageReadBytes(storeID uint64, bytesRead uint64) {
+func (mc *Cluster) UpdateStorageReadBytes(storeID uint64, bytesRead uint64, updateSingleOption ...struct{}) {
 	store := mc.GetStore(storeID)
 	newStats := proto.Clone(store.GetStoreStats()).(*pdpb.StoreStats)
 	newStats.BytesRead = bytesRead
+	if len(updateSingleOption) == 0 {
+		newStats.KeysRead = bytesRead / 100
+	}
 	now := time.Now().Second()
 	interval := &pdpb.TimeInterval{StartTimestamp: uint64(now - statistics.StoreHeartBeatReportInterval), EndTimestamp: uint64(now)}
 	newStats.Interval = interval
@@ -420,10 +426,13 @@ func (mc *Cluster) UpdateStorageReadBytes(storeID uint64, bytesRead uint64) {
 }
 
 // UpdateStorageWrittenKeys updates store written keys.
-func (mc *Cluster) UpdateStorageWrittenKeys(storeID uint64, keysWritten uint64) {
+func (mc *Cluster) UpdateStorageWrittenKeys(storeID uint64, keysWritten uint64, updateSingleOption ...struct{}) {
 	store := mc.GetStore(storeID)
 	newStats := proto.Clone(store.GetStoreStats()).(*pdpb.StoreStats)
 	newStats.KeysWritten = keysWritten
+	if len(updateSingleOption) == 0 {
+		newStats.BytesWritten = keysWritten * 100
+	}
 	now := time.Now().Second()
 	interval := &pdpb.TimeInterval{StartTimestamp: uint64(now - statistics.StoreHeartBeatReportInterval), EndTimestamp: uint64(now)}
 	newStats.Interval = interval
@@ -433,10 +442,13 @@ func (mc *Cluster) UpdateStorageWrittenKeys(storeID uint64, keysWritten uint64) 
 }
 
 // UpdateStorageReadKeys updates store read bytes.
-func (mc *Cluster) UpdateStorageReadKeys(storeID uint64, keysRead uint64) {
+func (mc *Cluster) UpdateStorageReadKeys(storeID uint64, keysRead uint64, updateSingleOption ...struct{}) {
 	store := mc.GetStore(storeID)
 	newStats := proto.Clone(store.GetStoreStats()).(*pdpb.StoreStats)
 	newStats.KeysRead = keysRead
+	if len(updateSingleOption) == 0 {
+		newStats.BytesRead = keysRead * 100
+	}
 	now := time.Now().Second()
 	interval := &pdpb.TimeInterval{StartTimestamp: uint64(now - statistics.StoreHeartBeatReportInterval), EndTimestamp: uint64(now)}
 	newStats.Interval = interval

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -19,6 +19,7 @@ import (
 	"math/rand"
 	"net/http"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 
@@ -254,6 +255,9 @@ func summaryStoresLoad(
 	kind core.ResourceKind,
 ) map[uint64]*storeLoadDetail {
 	loadDetail := make(map[uint64]*storeLoadDetail, len(storeByteRate))
+	allByteSum := 0.0
+	allKeySum := 0.0
+	allCount := 0.0
 
 	// Stores without byte rate statistics is not available to schedule.
 	for id, byteRate := range storeByteRate {
@@ -285,6 +289,9 @@ func summaryStoresLoad(
 				hotPeerSummary.WithLabelValues(ty, fmt.Sprintf("%v", id)).Set(keySum)
 			}
 		}
+		allByteSum += byteRate
+		allKeySum += keyRate
+		allCount += float64(len(hotPeers))
 
 		// Build store load prediction from current load and pending influence.
 		stLoadPred := (&storeLoad{
@@ -297,6 +304,29 @@ func summaryStoresLoad(
 		loadDetail[id] = &storeLoadDetail{
 			LoadPred: stLoadPred,
 			HotPeers: hotPeers,
+		}
+	}
+	storeLen := float64(len(storeByteRate))
+
+	for id, detail := range loadDetail {
+		byteExp := allByteSum / storeLen
+		keyExp := allKeySum / storeLen
+		countExp := allCount / storeLen
+		detail.LoadPred.Future.ExpByteRate = byteExp
+		detail.LoadPred.Future.ExpKeyRate = keyExp
+		detail.LoadPred.Future.ExpCount = countExp
+		// Debug
+		{
+			ty := "exp-byte-rate-" + rwTy.String() + "-" + kind.String()
+			hotPeerSummary.WithLabelValues(ty, fmt.Sprintf("%v", id)).Set(byteExp)
+		}
+		{
+			ty := "exp-key-rate-" + rwTy.String() + "-" + kind.String()
+			hotPeerSummary.WithLabelValues(ty, fmt.Sprintf("%v", id)).Set(keyExp)
+		}
+		{
+			ty := "exp-count-rate-" + rwTy.String() + "-" + kind.String()
+			hotPeerSummary.WithLabelValues(ty, fmt.Sprintf("%v", id)).Set(countExp)
 		}
 	}
 	return loadDetail
@@ -543,7 +573,12 @@ func (bs *balanceSolver) filterSrcStores() map[uint64]*storeLoadDetail {
 		if len(detail.HotPeers) == 0 {
 			continue
 		}
-		ret[id] = detail
+		if detail.LoadPred.min().ByteRate > bs.sche.conf.GetToleranceRatio()*detail.LoadPred.Future.ExpByteRate &&
+			detail.LoadPred.min().KeyRate > bs.sche.conf.GetToleranceRatio()*detail.LoadPred.Future.ExpKeyRate {
+			ret[id] = detail
+			balanceHotRegionCounter.WithLabelValues("src-store-succ", strconv.FormatUint(id, 10)).Inc()
+		}
+		balanceHotRegionCounter.WithLabelValues("src-store-failed", strconv.FormatUint(id, 10)).Inc()
 	}
 	return ret
 }
@@ -706,6 +741,13 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*storeLoadDetail {
 	ret := make(map[uint64]*storeLoadDetail, len(candidates))
 	for _, store := range candidates {
 		if filter.Target(bs.cluster, store, filters) {
+			detail := bs.stLoadDetail[store.GetID()]
+			if detail.LoadPred.max().ByteRate*bs.sche.conf.GetToleranceRatio() < detail.LoadPred.Future.ExpByteRate &&
+				detail.LoadPred.max().KeyRate*bs.sche.conf.GetToleranceRatio() < detail.LoadPred.Future.ExpKeyRate {
+				ret[store.GetID()] = bs.stLoadDetail[store.GetID()]
+				balanceHotRegionCounter.WithLabelValues("dst-store-succ", strconv.FormatUint(store.GetID(), 10)).Inc()
+			}
+			balanceHotRegionCounter.WithLabelValues("dst-store-fail", strconv.FormatUint(store.GetID(), 10)).Inc()
 			ret[store.GetID()] = bs.stLoadDetail[store.GetID()]
 		}
 	}
@@ -721,9 +763,8 @@ func (bs *balanceSolver) calcProgressiveRank() {
 	rank := int64(0)
 	if bs.rwTy == write && bs.opTy == transferLeader {
 		// In this condition, CPU usage is the matter.
-		// Only consider about count and key rate.
-		if srcLd.Count > dstLd.Count &&
-			srcLd.KeyRate >= dstLd.KeyRate+peer.GetKeyRate() {
+		// Only consider about key rate.
+		if srcLd.KeyRate >= dstLd.KeyRate+peer.GetKeyRate() {
 			rank = -1
 		}
 	} else {

--- a/server/schedulers/hot_region_config.go
+++ b/server/schedulers/hot_region_config.go
@@ -42,7 +42,7 @@ func initHotRegionScheduleConfig() *hotRegionSchedulerConfig {
 		GreatDecRatio:         0.95,
 		MinorDecRatio:         0.99,
 		MaxPeerNum:            1000,
-		ToleranceRatio:        1.02,
+		ToleranceRatio:        1.02, // Tolerate 2% difference
 	}
 }
 

--- a/server/schedulers/hot_region_config.go
+++ b/server/schedulers/hot_region_config.go
@@ -62,7 +62,7 @@ type hotRegionSchedulerConfig struct {
 	CountRankStepRatio    float64 `json:"count-rank-step-ratio"`
 	GreatDecRatio         float64 `json:"great-dec-ratio"`
 	MinorDecRatio         float64 `json:"minor-dec-ratio"`
-	ToleranceRatio        float64 `json:"minorDecRatio"`
+	ToleranceRatio        float64 `json:"tolerance-ratio"`
 }
 
 func (conf *hotRegionSchedulerConfig) EncodeConfig() ([]byte, error) {

--- a/server/schedulers/hot_region_config.go
+++ b/server/schedulers/hot_region_config.go
@@ -42,6 +42,7 @@ func initHotRegionScheduleConfig() *hotRegionSchedulerConfig {
 		GreatDecRatio:         0.95,
 		MinorDecRatio:         0.99,
 		MaxPeerNum:            1000,
+		ToleranceRatio:        1.02,
 	}
 }
 
@@ -61,6 +62,7 @@ type hotRegionSchedulerConfig struct {
 	CountRankStepRatio    float64 `json:"count-rank-step-ratio"`
 	GreatDecRatio         float64 `json:"great-dec-ratio"`
 	MinorDecRatio         float64 `json:"minor-dec-ratio"`
+	ToleranceRatio        float64 `json:"minorDecRatio"`
 }
 
 func (conf *hotRegionSchedulerConfig) EncodeConfig() ([]byte, error) {
@@ -79,6 +81,18 @@ func (conf *hotRegionSchedulerConfig) GetMaxPeerNumber() int {
 	conf.RLock()
 	defer conf.RUnlock()
 	return conf.MaxPeerNum
+}
+
+func (conf *hotRegionSchedulerConfig) GetToleranceRatio() float64 {
+	conf.RLock()
+	defer conf.RUnlock()
+	return conf.ToleranceRatio
+}
+
+func (conf *hotRegionSchedulerConfig) SetToleranceRatio(tol float64) {
+	conf.Lock()
+	defer conf.Unlock()
+	conf.ToleranceRatio = tol
 }
 
 func (conf *hotRegionSchedulerConfig) GetByteRankStepRatio() float64 {

--- a/server/schedulers/hot_test.go
+++ b/server/schedulers/hot_test.go
@@ -308,18 +308,11 @@ func (s *testHotWriteRegionSchedulerSuite) TestWithKeyRate(c *C) {
 	tc.AddRegionStore(4, 20)
 	tc.AddRegionStore(5, 20)
 
-	tc.UpdateStorageWrittenBytes(1, 10.5*MB*statistics.StoreHeartBeatReportInterval)
-	tc.UpdateStorageWrittenBytes(2, 9.5*MB*statistics.StoreHeartBeatReportInterval)
-	tc.UpdateStorageWrittenBytes(3, 9.5*MB*statistics.StoreHeartBeatReportInterval)
-	tc.UpdateStorageWrittenBytes(4, 9*MB*statistics.StoreHeartBeatReportInterval)
-	tc.UpdateStorageWrittenBytes(5, 8.9*MB*statistics.StoreHeartBeatReportInterval)
-
-	updateSingel := struct{}{}
-	tc.UpdateStorageWrittenKeys(1, 10.2*MB*statistics.StoreHeartBeatReportInterval, updateSingel)
-	tc.UpdateStorageWrittenKeys(2, 9.5*MB*statistics.StoreHeartBeatReportInterval, updateSingel)
-	tc.UpdateStorageWrittenKeys(3, 9.8*MB*statistics.StoreHeartBeatReportInterval, updateSingel)
-	tc.UpdateStorageWrittenKeys(4, 9*MB*statistics.StoreHeartBeatReportInterval, updateSingel)
-	tc.UpdateStorageWrittenKeys(5, 9.2*MB*statistics.StoreHeartBeatReportInterval, updateSingel)
+	tc.UpdateStorageWrittenStats(1, 10.5*MB*statistics.StoreHeartBeatReportInterval, 10.2*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageWrittenStats(2, 9.5*MB*statistics.StoreHeartBeatReportInterval, 9.5*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageWrittenStats(3, 9.5*MB*statistics.StoreHeartBeatReportInterval, 9.8*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageWrittenStats(4, 9*MB*statistics.StoreHeartBeatReportInterval, 9*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageWrittenStats(5, 8.9*MB*statistics.StoreHeartBeatReportInterval, 9.2*MB*statistics.StoreHeartBeatReportInterval)
 
 	addRegionInfo(tc, write, []testRegionInfo{
 		{1, []uint64{2, 1, 3}, 0.5 * MB, 0.5 * MB},
@@ -598,18 +591,11 @@ func (s *testHotReadRegionSchedulerSuite) TestWithKeyRate(c *C) {
 	tc.AddRegionStore(4, 20)
 	tc.AddRegionStore(5, 20)
 
-	tc.UpdateStorageReadBytes(1, 10.5*MB*statistics.StoreHeartBeatReportInterval)
-	tc.UpdateStorageReadBytes(2, 9.5*MB*statistics.StoreHeartBeatReportInterval)
-	tc.UpdateStorageReadBytes(3, 9.5*MB*statistics.StoreHeartBeatReportInterval)
-	tc.UpdateStorageReadBytes(4, 9*MB*statistics.StoreHeartBeatReportInterval)
-	tc.UpdateStorageReadBytes(5, 8.9*MB*statistics.StoreHeartBeatReportInterval)
-
-	updateSingel := struct{}{}
-	tc.UpdateStorageReadKeys(1, 10.2*MB*statistics.StoreHeartBeatReportInterval, updateSingel)
-	tc.UpdateStorageReadKeys(2, 9.5*MB*statistics.StoreHeartBeatReportInterval, updateSingel)
-	tc.UpdateStorageReadKeys(3, 9.8*MB*statistics.StoreHeartBeatReportInterval, updateSingel)
-	tc.UpdateStorageReadKeys(4, 9*MB*statistics.StoreHeartBeatReportInterval, updateSingel)
-	tc.UpdateStorageReadKeys(5, 9.2*MB*statistics.StoreHeartBeatReportInterval, updateSingel)
+	tc.UpdateStorageReadStats(1, 10.5*MB*statistics.StoreHeartBeatReportInterval, 10.2*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageReadStats(2, 9.5*MB*statistics.StoreHeartBeatReportInterval, 9.5*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageReadStats(3, 9.5*MB*statistics.StoreHeartBeatReportInterval, 9.8*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageReadStats(4, 9*MB*statistics.StoreHeartBeatReportInterval, 9*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageReadStats(5, 8.9*MB*statistics.StoreHeartBeatReportInterval, 9.2*MB*statistics.StoreHeartBeatReportInterval)
 
 	addRegionInfo(tc, read, []testRegionInfo{
 		{1, []uint64{1, 2, 4}, 0.5 * MB, 0.5 * MB},

--- a/server/schedulers/metrics.go
+++ b/server/schedulers/metrics.go
@@ -71,6 +71,14 @@ var balanceRegionCounter = prometheus.NewCounterVec(
 		Help:      "Counter of balance region scheduler.",
 	}, []string{"type", "address", "store"})
 
+var balanceHotRegionCounter = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "pd",
+		Subsystem: "scheduler",
+		Name:      "hot_region",
+		Help:      "Counter of hot region scheduler.",
+	}, []string{"type", "store"})
+
 var balanceDirectionCounter = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "pd",
@@ -101,6 +109,7 @@ func init() {
 	prometheus.MustRegister(hotPeerSummary)
 	prometheus.MustRegister(balanceLeaderCounter)
 	prometheus.MustRegister(balanceRegionCounter)
+	prometheus.MustRegister(balanceHotRegionCounter)
 	prometheus.MustRegister(balanceDirectionCounter)
 	prometheus.MustRegister(scatterRangeLeaderCounter)
 	prometheus.MustRegister(scatterRangeRegionCounter)

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -208,6 +208,10 @@ type storeLoad struct {
 	ByteRate float64
 	KeyRate  float64
 	Count    float64
+
+	ExpByteRate float64
+	ExpKeyRate  float64
+	ExpCount    float64
 }
 
 func (load *storeLoad) ToLoadPred(infl Influence) *storeLoadPred {


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
To prevent excessive redundant scheduling
![image](https://user-images.githubusercontent.com/6428910/77816502-11bfad80-70fe-11ea-8603-aa0fa5abb69a.png)        
### What is changed and how it works?
add the avg load as an expectation.




### Release note <!-- bugfixes or new feature need a release note -->


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test
 - Manual test
the scheduler operator is reduced and QPS is stable.
![image](https://user-images.githubusercontent.com/6428910/77816796-bfcc5700-7100-11ea-9515-f903f9cb9551.png)
