### PR TITLE
schedulers/hot: let leader can be schedule even if the peer is not balanced

### DIFF
--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -75,10 +75,8 @@ const (
 	maxHotScheduleInterval = 20 * time.Second
 )
 
-var (
-	randomUpperBound = 3
-	randomLowBound   = 0
-)
+// schedulePeerPr the probability of schedule the hot peer.
+var schedulePeerPr = 0.66
 
 type hotScheduler struct {
 	name string
@@ -404,9 +402,9 @@ func (h *hotScheduler) balanceHotReadRegions(cluster opt.Cluster) []*operator.Op
 
 func (h *hotScheduler) balanceHotWriteRegions(cluster opt.Cluster) []*operator.Operator {
 	// prefer to balance by peer
-	seed := h.r.Intn(randomUpperBound-randomLowBound) + randomLowBound
+	s := h.r.Intn(100)
 	switch {
-	case seed > 0:
+	case s < int(schedulePeerPr*100):
 		peerSolver := newBalanceSolver(h, cluster, write, movePeer)
 		ops := peerSolver.solve()
 		if len(ops) > 0 {

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -71,7 +71,6 @@ const (
 	// HotWriteRegionType is hot write region scheduler type.
 	HotWriteRegionType = "hot-write-region"
 
-	hotRegionLimitFactor   = 0.75
 	minHotScheduleInterval = time.Second
 	maxHotScheduleInterval = 20 * time.Second
 )

--- a/server/schedulers/hot_test.go
+++ b/server/schedulers/hot_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func init() {
-	randomLowBound = 1
+	schedulePeerPr = 1.0
 }
 
 var _ = Suite(&testHotWriteRegionSchedulerSuite{})

--- a/server/schedulers/hot_test.go
+++ b/server/schedulers/hot_test.go
@@ -29,6 +29,10 @@ import (
 	"github.com/pingcap/pd/v4/server/statistics"
 )
 
+func init() {
+	randomLowBound = 1
+}
+
 var _ = Suite(&testHotWriteRegionSchedulerSuite{})
 var _ = Suite(&testHotSchedulerSuite{})
 


### PR DESCRIPTION
…lanced

Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
In this scenario: 9 tikv, running with a workload  `oltp_insert` (6 tables)
- the count is not suitable for calculating limit because there are many hot regions (index) and only 6 very hot regions (row data)
- there are too many hot regions, so the hot leader may have no chance to be scheduled.
![image](https://user-images.githubusercontent.com/6428910/77829603-08662d80-715e-11ea-9146-14b765a853da.png)
![image](https://user-images.githubusercontent.com/6428910/77829619-22077500-715e-11ea-9c72-b348869fdc97.png)



### What is changed and how it works?
- remove the auto limit
- randomly schedule peer or leader.

### Release note <!-- bugfixes or new feature need a release note -->


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test 
