### PR TITLE
support change multi config at a time

### DIFF
--- a/server/api/middleware.go
+++ b/server/api/middleware.go
@@ -209,6 +209,9 @@ func handleComponentPost(s *server.Server, r *http.Request) (*http.Request, int,
 	component = cm.GetComponent(componentInfo)
 	cm.RUnlock()
 	if component == "" {
+		if strings.Contains(componentInfo, ":") {
+			return nil, http.StatusBadRequest, errors.Errorf("invalid component id: %v", componentInfo)
+		}
 		component = componentInfo
 		kind = globalKind
 	} else {

--- a/tests/pdctl/component/component_test.go
+++ b/tests/pdctl/component/component_test.go
@@ -108,4 +108,18 @@ func (s *componentTestSuite) TestComponent(c *C) {
 		c.Assert(strings.Contains(obtain, `location-labels = ["zone", "rack"]`), IsTrue)
 		c.Assert(strings.Contains(obtain, `level = "warn"`), IsTrue)
 	}
+
+	// change multi config at one time
+	args = []string{"-u", pdAddrs[0], "component", "set", "pd", "schedule.high-space-ratio", "0.3", "schedule.low-space-ratio", "0.4"}
+	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	c.Assert(err, IsNil)
+	time.Sleep(20 * time.Millisecond)
+	for i := 0; i < len(pdAddrs); i++ {
+		args = []string{"-u", pdAddrs[0], "component", "show", pdAddrs[i][7:]}
+		_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+		c.Assert(err, IsNil)
+		obtain := string(output)
+		c.Assert(strings.Contains(obtain, "high-space-ratio = 0.3"), IsTrue)
+		c.Assert(strings.Contains(obtain, "low-space-ratio = 0.4"), IsTrue)
+	}
 }

--- a/tests/pdctl/component/component_test.go
+++ b/tests/pdctl/component/component_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/v4/server"
+	"github.com/pingcap/pd/v4/server/config"
 	"github.com/pingcap/pd/v4/tests"
 	"github.com/pingcap/pd/v4/tests/pdctl"
 )
@@ -42,7 +43,7 @@ func (s *componentTestSuite) SetUpSuite(c *C) {
 func (s *componentTestSuite) TestComponent(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	cluster, err := tests.NewTestCluster(ctx, 2)
+	cluster, err := tests.NewTestCluster(ctx, 2, func(cfg *config.Config) { cfg.EnableDynamicConfig = true })
 	c.Assert(err, IsNil)
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)

--- a/tools/pd-ctl/pdctl/command/component_command.go
+++ b/tools/pd-ctl/pdctl/command/component_command.go
@@ -136,14 +136,16 @@ func getComponentIDCommandFunc(cmd *cobra.Command, args []string) {
 	cmd.Println(r)
 }
 
-func postComponentConfigData(cmd *cobra.Command, componentInfo, key, value string) error {
-	var val interface{}
+func postComponentConfigData(cmd *cobra.Command, componentInfo string, kvPairs map[string]string) error {
 	data := make(map[string]interface{})
-	val, err := strconv.ParseFloat(value, 64)
-	if err != nil {
-		val = value
+	for k, v := range kvPairs {
+		var val interface{}
+		val, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			val = v
+		}
+		data[k] = val
 	}
-	data[key] = val
 	data["componentInfo"] = componentInfo
 
 	reqData, err := json.Marshal(&data)
@@ -160,12 +162,16 @@ func postComponentConfigData(cmd *cobra.Command, componentInfo, key, value strin
 }
 
 func setComponentConfigCommandFunc(cmd *cobra.Command, args []string) {
-	if len(args) != 3 {
-		cmd.Println(cmd.UsageString())
+	if len(args) < 3 || len(args)%2 != 1 {
+		cmd.Usage()
 		return
 	}
-	componentInfo, opt, val := args[0], args[1], args[2]
-	err := postComponentConfigData(cmd, componentInfo, opt, val)
+	kvPairs := make(map[string]string)
+	for i := 1; i < len(args); i += 2 {
+		kvPairs[args[i]] = args[i+1]
+	}
+	componentInfo := args[0]
+	err := postComponentConfigData(cmd, componentInfo, kvPairs)
 	if err != nil {
 		cmd.Printf("Failed to set component config: %s\n", err)
 		return


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Sometimes, we need to change multi configs at a time, especially for the configs of TiKV.

### What is changed and how it works?
This PR changes the component subcommand to support accepting multi arguments.

### Release note <!-- bugfixes or new feature need a release note -->
Support changing multi config at a time

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test