### PR TITLE
config: disable dynamic config by default

### DIFF
--- a/pkg/dashboard/manager.go
+++ b/pkg/dashboard/manager.go
@@ -100,6 +100,9 @@ func (m *Manager) updateInfo() {
 		m.isLeader = false
 		m.rc = nil
 		m.members = nil
+		if !m.enableDynamic {
+			m.srv.GetScheduleOption().Reload(m.srv.GetStorage())
+		}
 		return
 	}
 
@@ -184,12 +187,15 @@ func (m *Manager) setNewAddress() {
 		}
 	}
 	// set new dashboard address
-	m.rc.SetDashboardAddress(addr)
 	if m.enableDynamic {
 		if err := m.srv.UpdateConfigManager("pd-server.dashboard-address", addr); err != nil {
 			log.Error("failed to update the dashboard address in config manager", zap.Error(err))
 		}
+		return
 	}
+	cfg := m.srv.GetScheduleOption().GetPDServerConfig().Clone()
+	cfg.DashboardAddress = addr
+	m.srv.SetPDServerConfig(*cfg)
 }
 
 func (m *Manager) startService() {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1421,16 +1421,6 @@ func (c *RaftCluster) GetKeyType() core.KeyType {
 	return c.opt.GetKeyType()
 }
 
-// GetDashboardAddress gets dashboard address.
-func (c *RaftCluster) GetDashboardAddress() string {
-	return c.opt.GetDashboardAddress()
-}
-
-// SetDashboardAddress sets dashboard address.
-func (c *RaftCluster) SetDashboardAddress(address string) {
-	c.opt.SetDashboardAddress(address)
-}
-
 // IsReplaceOfflineReplicaEnabled returns if replace offline replica is enabled.
 func (c *RaftCluster) IsReplaceOfflineReplicaEnabled() bool {
 	return c.opt.IsReplaceOfflineReplicaEnabled()

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -208,7 +208,7 @@ const (
 	defaultEnableGRPCGateway   = true
 	defaultDisableErrorVerbose = true
 
-	defaultEnableDynamicConfig = true
+	defaultEnableDynamicConfig = false
 	defaultDashboardAddress    = "auto"
 
 	defaultDRWaitStoreTimeout = time.Minute

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -951,7 +951,8 @@ func (c *PDServerConfig) adjust(meta *configMetaData) error {
 	return nil
 }
 
-func (c *PDServerConfig) clone() *PDServerConfig {
+// Clone retruns a cloned PD server config.
+func (c *PDServerConfig) Clone() *PDServerConfig {
 	runtimeServices := make(typeutil.StringSlice, len(c.RuntimeServices))
 	copy(runtimeServices, c.RuntimeServices)
 	return &PDServerConfig{

--- a/server/config/option.go
+++ b/server/config/option.go
@@ -221,14 +221,6 @@ func (o *ScheduleOption) GetDashboardAddress() string {
 	return o.LoadPDServerConfig().DashboardAddress
 }
 
-// SetDashboardAddress sets the number of replicas for each region.
-func (o *ScheduleOption) SetDashboardAddress(address string) {
-	c := o.LoadPDServerConfig()
-	v := c.clone()
-	v.DashboardAddress = address
-	o.SetPDServerConfig(v)
-}
-
 // IsRemoveDownReplicaEnabled returns if remove down replica is enabled.
 func (o *ScheduleOption) IsRemoveDownReplicaEnabled() bool {
 	return o.Load().EnableRemoveDownReplica

--- a/server/server.go
+++ b/server/server.go
@@ -365,6 +365,9 @@ func (s *Server) startServer(ctx context.Context) error {
 	s.storage = core.NewStorage(kvBase).SetRegionStorage(regionStorage)
 	s.basicCluster = core.NewBasicCluster()
 	s.cluster = cluster.NewRaftCluster(ctx, s.GetClusterRootPath(), s.clusterID, syncer.NewRegionSyncer(s), s.client)
+	if !s.cfg.EnableDynamicConfig {
+		s.cluster.SetConfigCheck()
+	}
 	s.hbStreams = newHeartbeatStreams(ctx, s.clusterID, s.cluster)
 
 	// Run callbacks

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -162,7 +162,10 @@ func (s *clusterTestSuite) TestGetPutConfig(c *C) {
 }
 
 func (s *clusterTestSuite) TestReloadConfig(c *C) {
-	tc, err := tests.NewTestCluster(s.ctx, 3, func(conf *config.Config) { conf.PDServerCfg.UseRegionStorage = true })
+	tc, err := tests.NewTestCluster(s.ctx, 3, func(conf *config.Config) {
+		conf.PDServerCfg.UseRegionStorage = true
+		conf.EnableDynamicConfig = true
+	})
 	defer tc.Destroy()
 	c.Assert(err, IsNil)
 

--- a/tools/pd-ctl/pdctl/command/component_command.go
+++ b/tools/pd-ctl/pdctl/command/component_command.go
@@ -64,7 +64,7 @@ func NewDeleteComponentConfigCommand() *cobra.Command {
 // NewSetComponentConfigCommand return a set subcommand of componentCmd.
 func NewSetComponentConfigCommand() *cobra.Command {
 	sc := &cobra.Command{
-		Use:   "set [<component>|<component ID>] <option> <value>",
+		Use:   "set [<component>|<component ID>] <option> <value> [<option> <value>]...",
 		Short: "set the component config (set option with value)",
 		Run:   setComponentConfigCommandFunc,
 	}


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Since there are some problems in dynamic config, we will disable it by default.

### What is changed and how it works?
Just as above says.

### Release note <!-- bugfixes or new feature need a release note -->
Disable dynamic configuration change by default

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has configuration change
