### PR TITLE
schedulers: add src and dst tolerance ratio for hot scheduler

### DIFF
--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -589,8 +589,8 @@ func (bs *balanceSolver) filterSrcStores() map[uint64]*storeLoadDetail {
 		if len(detail.HotPeers) == 0 {
 			continue
 		}
-		if detail.LoadPred.min().ByteRate > bs.sche.conf.GetToleranceRatio()*detail.LoadPred.Future.ExpByteRate &&
-			detail.LoadPred.min().KeyRate > bs.sche.conf.GetToleranceRatio()*detail.LoadPred.Future.ExpKeyRate {
+		if detail.LoadPred.min().ByteRate > bs.sche.conf.GetSrcToleranceRatio()*detail.LoadPred.Future.ExpByteRate &&
+			detail.LoadPred.min().KeyRate > bs.sche.conf.GetSrcToleranceRatio()*detail.LoadPred.Future.ExpKeyRate {
 			ret[id] = detail
 			balanceHotRegionCounter.WithLabelValues("src-store-succ", strconv.FormatUint(id, 10)).Inc()
 		}
@@ -758,8 +758,8 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*storeLoadDetail {
 	for _, store := range candidates {
 		if filter.Target(bs.cluster, store, filters) {
 			detail := bs.stLoadDetail[store.GetID()]
-			if detail.LoadPred.max().ByteRate*bs.sche.conf.GetToleranceRatio() < detail.LoadPred.Future.ExpByteRate &&
-				detail.LoadPred.max().KeyRate*bs.sche.conf.GetToleranceRatio() < detail.LoadPred.Future.ExpKeyRate {
+			if detail.LoadPred.max().ByteRate*bs.sche.conf.GetDstToleranceRatio() < detail.LoadPred.Future.ExpByteRate &&
+				detail.LoadPred.max().KeyRate*bs.sche.conf.GetDstToleranceRatio() < detail.LoadPred.Future.ExpKeyRate {
 				ret[store.GetID()] = bs.stLoadDetail[store.GetID()]
 				balanceHotRegionCounter.WithLabelValues("dst-store-succ", strconv.FormatUint(store.GetID(), 10)).Inc()
 			}

--- a/server/schedulers/hot_region_config.go
+++ b/server/schedulers/hot_region_config.go
@@ -42,8 +42,8 @@ func initHotRegionScheduleConfig() *hotRegionSchedulerConfig {
 		GreatDecRatio:         0.95,
 		MinorDecRatio:         0.99,
 		MaxPeerNum:            1000,
-		SrcToleranceRatio:     1.05, // Tolerate 2% difference
-		DstToleranceRatio:     1.00, // Tolerate 2% difference
+		SrcToleranceRatio:     1.02, // Tolerate 2% difference
+		DstToleranceRatio:     1.02, // Tolerate 2% difference
 	}
 }
 

--- a/server/schedulers/hot_region_config.go
+++ b/server/schedulers/hot_region_config.go
@@ -42,7 +42,8 @@ func initHotRegionScheduleConfig() *hotRegionSchedulerConfig {
 		GreatDecRatio:         0.95,
 		MinorDecRatio:         0.99,
 		MaxPeerNum:            1000,
-		ToleranceRatio:        1.02, // Tolerate 2% difference
+		SrcToleranceRatio:     1.05, // Tolerate 2% difference
+		DstToleranceRatio:     1.00, // Tolerate 2% difference
 	}
 }
 
@@ -62,7 +63,8 @@ type hotRegionSchedulerConfig struct {
 	CountRankStepRatio    float64 `json:"count-rank-step-ratio"`
 	GreatDecRatio         float64 `json:"great-dec-ratio"`
 	MinorDecRatio         float64 `json:"minor-dec-ratio"`
-	ToleranceRatio        float64 `json:"tolerance-ratio"`
+	SrcToleranceRatio     float64 `json:"src-tolerance-ratio"`
+	DstToleranceRatio     float64 `json:"dst-tolerance-ratio"`
 }
 
 func (conf *hotRegionSchedulerConfig) EncodeConfig() ([]byte, error) {
@@ -83,16 +85,28 @@ func (conf *hotRegionSchedulerConfig) GetMaxPeerNumber() int {
 	return conf.MaxPeerNum
 }
 
-func (conf *hotRegionSchedulerConfig) GetToleranceRatio() float64 {
+func (conf *hotRegionSchedulerConfig) GetSrcToleranceRatio() float64 {
 	conf.RLock()
 	defer conf.RUnlock()
-	return conf.ToleranceRatio
+	return conf.SrcToleranceRatio
 }
 
-func (conf *hotRegionSchedulerConfig) SetToleranceRatio(tol float64) {
+func (conf *hotRegionSchedulerConfig) SetSrcToleranceRatio(tol float64) {
 	conf.Lock()
 	defer conf.Unlock()
-	conf.ToleranceRatio = tol
+	conf.SrcToleranceRatio = tol
+}
+
+func (conf *hotRegionSchedulerConfig) GetDstToleranceRatio() float64 {
+	conf.RLock()
+	defer conf.RUnlock()
+	return conf.DstToleranceRatio
+}
+
+func (conf *hotRegionSchedulerConfig) SetDstToleranceRatio(tol float64) {
+	conf.Lock()
+	defer conf.Unlock()
+	conf.DstToleranceRatio = tol
 }
 
 func (conf *hotRegionSchedulerConfig) GetByteRankStepRatio() float64 {

--- a/server/schedulers/hot_test.go
+++ b/server/schedulers/hot_test.go
@@ -302,7 +302,8 @@ func (s *testHotWriteRegionSchedulerSuite) TestWithKeyRate(c *C) {
 	opt := mockoption.NewScheduleOptions()
 	hb, err := schedule.CreateScheduler(HotWriteRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), nil)
 	c.Assert(err, IsNil)
-	hb.(*hotScheduler).conf.SetToleranceRatio(1)
+	hb.(*hotScheduler).conf.SetDstToleranceRatio(1)
+	hb.(*hotScheduler).conf.SetSrcToleranceRatio(1)
 	opt.HotRegionCacheHitsThreshold = 0
 
 	tc := mockcluster.NewCluster(opt)
@@ -585,7 +586,8 @@ func (s *testHotReadRegionSchedulerSuite) TestWithKeyRate(c *C) {
 	opt := mockoption.NewScheduleOptions()
 	hb, err := schedule.CreateScheduler(HotReadRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), nil)
 	c.Assert(err, IsNil)
-	hb.(*hotScheduler).conf.SetToleranceRatio(1)
+	hb.(*hotScheduler).conf.SetSrcToleranceRatio(1)
+	hb.(*hotScheduler).conf.SetDstToleranceRatio(1)
 	opt.HotRegionCacheHitsThreshold = 0
 
 	tc := mockcluster.NewCluster(opt)


### PR DESCRIPTION
Signed-off-by: lhy1024 <admin@liudos.us>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

After #2297, we introduce hot tolerance. After some tests, we found there need to be more accurate config

### What is changed and how it works?

This PR split tolerance to two configs, src and dst.

### Release note <!-- bugfixes or new feature need a release note -->


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test