### PR TITLE
config: fix data race in config manager

### DIFF
--- a/server/api/config.go
+++ b/server/api/config.go
@@ -423,7 +423,8 @@ func (h *confHandler) SetClusterVersion(w http.ResponseWriter, r *http.Request) 
 
 	if h.svr.GetConfig().EnableDynamicConfig {
 		kind := &configpb.ConfigKind{Kind: &configpb.ConfigKind_Global{Global: &configpb.Global{Component: server.Component}}}
-		v := &configpb.Version{Global: h.svr.GetConfigManager().GlobalCfgs[server.Component].GetVersion()}
+		cm := h.svr.GetConfigManager()
+		v := &configpb.Version{Global: cm.GetGlobalVersion(cm.GetGlobalConfigs(server.Component))}
 		entry := &configpb.ConfigEntry{Name: "cluster-version", Value: version}
 		client := h.svr.GetConfigClient()
 		if client == nil {

--- a/server/api/util.go
+++ b/server/api/util.go
@@ -127,7 +127,7 @@ func redirectUpdateReq(ctx context.Context, client pd.ConfigClient, cm *configma
 		configEntry := &configpb.ConfigEntry{Name: e.key, Value: e.value}
 		configEntries = append(configEntries, configEntry)
 	}
-	version := &configpb.Version{Global: cm.GlobalCfgs[server.Component].GetVersion()}
+	version := &configpb.Version{Global: cm.GetGlobalVersion(cm.GetGlobalConfigs(server.Component))}
 	kind := &configpb.ConfigKind{Kind: &configpb.ConfigKind_Global{Global: &configpb.Global{Component: server.Component}}}
 	status, _, err := client.Update(ctx, version, kind, configEntries)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -912,18 +912,16 @@ func (s *Server) DeleteLabelProperty(typ, labelKey, labelValue string) error {
 
 // UpdateConfigManager is used to update config manager directly.
 func (s *Server) UpdateConfigManager(name, value string) error {
-	configManager := s.GetConfigManager()
-	globalVersion := configManager.GetGlobalConfigs(Component).GetVersion()
+	cm := s.GetConfigManager()
+	globalVersion := cm.GetGlobalVersion(cm.GetGlobalConfigs(Component))
 	version := &configpb.Version{Global: globalVersion}
 	entries := []*configpb.ConfigEntry{{Name: name, Value: value}}
-	configManager.Lock()
-	_, status := configManager.UpdateGlobal(Component, version, entries)
-	configManager.Unlock()
+	_, status := cm.UpdateGlobal(Component, version, entries)
 	if status.GetCode() != configpb.StatusCode_OK {
 		return errors.New(status.GetMessage())
 	}
 
-	return configManager.Persist(s.GetStorage())
+	return cm.Persist(s.GetStorage())
 }
 
 // GetLabelProperty returns the whole label property config.


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fixes #2309.

### What is changed and how it works?
This PR adds some `*Locked` functions to avoid using lock outside of the config manager.

### Release note <!-- bugfixes or new feature need a release note -->
Fix a data race when getting the version from the config manager.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test