### PR TITLE
cluster: fix TestDispatch

### DIFF
--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -179,7 +179,7 @@ func (s *testCoordinatorSuite) TestBasic(c *C) {
 }
 
 func (s *testCoordinatorSuite) TestDispatch(c *C) {
-	tc, co, cleanup := prepare(nil, nil, func(co *coordinator) { co.run() }, c)
+	tc, co, cleanup := prepare(nil, nil, nil, c)
 	defer cleanup()
 
 	// Transfer peer from store 4 to store 1.
@@ -195,6 +195,8 @@ func (s *testCoordinatorSuite) TestDispatch(c *C) {
 	c.Assert(tc.updateLeaderCount(2, 20), IsNil)
 	c.Assert(tc.updateLeaderCount(1, 10), IsNil)
 	c.Assert(tc.addLeaderRegion(2, 4, 3, 2), IsNil)
+
+	co.run()
 
 	// Wait for schedule and turn off balance.
 	waitOperator(c, co, 1)
@@ -287,6 +289,7 @@ func prepare(setCfg func(*config.ScheduleConfig), setTc func(*testCluster), run 
 		setTc(tc)
 	}
 	tc.RaftCluster.configCheck = true
+	tc.RaftCluster.prepareChecker.isPrepared = true
 	co := newCoordinator(ctx, tc.RaftCluster, hbStreams)
 	if run != nil {
 		run(co)

--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -179,7 +179,7 @@ func (s *testCoordinatorSuite) TestBasic(c *C) {
 }
 
 func (s *testCoordinatorSuite) TestDispatch(c *C) {
-	tc, co, cleanup := prepare(nil, nil, nil, c)
+	tc, co, cleanup := prepare(nil, func(tc *testCluster) { tc.prepareChecker.isPrepared = true }, nil, c)
 	defer cleanup()
 
 	// Transfer peer from store 4 to store 1.
@@ -289,7 +289,6 @@ func prepare(setCfg func(*config.ScheduleConfig), setTc func(*testCluster), run 
 		setTc(tc)
 	}
 	tc.RaftCluster.configCheck = true
-	tc.RaftCluster.prepareChecker.isPrepared = true
 	co := newCoordinator(ctx, tc.RaftCluster, hbStreams)
 	if run != nil {
 		run(co)


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fix https://github.com/pingcap/pd/issues/1925

### What is changed and how it works?
we were expecting transfer leader 4->2, but sometimes it got 4->3, the reason is that balance leader scheduler and test code run concurrently. Possible execution sequence:

1. test: `tc.updateLeaderCount(4, 50)` (leader count 1:0, 2:0, 3:0, 4:50)
2. scheduler: sort stores by leader count (order 4, 1, 2, 3)
3. test: continue update leader counts (leader count 1:10, 2:20, 3:50, 4:50)
4. test: put region (leader:4, follower: 2, 3)
5. scheduler: select the region and create balance leader 4->3

how to fix: run coordinator after done all setups

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
   add some time.Sleep and test 20000 times.