### PR TITLE
tests: fix data race in TestSetScheduleOpt

### DIFF
--- a/pkg/dashboard/manager.go
+++ b/pkg/dashboard/manager.go
@@ -30,9 +30,8 @@ import (
 	"github.com/pingcap/pd/v4/server/cluster"
 )
 
-const (
-	checkInterval = time.Second
-)
+// CheckInterval is used to check if the dashboard address is switched
+var CheckInterval = time.Second
 
 // Manager is used to control dashboard.
 type Manager struct {
@@ -79,7 +78,7 @@ func (m *Manager) serviceLoop() {
 	defer logutil.LogPanic()
 	defer m.wg.Done()
 
-	ticker := time.NewTicker(checkInterval)
+	ticker := time.NewTicker(CheckInterval)
 	defer ticker.Stop()
 
 	for {

--- a/server/server.go
+++ b/server/server.go
@@ -652,7 +652,8 @@ func (s *Server) GetStorage() *core.Storage {
 	return s.storage
 }
 
-// SetStorage changes the storage for test purpose.
+// SetStorage changes the storage only for test purpose.
+// When we use it, we should prevent calling GetStorage, otherwise, it may cause a data race problem.
 func (s *Server) SetStorage(storage *core.Storage) {
 	s.storage = storage
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with a summary if it exists-->
Due to TestSetScheduleOpt uses `SetStorage` to change the storage, it may cause a race problem. This is because we may call `GetStorage` in other places at the same time. The problem only affects the testing. Fixes #2316 

### What is changed and how it works?
This PR prevents calling `GetStorage` manually by disabling dynamic config and increasing the check interval of the dashboard.

### Release note <!-- bugfixes or new feature need a release note -->


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test