### PR TITLE
pd-ctl: fix scheduler config balance-hot-region-scheduler list

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,7 @@ github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pO
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=

--- a/tests/pdctl/scheduler/scheduler_test.go
+++ b/tests/pdctl/scheduler/scheduler_test.go
@@ -239,4 +239,27 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 	c.Assert(strings.Contains(echo, "Success!"), IsTrue)
 	echo = pdctl.GetEcho([]string{"-u", pdAddr, "scheduler", "remove", "balance-region-scheduler"})
 	c.Assert(strings.Contains(echo, "Success!"), IsFalse)
+
+	// test hot region config
+	var conf map[string]interface{}
+	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "list"}, &conf)
+	expected1 := map[string]interface{}{
+		"min-hot-byte-rate":         float64(100),
+		"min-hot-key-rate":          float64(10),
+		"max-zombie-rounds":         float64(3),
+		"max-peer-number":           float64(1000),
+		"byte-rate-rank-step-ratio": 0.05,
+		"key-rate-rank-step-ratio":  0.05,
+		"count-rank-step-ratio":     0.01,
+		"great-dec-ratio":           0.95,
+		"minor-dec-ratio":           0.99,
+		"src-tolerance-ratio":       1.02,
+		"dst-tolerance-ratio":       1.02,
+	}
+	c.Assert(conf, DeepEquals, expected1)
+	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "set", "src-tolerance-ratio", "1.05"}, nil)
+	expected1["src-tolerance-ratio"] = 1.05
+	var conf1 map[string]interface{}
+	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler"}, &conf1)
+	c.Assert(conf1, DeepEquals, expected1)
 }

--- a/tools/pd-ctl/pdctl/command/scheduler.go
+++ b/tools/pd-ctl/pdctl/command/scheduler.go
@@ -528,7 +528,11 @@ func listSchedulerConfigCommandFunc(cmd *cobra.Command, args []string) {
 		cmd.Println(cmd.UsageString())
 		return
 	}
-	path := path.Join(schedulerConfigPrefix, cmd.Name(), "list")
+	p := cmd.Name()
+	if p == "list" {
+		p = cmd.Parent().Name()
+	}
+	path := path.Join(schedulerConfigPrefix, p, "list")
 	r, err := doRequest(cmd, path, http.MethodGet)
 	if err != nil {
 		cmd.Println(err)


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fixes #2320.

### What is changed and how it works?
This PR changes the path of list command and adds tests for the hot region scheduler.

### Release note <!-- bugfixes or new feature need a release note -->
Fix scheduler config balance-hot-region-scheduler list command in pd-ctl

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test