### PR TITLE
api: return 404 when scheduler is not found

### DIFF
--- a/server/api/scheduler_test.go
+++ b/server/api/scheduler_test.go
@@ -76,14 +76,15 @@ func (s *testScheduleSuite) TestOriginAPI(c *C) {
 	c.Assert(readJSON(listURL, &resp1), IsNil)
 	c.Assert(resp1["store-id-ranges"], HasLen, 1)
 	deleteURL = fmt.Sprintf("%s/%s", s.urlPrefix, "evict-leader-scheduler-2")
-	_, err = doDelete(deleteURL)
+	res, err := doDelete(deleteURL)
 	c.Assert(err, IsNil)
+	c.Assert(res.StatusCode, Equals, 200)
 	c.Assert(rc.GetSchedulers(), HasLen, 0)
 	resp2 := make(map[string]interface{})
 	c.Assert(readJSON(listURL, &resp2), NotNil)
 
 	r, _ := doDelete(deleteURL)
-	c.Assert(r.StatusCode, Equals, 500)
+	c.Assert(r.StatusCode, Equals, 404)
 }
 
 func (s *testScheduleSuite) TestAPI(c *C) {
@@ -174,6 +175,9 @@ func (s *testScheduleSuite) TestAPI(c *C) {
 				c.Assert(readJSON(listURL, &resp), IsNil)
 				delete(exceptMap, "2")
 				c.Assert(resp["store-id-ranges"], DeepEquals, exceptMap)
+				res, err := doDelete(deleteURL)
+				c.Assert(err, IsNil)
+				c.Assert(res.StatusCode, Equals, 404)
 			},
 		},
 		{
@@ -235,6 +239,9 @@ func (s *testScheduleSuite) TestAPI(c *C) {
 				c.Assert(readJSON(listURL, &resp), IsNil)
 				delete(exceptMap, "2")
 				c.Assert(resp["store-id-ranges"], DeepEquals, exceptMap)
+				res, err := doDelete(deleteURL)
+				c.Assert(err, IsNil)
+				c.Assert(res.StatusCode, Equals, 404)
 			},
 		},
 	}

--- a/server/cluster/cluster_worker.go
+++ b/server/cluster/cluster_worker.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/pd/v4/server/core"
 	"github.com/pingcap/pd/v4/server/schedule"
+	"github.com/pingcap/pd/v4/server/schedulers"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -111,7 +112,7 @@ func (c *RaftCluster) HandleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*
 	for i := 0; i < int(splitCount); i++ {
 		newRegionID, err := c.id.Alloc()
 		if err != nil {
-			return nil, ErrSchedulerNotFound
+			return nil, schedulers.ErrSchedulerNotFound
 		}
 
 		peerIDs := make([]uint64, len(request.Region.Peers))

--- a/server/schedulers/evict_leader.go
+++ b/server/schedulers/evict_leader.go
@@ -346,7 +346,11 @@ func (handler *evictLeaderHandler) DeleteConfig(w http.ResponseWriter, r *http.R
 		}
 		if last {
 			if err := handler.config.cluster.RemoveScheduler(EvictLeaderName); err != nil {
-				handler.rd.JSON(w, http.StatusInternalServerError, err)
+				if err == ErrSchedulerNotFound {
+					handler.rd.JSON(w, http.StatusNotFound, err)
+				} else {
+					handler.rd.JSON(w, http.StatusInternalServerError, err)
+				}
 				return
 			}
 			resp = lastStoreDeleteInfo
@@ -355,7 +359,7 @@ func (handler *evictLeaderHandler) DeleteConfig(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	handler.rd.JSON(w, http.StatusInternalServerError, ErrScheduleConfigNotExist)
+	handler.rd.JSON(w, http.StatusNotFound, ErrScheduleConfigNotExist)
 }
 
 func newEvictLeaderHandler(config *evictLeaderSchedulerConfig) http.Handler {

--- a/server/schedulers/grant_leader.go
+++ b/server/schedulers/grant_leader.go
@@ -296,7 +296,11 @@ func (handler *grantLeaderHandler) DeleteConfig(w http.ResponseWriter, r *http.R
 		}
 		if last {
 			if err := handler.config.cluster.RemoveScheduler(GrantLeaderName); err != nil {
-				handler.rd.JSON(w, http.StatusInternalServerError, err)
+				if err == ErrSchedulerNotFound {
+					handler.rd.JSON(w, http.StatusNotFound, err)
+				} else {
+					handler.rd.JSON(w, http.StatusInternalServerError, err)
+				}
 				return
 			}
 			resp = lastStoreDeleteInfo
@@ -305,7 +309,7 @@ func (handler *grantLeaderHandler) DeleteConfig(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	handler.rd.JSON(w, http.StatusInternalServerError, ErrScheduleConfigNotExist)
+	handler.rd.JSON(w, http.StatusNotFound, ErrScheduleConfigNotExist)
 }
 
 func newGrantLeaderHandler(config *grantLeaderSchedulerConfig) http.Handler {

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -36,8 +36,14 @@ const (
 	minTolerantSizeRatio    float64 = 1.0
 )
 
-// ErrScheduleConfigNotExist the config is not correct.
-var ErrScheduleConfigNotExist = errors.New("the config does not exist")
+var (
+	// ErrSchedulerExisted is error info for scheduler has already existed.
+	ErrSchedulerExisted = errors.New("scheduler existed")
+	// ErrSchedulerNotFound is error info for scheduler is not found.
+	ErrSchedulerNotFound = errors.New("scheduler not found")
+	// ErrScheduleConfigNotExist the config is not correct.
+	ErrScheduleConfigNotExist = errors.New("the config does not exist")
+)
 
 func minUint64(a, b uint64) uint64 {
 	if a < b {


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fixes #2319.

### What is changed and how it works?
This PR returns 404 when the scheduler/scheduler config is not found.

### Release note <!-- bugfixes or new feature need a release note -->
Fix the problem that returns 500 when the scheduler is not found

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has HTTP API interfaces change (Don't forget to [update API document](https://github.com/pingcap/pd/blob/master/docs/development.md#updating-api-documentation))