### PR TITLE
go.mod: update sysutil

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d
 	github.com/pingcap/kvproto v0.0.0-20200324130106-b8bc94dd8a36
 	github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd
-	github.com/pingcap/sysutil v0.0.0-20200309085538-962fd285f3bb
+	github.com/pingcap/sysutil v0.0.0-20200408114249-ed3bd6f7fdb1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.0.0
 	github.com/sirupsen/logrus v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -296,8 +296,8 @@ github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIf
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd h1:CV3VsP3Z02MVtdpTMfEgRJ4T9NGgGTxdHpJerent7rM=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
-github.com/pingcap/sysutil v0.0.0-20200309085538-962fd285f3bb h1:bDbgLaNTRNK6Qw7KjvEqqfCQstY8WMEcXyXTU7yzYKg=
-github.com/pingcap/sysutil v0.0.0-20200309085538-962fd285f3bb/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
+github.com/pingcap/sysutil v0.0.0-20200408114249-ed3bd6f7fdb1 h1:PI8YpTl45F8ilNkrPtT4IdbcZB1SCEa+gK/U5GJYl3E=
+github.com/pingcap/sysutil v0.0.0-20200408114249-ed3bd6f7fdb1/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

Signed-off-by: crazycs520 <crazycs520@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

update go.mod for https://github.com/pingcap/sysutil/pull/15.

Before

```sql
select * from `CLUSTER_LOAD` where device_type='cpu'
+------+-------------------+-------------+-------------+------------+-------------+
| TYPE | INSTANCE          | DEVICE_TYPE | DEVICE_NAME | NAME       | VALUE       |
+------+-------------------+-------------+-------------+------------+-------------+
| pd   | 127.0.0.1:2379  | cpu         | cpu         | load1      | 2.83          |
| pd   | 127.0.0.1:2379  | cpu         | cpu         | load5      | 2.61          |
| pd   | 127.0.0.1:2379  | cpu         | cpu         | load15     | 2.36          |
| pd   | 127.0.0.1:2379  | cpu         | cpu0        | user       | 5600.77       |
| pd   | 127.0.0.1:2379  | cpu         | cpu0        | system     | 4139.77       |
| pd   | 127.0.0.1:2379  | cpu         | cpu0        | idle       | 85203.46      |
| pd   | 127.0.0.1:2379  | cpu         | cpu0        | nice       | 0.00          |
| pd   | 127.0.0.1:2379  | cpu         | cpu0        | iowait     | 0.00          |
| pd   | 127.0.0.1:2379  | cpu         | cpu0        | irq        | 0.00          |
| pd   | 127.0.0.1:2379  | cpu         | cpu0        | softirq    | 0.00          |
| pd   | 127.0.0.1:2379  | cpu         | cpu0        | steal      | 0.00          |
| pd   | 127.0.0.1:2379  | cpu         | cpu0        | guest      | 0.00          |
| pd   | 127.0.0.1:2379  | cpu         | cpu0        | guest_nice | 0.00          |
| pd   | 127.0.0.1:2379  | cpu         | cpu1        | user       | 809.16        |
| pd   | 127.0.0.1:2379  | cpu         | cpu1        | system     | 326.88        |
| pd   | 127.0.0.1:2379  | cpu         | cpu1        | idle       | 93807.61      |
| pd   | 127.0.0.1:2379  | cpu         | cpu1        | nice       | 0.00          |
| pd   | 127.0.0.1:2379  | cpu         | cpu1        | iowait     | 0.00          |
| pd   | 127.0.0.1:2379  | cpu         | cpu1        | irq        | 0.00          |

...
```

This PR: 

```sql
select * from `CLUSTER_LOAD` where device_type='cpu'
+------+-----------------+-------------+-------------+------------+--------------+
| TYPE | INSTANCE        | DEVICE_TYPE | DEVICE_NAME | NAME       | VALUE        |
+------+-----------------+-------------+-------------+------------+--------------+
      | cpu         | load15     | 2.30          |
| pd   | 127.0.0.1:2379  | cpu         | usage       | user       | 0.04          |
| pd   | 127.0.0.1:2379  | cpu         | usage       | system     | 0.04          |
| pd   | 127.0.0.1:2379  | cpu         | usage       | idle       | 0.92          |
| pd   | 127.0.0.1:2379  | cpu         | usage       | nice       | 0.00          |
| pd   | 127.0.0.1:2379  | cpu         | usage       | iowait     | 0.00          |
| pd   | 127.0.0.1:2379  | cpu         | usage       | irq        | 0.00          |
| pd   | 127.0.0.1:2379  | cpu         | usage       | softirq    | 0.00          |
| pd   | 127.0.0.1:2379  | cpu         | usage       | steal      | 0.00          |
| pd   | 127.0.0.1:2379  | cpu         | usage       | guest      | 0.00          |
| pd   | 127.0.0.1:2379  | cpu         | usage       | guest_nice | 0.00          |

```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

- No.
