### PR TITLE
api: add replication status to region

### DIFF
--- a/server/api/region.go
+++ b/server/api/region.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/kvproto/pkg/replication_modepb"
 	"github.com/pingcap/pd/v4/server"
 	"github.com/pingcap/pd/v4/server/core"
 	"github.com/unrolled/render"
@@ -44,6 +45,24 @@ type RegionInfo struct {
 	ReadKeys        uint64            `json:"read_keys"`
 	ApproximateSize int64             `json:"approximate_size"`
 	ApproximateKeys int64             `json:"approximate_keys"`
+
+	ReplicationStatus *ReplicationStatus `json:"replication_status,omitempty"`
+}
+
+// ReplicationStatus represents the replication mode status of the region.
+type ReplicationStatus struct {
+	State   string `json:"state"`
+	StateID uint64 `json:"state_id"`
+}
+
+func fromPBReplicationStatus(s *replication_modepb.RegionReplicationStatus) *ReplicationStatus {
+	if s == nil {
+		return nil
+	}
+	return &ReplicationStatus{
+		State:   replication_modepb.RegionReplicationState_name[int32(s.GetState())],
+		StateID: s.GetStateId(),
+	}
 }
 
 // NewRegionInfo create a new api RegionInfo.
@@ -71,6 +90,7 @@ func InitRegion(r *core.RegionInfo, s *RegionInfo) *RegionInfo {
 	s.ReadKeys = r.GetKeysRead()
 	s.ApproximateSize = r.GetApproximateSize()
 	s.ApproximateKeys = r.GetApproximateKeys()
+	s.ReplicationStatus = fromPBReplicationStatus(r.GetReplicationStatus())
 
 	return s
 }


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fix #2338

### What is changed and how it works?
```
./bin/pd-ctl region
{"count":1,"regions":[{"id":2,"start_key":"","end_key":"","epoch":{"conf_ver":1,"version":1},"peers":[{"id":3,"store_id":1}],"leader":{"id":3,"store_id":1},"written_bytes":41,"read_bytes":0,"written_keys":1,"read_keys":0,"approximate_size":1,"approximate_keys":0,"replication_status":{"state":"INTEGRITY_OVER_LABEL","state_id":4}}]}
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)
   - start cluster with replication mode and query region

Code changes
 - Has HTTP API interfaces change (Don't forget to [update API document](https://github.com/pingcap/pd/blob/master/docs/development.md#updating-api-documentation))