### PR TITLE
replication_mod: add total and current metrics

### DIFF
--- a/server/replication/replication_mode.go
+++ b/server/replication/replication_mode.go
@@ -102,13 +102,13 @@ func (m *ModeManager) GetReplicationStatusHTTP() *HTTPReplicationStatus {
 	status.Mode = m.config.ReplicationMode
 	switch status.Mode {
 	case modeMajority:
-	case modeDRAutosync:
-		status.DrAutosync.LabelKey = m.config.DRAutoSync.LabelKey
-		status.DrAutosync.State = m.drAutosync.State
-		status.DrAutosync.StateID = m.drAutosync.StateID
-		status.DrAutosync.RecoverProgress = m.drAutosync.RecoverProgress
-		status.DrAutosync.TotalRegions = m.drAutosync.TotalRegions
-		status.DrAutosync.SyncedRegions = m.drAutosync.SyncedRegions
+	case modeDRAutoSync:
+		status.DrAutoSync.LabelKey = m.config.DRAutoSync.LabelKey
+		status.DrAutoSync.State = m.drAutoSync.State
+		status.DrAutoSync.StateID = m.drAutoSync.StateID
+		status.DrAutoSync.RecoverProgress = m.drAutoSync.RecoverProgress
+		status.DrAutoSync.TotalRegions = m.drAutoSync.TotalRegions
+		status.DrAutoSync.SyncedRegions = m.drAutoSync.SyncedRegions
 	}
 	return &status
 }
@@ -307,7 +307,7 @@ func (m *ModeManager) recoverProgress() (current, total int) {
 func (m *ModeManager) updateRecoverProgress(progress float32, total int, current int) {
 	m.Lock()
 	defer m.Unlock()
-	m.drAutosync.RecoverProgress = progress
-	m.drAutosync.TotalRegions = total
-	m.drAutosync.SyncedRegions = current
+	m.drAutoSync.RecoverProgress = progress
+	m.drAutoSync.TotalRegions = total
+	m.drAutoSync.SyncedRegions = current
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
As when we use 2dc replication, we may need more metrics to monitor replication progress.

### What is changed and how it works?
add `total` and `current` metric through httpstatus api.

### Release note <!-- bugfixes or new feature need a release note -->


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - No code

Code changes

 - Has configuration change
 - Has HTTP API interfaces change (Don't forget to [update API document](https://github.com/pingcap/pd/blob/master/docs/development.md#updating-api-documentation))
 - Has persistent data change