### PR TITLE
Support querying a single parameter 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20171208011716-f6d7a1f6fbf3
 	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/montanaflynn/stats v0.0.0-20151014174947-eeaced052adb
 	github.com/onsi/gomega v1.4.2 // indirect
 	github.com/opentracing/opentracing-go v1.0.2
+	github.com/pelletier/go-toml v1.3.0
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d
 	github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200407064406-b2b8ad403d01
 	github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12

--- a/tests/pdctl/component/component_test.go
+++ b/tests/pdctl/component/component_test.go
@@ -123,4 +123,13 @@ func (s *componentTestSuite) TestComponent(c *C) {
 		c.Assert(strings.Contains(obtain, "high-space-ratio = 0.3"), IsTrue)
 		c.Assert(strings.Contains(obtain, "low-space-ratio = 0.4"), IsTrue)
 	}
+
+	// component show single param
+	for i := 0; i < len(pdAddrs); i++ {
+		args = []string{"-u", pdAddrs[0], "component", "show", pdAddrs[i][7:], "replication-mode"}
+		_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+		c.Assert(err, IsNil)
+		obtain := string(output)
+		c.Assert(strings.Contains(obtain, "replication-mode"), IsTrue)
+	}
 }

--- a/tools/pd-ctl/pdctl/command/component_command.go
+++ b/tools/pd-ctl/pdctl/command/component_command.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"strconv"
 
+	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -98,18 +99,12 @@ func showComponentConfigCommandFunc(cmd *cobra.Command, args []string) {
 		cmd.Println(r)
 		return
 	}
-	param := args[1]
-	var data map[string]interface{}
-	err = json.Unmarshal([]byte(r), &data)
+	tree, err := toml.Load(r)
 	if err != nil {
-		cmd.Printf("Failed to unmarshal result: %s\n", err)
+		cmd.Printf("Failed to load data: %s\n", err)
 		return
 	}
-	if paramVal, ok := data[param]; ok {
-		cmd.Println(paramVal)
-		return
-	}
-	cmd.Printf("Failed to get component config param: %s\n", err)
+	cmd.Println(tree.Get(args[1]))
 }
 
 func deleteComponentConfigCommandFunc(cmd *cobra.Command, args []string) {

--- a/tools/pd-ctl/pdctl/command/component_command.go
+++ b/tools/pd-ctl/pdctl/command/component_command.go
@@ -82,8 +82,9 @@ func NewGetComponentIDCommand() *cobra.Command {
 }
 
 func showComponentConfigCommandFunc(cmd *cobra.Command, args []string) {
-	if len(args) != 1 {
-		cmd.Usage()
+	argLen := len(args)
+	if argLen < 1 {
+		_ = cmd.Usage()
 		return
 	}
 
@@ -93,7 +94,22 @@ func showComponentConfigCommandFunc(cmd *cobra.Command, args []string) {
 		cmd.Printf("Failed to get component config: %s\n", err)
 		return
 	}
-	cmd.Println(r)
+	if argLen == 1 {
+		cmd.Println(r)
+		return
+	}
+	param := args[1]
+	var data map[string]interface{}
+	err = json.Unmarshal([]byte(r), &data)
+	if err != nil {
+		cmd.Printf("Failed to unmarshal result: %s\n", err)
+		return
+	}
+	if paramVal, ok := data[param]; ok {
+		cmd.Println(paramVal)
+		return
+	}
+	cmd.Printf("Failed to get component config param: %s\n", err)
 }
 
 func deleteComponentConfigCommandFunc(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
UCP: #2228

Signed-off-by: wq1019 <2013855675@qq.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Support querying a single parameter for `component` subcommand in `pd-ctl`.
### What is changed and how it works?
Filtering the parameter list only returns a single parameter of the API result.
### Release note <!-- bugfixes or new feature need a release note -->

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test