### PR TITLE
API: add git_hash in pd-member's api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12
 	github.com/pingcap/errcode v0.0.0-20180921232412-a1a7271709d9
 	github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d
-	github.com/pingcap/kvproto v0.0.0-20200409042513-05af14db7537
+	github.com/pingcap/kvproto v0.0.0-20200410092417-d20cd6ac1321
 	github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd
 	github.com/pingcap/sysutil v0.0.0-20200408114249-ed3bd6f7fdb1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -290,12 +290,8 @@ github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d h1:F8vp38kTAckN+
 github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d/go.mod h1:DNS3Qg7bEDhU6EXNHF+XSv/PGznQaMJ5FWvctpm6pQI=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/kvproto v0.0.0-20200214064158-62d31900d88e/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20200409042513-05af14db7537 h1:MwOTgYJ7EKcXt6Tci+VsDZit0KzFMQ0mNpJmFpcnFrE=
-github.com/pingcap/kvproto v0.0.0-20200409042513-05af14db7537/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/kvproto v0.0.0-20200410092417-d20cd6ac1321 h1:OeDTuueTyWXo8wTy9W0wxDs3spJnpe+hu+F26R/dtro=
 github.com/pingcap/kvproto v0.0.0-20200410092417-d20cd6ac1321/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20200417092353-efbe03bcffbd h1:BuTFEyCEm71vUU/3qmndWNWfySS0Jwek1iZ1rQ/4Jqc=
-github.com/pingcap/kvproto v0.0.0-20200417092353-efbe03bcffbd/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9 h1:AJD9pZYm72vMgPcQDww9rkZ1DnWfl0pXV3BOWlkYIjA=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd h1:CV3VsP3Z02MVtdpTMfEgRJ4T9NGgGTxdHpJerent7rM=

--- a/go.sum
+++ b/go.sum
@@ -292,6 +292,10 @@ github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO
 github.com/pingcap/kvproto v0.0.0-20200214064158-62d31900d88e/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/kvproto v0.0.0-20200409042513-05af14db7537 h1:MwOTgYJ7EKcXt6Tci+VsDZit0KzFMQ0mNpJmFpcnFrE=
 github.com/pingcap/kvproto v0.0.0-20200409042513-05af14db7537/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20200410092417-d20cd6ac1321 h1:OeDTuueTyWXo8wTy9W0wxDs3spJnpe+hu+F26R/dtro=
+github.com/pingcap/kvproto v0.0.0-20200410092417-d20cd6ac1321/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20200417092353-efbe03bcffbd h1:BuTFEyCEm71vUU/3qmndWNWfySS0Jwek1iZ1rQ/4Jqc=
+github.com/pingcap/kvproto v0.0.0-20200417092353-efbe03bcffbd/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9 h1:AJD9pZYm72vMgPcQDww9rkZ1DnWfl0pXV3BOWlkYIjA=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd h1:CV3VsP3Z02MVtdpTMfEgRJ4T9NGgGTxdHpJerent7rM=

--- a/server/api/member.go
+++ b/server/api/member.go
@@ -84,6 +84,12 @@ func (h *memberHandler) getMembers() (*pdpb.GetMembersResponse, error) {
 			continue
 		}
 		m.LeaderPriority = int32(leaderPriority)
+		gitHash, e := h.svr.GetMember().GetMemberBinaryVersion(m.GetMemberId())
+		if e != nil {
+			log.Error("failed to load binary hash", zap.Uint64("member", m.GetMemberId()), zap.Error(err))
+			continue
+		}
+		m.GitHash = gitHash
 	}
 	return members, nil
 }

--- a/server/member/leader.go
+++ b/server/member/leader.go
@@ -368,6 +368,10 @@ func (m *Member) SetMemberDeployPath(id uint64) error {
 	return nil
 }
 
+func (m *Member) getMemberGitHashPath(id uint64) string {
+	return path.Join(m.rootPath, fmt.Sprintf("member/%d/git_hash", id))
+}
+
 func (m *Member) getMemberBinaryVersionPath(id uint64) string {
 	return path.Join(m.rootPath, fmt.Sprintf("member/%d/binary_version", id))
 }
@@ -375,6 +379,19 @@ func (m *Member) getMemberBinaryVersionPath(id uint64) string {
 // GetMemberBinaryVersion loads a member's binary version.
 func (m *Member) GetMemberBinaryVersion(id uint64) (string, error) {
 	key := m.getMemberBinaryVersionPath(id)
+	res, err := etcdutil.EtcdKVGet(m.client, key)
+	if err != nil {
+		return "", err
+	}
+	if len(res.Kvs) == 0 {
+		return "", errors.New("no value")
+	}
+	return string(res.Kvs[0].Value), nil
+}
+
+// GetMemberGitHash loads a member's git hash.
+func (m *Member) GetMemberGitHash(id uint64) (string, error) {
+	key := m.getMemberGitHashPath(id)
 	res, err := etcdutil.EtcdKVGet(m.client, key)
 	if err != nil {
 		return "", err
@@ -395,6 +412,19 @@ func (m *Member) SetMemberBinaryVersion(id uint64, releaseVersion string) error 
 	}
 	if !res.Succeeded {
 		return errors.New("failed to save binary version")
+	}
+	return nil
+}
+
+func (m *Member) SetMemberGitHash(id uint64, gitHash string) error {
+	key := m.getMemberGitHashPath(id)
+	txn := kv.NewSlowLogTxn(m.client)
+	res, err := txn.Then(clientv3.OpPut(key, gitHash)).Commit()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if !res.Succeeded {
+		return errors.New("failed to save git hash")
 	}
 	return nil
 }

--- a/server/member/leader.go
+++ b/server/member/leader.go
@@ -416,6 +416,7 @@ func (m *Member) SetMemberBinaryVersion(id uint64, releaseVersion string) error 
 	return nil
 }
 
+// SetMemberGitHash saves a member's git hash.
 func (m *Member) SetMemberGitHash(id uint64, gitHash string) error {
 	key := m.getMemberGitHashPath(id)
 	txn := kv.NewSlowLogTxn(m.client)

--- a/server/server.go
+++ b/server/server.go
@@ -331,6 +331,7 @@ func (s *Server) startServer(ctx context.Context) error {
 	s.member.MemberInfo(s.cfg, s.Name(), s.rootPath)
 	s.member.SetMemberDeployPath(s.member.ID())
 	s.member.SetMemberBinaryVersion(s.member.ID(), PDReleaseVersion)
+	s.member.SetMemberGitHash(s.member.ID(), PDGitHash)
 	s.idAllocator = id.NewAllocatorImpl(s.client, s.rootPath, s.member.MemberValue())
 	s.tso = tso.NewTimestampOracle(
 		s.client,


### PR DESCRIPTION

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

TiDB-Dashboard require git-hash for components, and previous pd don't have logic about git-hash. So This pr change it and add git hash. 


### What is changed and how it works?

This pr: https://github.com/pingcap/kvproto/pull/599 modify kvproto and add `git_hash` field. This pr add the logic in pd api.

### Release note <!-- bugfixes or new feature need a release note -->

Please put it in 4.0.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/pingcap/pd/blob/master/docs/development.md#updating-api-documentation))

Side effects


Related changes

- Need to cherry-pick to the release branch