### PR TITLE
schedule: change store limit to unlimited when offline a store

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -16,7 +16,6 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"math"
 	"net/http"
 	"sync"
 	"time"
@@ -943,8 +942,8 @@ func (c *RaftCluster) RemoveStore(storeID uint64) error {
 		zap.String("store-address", newStore.GetAddress()))
 	err := c.putStoreLocked(newStore)
 	if err == nil {
-		// set the store limit to unlimit
-		c.coordinator.opController.SetStoreLimit(store.GetID(), float64(math.MaxInt64), storelimit.Auto, storelimit.RegionRemove)
+		// set the remove peer limit of the store to unlimited
+		c.coordinator.opController.SetStoreLimit(store.GetID(), storelimit.Unlimited, storelimit.Manual, storelimit.RegionRemove)
 	}
 	return err
 }

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -16,6 +16,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/http"
 	"sync"
 	"time"
@@ -940,7 +941,12 @@ func (c *RaftCluster) RemoveStore(storeID uint64) error {
 	log.Warn("store has been offline",
 		zap.Uint64("store-id", newStore.GetID()),
 		zap.String("store-address", newStore.GetAddress()))
-	return c.putStoreLocked(newStore)
+	err := c.putStoreLocked(newStore)
+	if err == nil {
+		// set the store limit to unlimit
+		c.coordinator.opController.SetStoreLimit(store.GetID(), float64(math.MaxInt64), storelimit.Auto, storelimit.RegionRemove)
+	}
+	return err
 }
 
 // BuryStore marks a store as tombstone in cluster.

--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -869,7 +869,6 @@ func (oc *OperatorController) exceedStoreLimit(ops ...*operator.Operator) bool {
 			if stepCost == 0 {
 				continue
 			}
-
 			available := oc.getOrCreateStoreLimit(storeID, v).Available()
 			storeLimitGauge.WithLabelValues(strconv.FormatUint(storeID, 10), "available", n).Set(float64(available) / float64(storelimit.RegionInfluence[v]))
 			if available < stepCost {

--- a/server/schedule/storelimit/store_limit.go
+++ b/server/schedule/storelimit/store_limit.go
@@ -14,6 +14,7 @@
 package storelimit
 
 import (
+	"math"
 	"time"
 
 	"github.com/juju/ratelimit"
@@ -96,10 +97,15 @@ type StoreLimit struct {
 // NewStoreLimit returns a StoreLimit object
 func NewStoreLimit(rate float64, mode Mode, regionInfluence int64) *StoreLimit {
 	capacity := regionInfluence
-	if rate > 1 {
+	// unlimited
+	if rate == float64(math.MaxInt64) {
+		capacity = math.MaxInt64
+	} else if rate > 1 {
 		capacity = int64(rate * float64(regionInfluence))
+		rate *= float64(regionInfluence)
+	} else {
+		rate *= float64(regionInfluence)
 	}
-	rate *= float64(regionInfluence)
 	return &StoreLimit{
 		bucket:          ratelimit.NewBucketWithRate(rate, capacity),
 		mode:            mode,

--- a/server/schedule/storelimit/store_limit.go
+++ b/server/schedule/storelimit/store_limit.go
@@ -14,7 +14,6 @@
 package storelimit
 
 import (
-	"math"
 	"time"
 
 	"github.com/juju/ratelimit"
@@ -23,6 +22,8 @@ import (
 const (
 	// SmallRegionThreshold is used to represent a region which can be regarded as a small region once the size is small than it.
 	SmallRegionThreshold int64 = 20
+	// Unlimited is used to control the store limit. Here uses a big enough number to represent unlimited.
+	Unlimited = float64(100000000)
 )
 
 // RegionInfluence represents the influence of a operator step, which is used by store limit.
@@ -98,8 +99,8 @@ type StoreLimit struct {
 func NewStoreLimit(rate float64, mode Mode, regionInfluence int64) *StoreLimit {
 	capacity := regionInfluence
 	// unlimited
-	if rate == float64(math.MaxInt64) {
-		capacity = math.MaxInt64
+	if rate >= Unlimited {
+		capacity = int64(Unlimited)
 	} else if rate > 1 {
 		capacity = int64(rate * float64(regionInfluence))
 		rate *= float64(regionInfluence)


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
After #2226, the speed of both add and remove a store may be slower because of the rate limit of removing peers. 

### What is changed and how it works?
This PR changes the rate of removing peers to unlimited when a store is offline.

### Release note <!-- bugfixes or new feature need a release note -->
Change rate limit of removing peers to unlimited when offline a store

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test 

When removing a store, the limit of removing peers for the offline store will be `556780641449999900` which represents unlimited.
```
» store limit region-remove
{
  "1": {
    "rate": 556780641449999900,
    "mode": "auto"
  },
  "104": {
    "rate": 15,
    "mode": "auto"
  },
  "116": {
    "rate": 15,
    "mode": "auto"
  }
```

For operator:
<img width="1901" alt="Screen Shot 2020-04-23 at 1 04 02 PM" src="https://user-images.githubusercontent.com/35896542/80061199-2fe4c600-8563-11ea-8244-6bfa20c56cd0.png">
It's no longer 15/min and depends on how many stores in the cluster.