### PR TITLE
*: persist the component address

### DIFF
--- a/pkg/component/manager_test.go
+++ b/pkg/component/manager_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/pd/v4/server/core"
+	"github.com/pingcap/pd/v4/server/kv"
 )
 
 func Test(t *testing.T) {
@@ -29,7 +31,7 @@ var _ = Suite(&testManagerSuite{})
 type testManagerSuite struct{}
 
 func (s *testManagerSuite) TestManager(c *C) {
-	m := NewManager()
+	m := NewManager(core.NewStorage(kv.NewMemoryKV()))
 	// register legal address
 	c.Assert(m.Register("c1", "127.0.0.1:1"), IsNil)
 	c.Assert(m.Register("c1", "127.0.0.1:2"), IsNil)

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -181,10 +181,10 @@ func createRouter(ctx context.Context, prefix string, svr *server.Server) *mux.R
 	clusterRouter.HandleFunc("/replication_mode/status", replicationModeHandler.GetStatus)
 
 	componentHandler := newComponentHandler(svr, rd)
-	apiRouter.HandleFunc("/component", componentHandler.Register).Methods("POST")
-	apiRouter.HandleFunc("/component/{component}/{addr}", componentHandler.UnRegister).Methods("DELETE")
-	apiRouter.HandleFunc("/component", componentHandler.GetAllAddress).Methods("GET")
-	apiRouter.HandleFunc("/component/{type}", componentHandler.GetAddress).Methods("GET")
+	clusterRouter.HandleFunc("/component", componentHandler.Register).Methods("POST")
+	clusterRouter.HandleFunc("/component/{component}/{addr}", componentHandler.UnRegister).Methods("DELETE")
+	clusterRouter.HandleFunc("/component", componentHandler.GetAllAddress).Methods("GET")
+	clusterRouter.HandleFunc("/component/{type}", componentHandler.GetAddress).Methods("GET")
 
 	pluginHandler := newPluginHandler(handler, rd)
 	apiRouter.HandleFunc("/plugin", pluginHandler.LoadPlugin).Methods("POST")

--- a/server/core/storage.go
+++ b/server/core/storage.go
@@ -32,13 +32,13 @@ import (
 )
 
 const (
-	clusterPath     = "raft"
-	configPath      = "config"
-	schedulePath    = "schedule"
-	gcPath          = "gc"
-	rulesPath       = "rules"
-	replicationPath = "replication_mode"
-
+	clusterPath              = "raft"
+	configPath               = "config"
+	schedulePath             = "schedule"
+	gcPath                   = "gc"
+	rulesPath                = "rules"
+	replicationPath          = "replication_mode"
+	componentPath            = "component"
 	customScheduleConfigPath = "scheduler_config"
 )
 
@@ -278,6 +278,31 @@ func (s *Storage) LoadReplicationStatus(mode string, status interface{}) (bool, 
 		return false, nil
 	}
 	err = json.Unmarshal([]byte(v), status)
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+	return true, nil
+}
+
+// SaveComponent stores marshalable components to the componentPath.
+func (s *Storage) SaveComponent(component interface{}) error {
+	value, err := json.Marshal(component)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return s.Save(componentPath, string(value))
+}
+
+// LoadComponent loads components from componentPath then unmarshal it to component.
+func (s *Storage) LoadComponent(component interface{}) (bool, error) {
+	v, err := s.Load(componentPath)
+	if err != nil {
+		return false, err
+	}
+	if v == "" {
+		return false, nil
+	}
+	err = json.Unmarshal([]byte(v), component)
 	if err != nil {
 		return false, errors.WithStack(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
-	"github.com/pingcap/pd/v4/pkg/component"
 	"github.com/pingcap/pd/v4/pkg/etcdutil"
 	"github.com/pingcap/pd/v4/pkg/grpcutil"
 	"github.com/pingcap/pd/v4/pkg/logutil"
@@ -124,9 +123,6 @@ type Server struct {
 	// Zap logger
 	lg       *zap.Logger
 	logProps *log.ZapProperties
-
-	// It's used to manage components.
-	componentManager *component.Manager
 
 	// Add callback functions at different stages
 	startCallbacks []func()
@@ -365,7 +361,6 @@ func (s *Server) startServer(ctx context.Context) error {
 	s.basicCluster = core.NewBasicCluster()
 	s.cluster = cluster.NewRaftCluster(ctx, s.GetClusterRootPath(), s.clusterID, syncer.NewRegionSyncer(s), s.client, s.httpClient)
 	s.hbStreams = newHeartbeatStreams(ctx, s.clusterID, s.cluster)
-	s.componentManager = component.NewManager()
 
 	// Run callbacks
 	for _, cb := range s.startCallbacks {
@@ -623,11 +618,6 @@ func (s *Server) GetClient() *clientv3.Client {
 // GetHTTPClient returns builtin etcd client.
 func (s *Server) GetHTTPClient() *http.Client {
 	return s.httpClient
-}
-
-// GetComponentManager returns the component manager of server.
-func (s *Server) GetComponentManager() *component.Manager {
-	return s.componentManager
 }
 
 // GetLeader returns leader of etcd.


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Previously, the component addresses are only kept in memory.

### What is changed and how it works?
This PR persists the component addresses to etcd.

### Release note <!-- bugfixes or new feature need a release note -->


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test