### PR TITLE
Improve the heartbeat processing by store ShallowClone.

### DIFF
--- a/server/core/store.go
+++ b/server/core/store.go
@@ -91,6 +91,29 @@ func (s *StoreInfo) Clone(opts ...StoreCreateOption) *StoreInfo {
 	return store
 }
 
+// ShallowClone creates a copy of current StoreInfo, but not clone 'meta'.
+func (s *StoreInfo) ShallowClone(opts ...StoreCreateOption) *StoreInfo {
+	store := &StoreInfo{
+		meta:             s.meta,
+		stats:            s.stats,
+		blocked:          s.blocked,
+		leaderCount:      s.leaderCount,
+		regionCount:      s.regionCount,
+		leaderSize:       s.leaderSize,
+		regionSize:       s.regionSize,
+		pendingPeerCount: s.pendingPeerCount,
+		lastPersistTime:  s.lastPersistTime,
+		leaderWeight:     s.leaderWeight,
+		regionWeight:     s.regionWeight,
+		available:        s.available,
+	}
+
+	for _, opt := range opts {
+		opt(store)
+	}
+	return store
+}
+
 // IsBlocked returns if the store is blocked.
 func (s *StoreInfo) IsBlocked() bool {
 	return s.blocked
@@ -640,7 +663,7 @@ func (s *StoresInfo) SetRegionSize(storeID uint64, regionSize int64) {
 // UpdateStoreStatus updates the information of the store.
 func (s *StoresInfo) UpdateStoreStatus(storeID uint64, leaderCount int, regionCount int, pendingPeerCount int, leaderSize int64, regionSize int64) {
 	if store, ok := s.stores[storeID]; ok {
-		newStore := store.Clone(SetLeaderCount(leaderCount),
+		newStore := store.ShallowClone(SetLeaderCount(leaderCount),
 			SetRegionCount(regionCount),
 			SetPendingPeerCount(pendingPeerCount),
 			SetLeaderSize(leaderSize),

--- a/server/core/store_test.go
+++ b/server/core/store_test.go
@@ -95,36 +95,6 @@ func (s *testConcurrencySuite) TestCloneStore(c *C) {
 	wg.Wait()
 }
 
-func (s *testConcurrencySuite) TestShallowCloneStore(c *C) {
-	meta := &metapb.Store{Id: 1, Address: "mock://tikv-1", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z1"}, {Key: "host", Value: "h1"}}}
-	store := NewStoreInfo(meta)
-	start := time.Now()
-	wg := sync.WaitGroup{}
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		for {
-			if time.Since(start) > time.Second {
-				break
-			}
-			store.GetMeta().GetState()
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		for {
-			if time.Since(start) > time.Second {
-				break
-			}
-			store.ShallowClone(
-				SetStoreState(metapb.StoreState_Up),
-				SetLastHeartbeatTS(time.Now()),
-			)
-		}
-	}()
-	wg.Wait()
-}
-
 var _ = Suite(&testStoreSuite{})
 
 type testStoreSuite struct{}

--- a/server/core/store_test.go
+++ b/server/core/store_test.go
@@ -95,6 +95,36 @@ func (s *testConcurrencySuite) TestCloneStore(c *C) {
 	wg.Wait()
 }
 
+func (s *testConcurrencySuite) TestShallowCloneStore(c *C) {
+	meta := &metapb.Store{Id: 1, Address: "mock://tikv-1", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z1"}, {Key: "host", Value: "h1"}}}
+	store := NewStoreInfo(meta)
+	start := time.Now()
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for {
+			if time.Since(start) > time.Second {
+				break
+			}
+			store.GetMeta().GetState()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for {
+			if time.Since(start) > time.Second {
+				break
+			}
+			store.ShallowClone(
+				SetStoreState(metapb.StoreState_Up),
+				SetLastHeartbeatTS(time.Now()),
+			)
+		}
+	}()
+	wg.Wait()
+}
+
 var _ = Suite(&testStoreSuite{})
 
 type testStoreSuite struct{}


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->
When the store clone,add a method called ShallowClone,it won't clone the meta
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Improve the  heartbeat processing 
https://github.com/pingcap/pd/issues/2391

### What is changed and how it works?
When the store clone,add a method called ShallowClone,it won't clone the meta.

The test conditions are: 1 million region 20store 0.1 region-update-ratio, 10heartbeat-rounds. The average heartbeat is the average of the last 9 times.

the improve percent like this:
no.|improve content |related code |average heartbeat/s | improve percent
---|---|---|---|---
1|   master branch |     |   101652 | 0%    
2|use ShallowClone when UpdateStoreStatus.|   store.go 666: newStore := store.ShallowClone(SetLeaderCount(leaderCount),  | 124109   |     22%



Tests <!-- At least one of them must be included. -->

 - Unit test

