### PR TITLE
replication_mode: fix config issues

### DIFF
--- a/server/api/config_test.go
+++ b/server/api/config_test.go
@@ -91,7 +91,7 @@ func (s *testConfigSuite) TestConfigAll(c *C) {
 		"pd-server.metric-storage":                "http://127.0.0.1:1234",
 		"log.level":                               "warn",
 		"cluster-version":                         "v4.0.0-beta",
-		"replication-mode.replication-mode":       "dr_auto_sync",
+		"replication-mode.replication-mode":       "dr-auto-sync",
 		"replication-mode.dr-auto-sync.label-key": "foobar",
 	}
 	postData, err = json.Marshal(l)
@@ -106,7 +106,7 @@ func (s *testConfigSuite) TestConfigAll(c *C) {
 	cfg.PDServerCfg.MetricStorage = "http://127.0.0.1:1234"
 	cfg.Log.Level = "warn"
 	cfg.ReplicationMode.DRAutoSync.LabelKey = "foobar"
-	cfg.ReplicationMode.ReplicationMode = "dr_auto_sync"
+	cfg.ReplicationMode.ReplicationMode = "dr-auto-sync"
 	v, err := cluster.ParseVersion("v4.0.0-beta")
 	c.Assert(err, IsNil)
 	cfg.ClusterVersion = *v

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1146,10 +1146,20 @@ func (c *ReplicationModeConfig) Clone() *ReplicationModeConfig {
 }
 
 func (c *ReplicationModeConfig) adjust(meta *configMetaData) {
-	if !meta.IsDefined("replication-mode") {
+	if !meta.IsDefined("replication-mode") || NormalizeReplicationMode(c.ReplicationMode) == "" {
 		c.ReplicationMode = "majority"
 	}
 	c.DRAutoSync.adjust(meta.Child("dr-auto-sync"))
+}
+
+// NormalizeReplicationMode converts user's input mode to internal use.
+// It returns "" if failed to convert.
+func NormalizeReplicationMode(m string) string {
+	s := strings.ReplaceAll(strings.ToLower(m), "_", "-")
+	if s == "majority" || s == "dr-auto-sync" {
+		return s
+	}
+	return ""
 }
 
 // DRAutoSyncReplicationConfig is the configuration for auto sync mode between 2 data centers.

--- a/server/replication/replication_mode.go
+++ b/server/replication/replication_mode.go
@@ -97,8 +97,10 @@ func NewReplicationModeManager(config config.ReplicationModeConfig, storage *cor
 func (m *ModeManager) UpdateConfig(config config.ReplicationModeConfig) error {
 	m.Lock()
 	defer m.Unlock()
-	// Handle 'majority -> dr-auto-sync' as special case. (sync_recover mode)
-	if m.config.ReplicationMode == modeMajority && config.ReplicationMode == modeDRAutoSync {
+	// If mode change from 'majority' to 'dr-auto-sync', or the label key is
+	// updated, switch to 'sync_recover' state.
+	if (m.config.ReplicationMode == modeMajority && config.ReplicationMode == modeDRAutoSync) ||
+		(m.config.ReplicationMode == modeDRAutoSync && config.ReplicationMode == modeDRAutoSync && m.config.DRAutoSync.LabelKey != config.DRAutoSync.LabelKey) {
 		old := m.config
 		m.config = config
 		err := m.drSwitchToSyncRecoverWithLock()

--- a/server/replication/replication_mode.go
+++ b/server/replication/replication_mode.go
@@ -100,7 +100,7 @@ func (m *ModeManager) UpdateConfig(config config.ReplicationModeConfig) error {
 	// If mode change from 'majority' to 'dr-auto-sync', or the label key is
 	// updated, switch to 'sync_recover' state.
 	if (m.config.ReplicationMode == modeMajority && config.ReplicationMode == modeDRAutoSync) ||
-		(m.config.ReplicationMode == modeDRAutoSync && config.ReplicationMode == modeDRAutoSync && m.config.DRAutoSync.LabelKey != config.DRAutoSync.LabelKey) {
+		(m.config.ReplicationMode == modeDRAutoSync && config.ReplicationMode == modeDRAutoSync && m.config.DRAutoSync.LabelKey != config.DRAutoSync.LabelKey && m.drAutoSync.State == drStateSync) {
 		old := m.config
 		m.config = config
 		err := m.drSwitchToSyncRecoverWithLock()

--- a/server/replication/replication_mode.go
+++ b/server/replication/replication_mode.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pingcap/kvproto/pkg/replication_modepb"
 	pb "github.com/pingcap/kvproto/pkg/replication_modepb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/pd/v4/server/config"
@@ -35,12 +34,12 @@ const (
 	modeDRAutoSync = "dr-auto-sync"
 )
 
-func modeToPB(m string) replication_modepb.ReplicationMode {
+func modeToPB(m string) pb.ReplicationMode {
 	switch m {
 	case modeMajority:
-		return replication_modepb.ReplicationMode_MAJORITY
+		return pb.ReplicationMode_MAJORITY
 	case modeDRAutoSync:
-		return replication_modepb.ReplicationMode_DR_AUTO_SYNC
+		return pb.ReplicationMode_DR_AUTO_SYNC
 	}
 	return 0
 }

--- a/server/replication/replication_mode.go
+++ b/server/replication/replication_mode.go
@@ -111,7 +111,7 @@ func (m *ModeManager) UpdateConfig(config config.ReplicationModeConfig) error {
 	if m.config.ReplicationMode == modeDRAutoSync && config.ReplicationMode == modeDRAutoSync && m.config.DRAutoSync.LabelKey != config.DRAutoSync.LabelKey {
 		old := m.config
 		m.config = config
-		err := m.drSwitchToAsync()
+		err := m.drSwitchToAsyncWithLock()
 		if err != nil {
 			// restore
 			m.config = old
@@ -209,6 +209,12 @@ func (m *ModeManager) loadDRAutoSync() error {
 }
 
 func (m *ModeManager) drSwitchToAsync() error {
+	m.Lock()
+	defer m.Unlock()
+	return m.drSwitchToAsyncWithLock()
+}
+
+func (m *ModeManager) drSwitchToAsyncWithLock() error {
 	m.Lock()
 	defer m.Unlock()
 	id, err := m.cluster.AllocID()

--- a/server/replication/replication_mode.go
+++ b/server/replication/replication_mode.go
@@ -215,8 +215,6 @@ func (m *ModeManager) drSwitchToAsync() error {
 }
 
 func (m *ModeManager) drSwitchToAsyncWithLock() error {
-	m.Lock()
-	defer m.Unlock()
 	id, err := m.cluster.AllocID()
 	if err != nil {
 		log.Warn("failed to switch to async state", zap.String("replicate-mode", modeDRAutoSync), zap.Error(err))

--- a/server/server.go
+++ b/server/server.go
@@ -979,6 +979,10 @@ func (s *Server) GetReplicationModeConfig() *config.ReplicationModeConfig {
 
 // SetReplicationModeConfig sets the replication mode.
 func (s *Server) SetReplicationModeConfig(cfg config.ReplicationModeConfig) error {
+	if config.NormalizeReplicationMode(cfg.ReplicationMode) == "" {
+		return errors.Errorf("invalid replication mode: %v", cfg.ReplicationMode)
+	}
+
 	old := s.persistOptions.GetReplicationModeConfig()
 	s.persistOptions.SetReplicationModeConfig(&cfg)
 	if err := s.persistOptions.Persist(s.storage); err != nil {

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -344,4 +344,9 @@ func (s *configTestSuite) TestReplicationMode(c *C) {
 	c.Assert(err, IsNil)
 	conf.DRAutoSync.LabelKey = "foobar"
 	check()
+
+	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "set", "replication-mode", "dr-auto-sync", "primary-replicas", "5")
+	c.Assert(err, IsNil)
+	conf.DRAutoSync.PrimaryReplicas = 5
+	check()
 }

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -335,9 +335,9 @@ func (s *configTestSuite) TestReplicationMode(c *C) {
 
 	check()
 
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "set", "replication-mode", "dr_auto_sync")
+	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "set", "replication-mode", "dr-auto-sync")
 	c.Assert(err, IsNil)
-	conf.ReplicationMode = "dr_auto_sync"
+	conf.ReplicationMode = "dr-auto-sync"
 	check()
 
 	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "set", "replication-mode", "dr-auto-sync", "label-key", "foobar")

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -745,7 +745,7 @@ func (s *clusterTestSuite) TestTiFlashWithPlacementRules(c *C) {
 
 func (s *clusterTestSuite) TestReplicationModeStatus(c *C) {
 	tc, err := tests.NewTestCluster(s.ctx, 1, func(conf *config.Config) {
-		conf.ReplicationMode.ReplicationMode = "dr_auto_sync"
+		conf.ReplicationMode.ReplicationMode = "dr-auto-sync"
 	})
 
 	defer tc.Destroy()

--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -20,8 +20,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path"
+	"reflect"
 	"strconv"
+	"strings"
 
+	"github.com/pingcap/pd/v4/server/config"
 	"github.com/pingcap/pd/v4/server/schedule/placement"
 	"github.com/spf13/cobra"
 )
@@ -349,11 +352,40 @@ func setReplicationModeCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) == 1 {
 		postJSON(cmd, replicationModePrefix, map[string]interface{}{"replication-mode": args[0]})
 	} else if len(args) == 3 {
+		t := findFieldByJsonTag(reflect.TypeOf(config.ReplicationModeConfig{}), []string{args[0], args[1]})
+		if t != nil && t.Kind() != reflect.String {
+			// convert to number for numberic fields.
+			arg2, err := strconv.ParseInt(args[2], 10, 64)
+			if err != nil {
+				cmd.Printf("value %v cannot covert to number: %v", args[2], err)
+				return
+			}
+			postJSON(cmd, replicationModePrefix, map[string]interface{}{args[0]: map[string]interface{}{args[1]: arg2}})
+			return
+		}
 		postJSON(cmd, replicationModePrefix, map[string]interface{}{args[0]: map[string]string{args[1]: args[2]}})
 	} else {
 		cmd.Println(cmd.UsageString())
-		return
 	}
+}
+
+func findFieldByJsonTag(t reflect.Type, tags []string) reflect.Type {
+	if len(tags) == 0 {
+		return t
+	}
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+	for i := 0; i < t.NumField(); i++ {
+		jsonTag := t.Field(i).Tag.Get("json")
+		if i := strings.Index(jsonTag, ","); i != -1 { // trim 'foobar,string' to 'foobar'
+			jsonTag = jsonTag[:i]
+		}
+		if jsonTag == tags[0] {
+			return findFieldByJsonTag(t.Field(i).Type, tags[1:])
+		}
+	}
+	return nil
 }
 
 // NewPlacementRulesCommand placement rules subcommand

--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -352,7 +352,7 @@ func setReplicationModeCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) == 1 {
 		postJSON(cmd, replicationModePrefix, map[string]interface{}{"replication-mode": args[0]})
 	} else if len(args) == 3 {
-		t := findFieldByJsonTag(reflect.TypeOf(config.ReplicationModeConfig{}), []string{args[0], args[1]})
+		t := findFieldByJSONTag(reflect.TypeOf(config.ReplicationModeConfig{}), []string{args[0], args[1]})
 		if t != nil && t.Kind() != reflect.String {
 			// convert to number for numberic fields.
 			arg2, err := strconv.ParseInt(args[2], 10, 64)
@@ -369,7 +369,7 @@ func setReplicationModeCommandFunc(cmd *cobra.Command, args []string) {
 	}
 }
 
-func findFieldByJsonTag(t reflect.Type, tags []string) reflect.Type {
+func findFieldByJSONTag(t reflect.Type, tags []string) reflect.Type {
 	if len(tags) == 0 {
 		return t
 	}
@@ -382,7 +382,7 @@ func findFieldByJsonTag(t reflect.Type, tags []string) reflect.Type {
 			jsonTag = jsonTag[:i]
 		}
 		if jsonTag == tags[0] {
-			return findFieldByJsonTag(t.Field(i).Type, tags[1:])
+			return findFieldByJSONTag(t.Field(i).Type, tags[1:])
 		}
 	}
 	return nil


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fix #2386 
Fix #2387 
Fix #2388 

### What is changed and how it works?
- change `dr_auto_sync` to `dr-auto-sync` (and auto convert `_` to `-`)
- validate config, if wrong return error
- support pd-ctl set numbers (e.g. primary-replicas)
- switch status to sync_recover when the label key is updated


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test
