### PR TITLE
config: make max reset ts gap readable

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -912,7 +912,7 @@ type PDServerConfig struct {
 	// UseRegionStorage enables the independent region storage.
 	UseRegionStorage bool `toml:"use-region-storage" json:"use-region-storage,string"`
 	// MaxResetTSGap is the max gap to reset the tso.
-	MaxResetTSGap time.Duration `toml:"max-reset-ts-gap" json:"max-reset-ts-gap"`
+	MaxResetTSGap typeutil.Duration `toml:"max-gap-reset-ts" json:"max-gap-reset-ts"`
 	// KeyType is option to specify the type of keys.
 	// There are some types supported: ["table", "raw", "txn"], default: "table"
 	KeyType string `toml:"key-type" json:"key-type"`
@@ -926,11 +926,9 @@ type PDServerConfig struct {
 }
 
 func (c *PDServerConfig) adjust(meta *configMetaData) error {
+	adjustDuration(&c.MaxResetTSGap, defaultMaxResetTsGap)
 	if !meta.IsDefined("use-region-storage") {
 		c.UseRegionStorage = defaultUseRegionStorage
-	}
-	if !meta.IsDefined("max-reset-ts-gap") {
-		c.MaxResetTSGap = defaultMaxResetTsGap
 	}
 	if !meta.IsDefined("key-type") {
 		c.KeyType = defaultKeyType

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -262,7 +262,7 @@ func (o *PersistOptions) GetKeyType() core.KeyType {
 
 // GetMaxResetTSGap gets the max gap to reset the tso.
 func (o *PersistOptions) GetMaxResetTSGap() time.Duration {
-	return o.GetPDServerConfig().MaxResetTSGap
+	return o.GetPDServerConfig().MaxResetTSGap.Duration
 }
 
 // GetDashboardAddress gets dashboard address.


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fix #2365.

### What is changed and how it works?
This PR uses `typeutil.Duration` instead of `time.Duration`. 

### Release note <!-- bugfixes or new feature need a release note -->
Fix the issue that the config item of the max gap to reset ts is not readable

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test