### PR TITLE
Reduce the unnecessary updateStoreStatusLocked call counts.

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -569,13 +569,17 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 		}
 
 		// Update related stores.
+		storeMap := make(map[uint64]uint64)
+		for _, p := range region.GetPeers() {
+			storeMap[p.GetStoreId()] = p.GetStoreId()
+		}
 		if origin != nil {
 			for _, p := range origin.GetPeers() {
-				c.updateStoreStatusLocked(p.GetStoreId())
+				storeMap[p.GetStoreId()] = p.GetStoreId()
 			}
 		}
-		for _, p := range region.GetPeers() {
-			c.updateStoreStatusLocked(p.GetStoreId())
+		for key := range storeMap {
+			c.updateStoreStatusLocked(key)
 		}
 		regionEventCounter.WithLabelValues("update_cache").Inc()
 	}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -569,13 +569,13 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 		}
 
 		// Update related stores.
-		storeMap := make(map[uint64]uint64)
+		storeMap := make(map[uint64]struct{})
 		for _, p := range region.GetPeers() {
-			storeMap[p.GetStoreId()] = p.GetStoreId()
+			storeMap[p.GetStoreId()] = struct{}{}
 		}
 		if origin != nil {
 			for _, p := range origin.GetPeers() {
-				storeMap[p.GetStoreId()] = p.GetStoreId()
+				storeMap[p.GetStoreId()] = struct{}{}
 			}
 		}
 		for key := range storeMap {


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Improve the heartbeat processing
UCP #2395 

### What is changed and how it works?
Reduce the call counts of updateStoreStatusLocked.

The test conditions are: 1 million region 20store 0.1 region-update-ratio, 10heartbeat-rounds. The average heartbeat is the average of the last 9 times.

the improve percent like this:
no.|improve content |related code |average heartbeat/s | improve percent
---|---|---|---|---
1|   master branch |     |   101652 | 0%    
2|use ShallowClone when UpdateStoreStatus.|   store.go 666: newStore := store.ShallowClone(SetLeaderCount(leaderCount),  | 124109   |     22%
3|use reduce the number of updates when update related stores.|   cluster.go 572-583: c.updateStoreStatusLocked(key),  | 132076   |     7.8%


Tests <!-- At least one of them must be included. -->

 - Unit test
