### PR TITLE
api: fix the encoded path of region key

### DIFF
--- a/server/api/region.go
+++ b/server/api/region.go
@@ -16,6 +16,7 @@ package api
 import (
 	"container/heap"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 
@@ -145,6 +146,11 @@ func (h *regionHandler) GetRegionByKey(w http.ResponseWriter, r *http.Request) {
 	rc := getCluster(r.Context())
 	vars := mux.Vars(r)
 	key := vars["key"]
+	key, err := url.QueryUnescape(key)
+	if err != nil {
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	regionInfo := rc.GetRegionInfoByKey([]byte(key))
 	h.rd.JSON(w, http.StatusOK, NewRegionInfo(regionInfo))
 }

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -124,7 +124,7 @@ func createRouter(ctx context.Context, prefix string, svr *server.Server) *mux.R
 
 	regionHandler := newRegionHandler(svr, rd)
 	clusterRouter.HandleFunc("/region/id/{id}", regionHandler.GetRegionByID).Methods("GET")
-	clusterRouter.HandleFunc("/region/key/{key}", regionHandler.GetRegionByKey).Methods("GET")
+	clusterRouter.UseEncodedPath().HandleFunc("/region/key/{key}", regionHandler.GetRegionByKey).Methods("GET")
 
 	srd := createStreamingRender()
 	regionsAllHandler := newRegionsHandler(svr, srd)

--- a/tests/pdctl/region/region_test.go
+++ b/tests/pdctl/region/region_test.go
@@ -236,6 +236,14 @@ func (s *regionTestSuite) TestRegion(c *C) {
 	c.Assert(json.Unmarshal(output, &regionInfo), IsNil)
 	c.Assert(&regionInfo, DeepEquals, api.NewRegionInfo(r2))
 
+	// issue #2351
+	args = []string{"-u", pdAddr, "region", "key", "--format=hex", "622f62"}
+	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	c.Assert(err, IsNil)
+	regionInfo = api.RegionInfo{}
+	c.Assert(json.Unmarshal(output, &regionInfo), IsNil)
+	c.Assert(&regionInfo, DeepEquals, api.NewRegionInfo(r2))
+
 	// region startkey --format=raw <key> command
 	args = []string{"-u", pdAddr, "region", "startkey", "--format=raw", "b", "2"}
 	_, output, err = pdctl.ExecuteCommandC(cmd, args...)


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fix the `404` problem when using region key in pd-ctl, which is mentioned in #2351.

### What is changed and how it works?
This PR uses [`UseEncodedPath`](https://www.gorillatoolkit.org/pkg/mux#Router.UseEncodedPath) to solve the `%2F` problem.

### Release note <!-- bugfixes or new feature need a release note -->
Fix the `404` problem when using `region key` in pd-ctl

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test