### PR TITLE
*: add pd-recover to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ FROM alpine:3.5
 
 COPY --from=builder /go/src/github.com/pingcap/pd/bin/pd-server /pd-server
 COPY --from=builder /go/src/github.com/pingcap/pd/bin/pd-ctl /pd-ctl
+COPY --from=builder /go/src/github.com/pingcap/pd/bin/pd-recover /pd-recover
 COPY --from=builder /jq /usr/local/bin/jq
 
 EXPOSE 2379 2380

--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,9 @@ dev: build tools check test
 
 ci: build check basic-test
 
-build: pd-server pd-ctl
+build: pd-server pd-ctl pd-recover
 
-tools: pd-tso-bench pd-recover pd-analysis pd-heartbeat-bench
+tools: pd-tso-bench pd-analysis pd-heartbeat-bench
 
 pd-server: export GO111MODULE=on
 pd-server:
@@ -106,7 +106,7 @@ pd-tso-bench:
 	CGO_ENABLED=0 go build -o bin/pd-tso-bench tools/pd-tso-bench/main.go
 pd-recover: export GO111MODULE=on
 pd-recover:
-	CGO_ENABLED=0 go build -o bin/pd-recover tools/pd-recover/main.go
+	CGO_ENABLED=0 go build -gcflags '$(GCFLAGS)' -ldflags '$(LDFLAGS)' -o bin/pd-recover tools/pd-recover/main.go
 pd-analysis: export GO111MODULE=on
 pd-analysis:
 	CGO_ENABLED=0 go build -gcflags '$(GCFLAGS)' -ldflags '$(LDFLAGS)' -o bin/pd-analysis tools/pd-analysis/main.go

--- a/tools/pd-recover/main.go
+++ b/tools/pd-recover/main.go
@@ -12,16 +12,18 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/v4/pkg/typeutil"
+	"github.com/pingcap/pd/v4/server"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/pkg/transport"
 )
 
 var (
+	v         = flag.Bool("V", false, "print version information.")
 	endpoints = flag.String("endpoints", "http://127.0.0.1:2379", "endpoints urls")
 	allocID   = flag.Uint64("alloc-id", 0, "please make sure alloced ID is safe")
 	clusterID = flag.Uint64("cluster-id", 0, "please make cluster ID match with tikv")
 	caPath    = flag.String("cacert", "", "path of file that contains list of trusted SSL CAs.")
-	certPath  = flag.String("cert", "", "path of file that contains X509 certificate in PEM format..")
+	certPath  = flag.String("cert", "", "path of file that contains X509 certificate in PEM format.")
 	keyPath   = flag.String("key", "", "path of file that contains X509 key in PEM format.")
 )
 
@@ -40,6 +42,10 @@ func exitErr(err error) {
 
 func main() {
 	flag.Parse()
+	if *v {
+		server.PrintPDInfo()
+		return
+	}
 	if *clusterID == 0 {
 		fmt.Println("please specify safe cluster-id")
 		return

--- a/tools/pd-recover/main.go
+++ b/tools/pd-recover/main.go
@@ -42,13 +42,13 @@ func exitErr(err error) {
 
 func main() {
 	fs := flag.NewFlagSet("pd-recover", flag.ExitOnError)
-	fs.BoolVar(&v, "V", false, "print version information.")
+	fs.BoolVar(&v, "V", false, "print version information")
 	fs.StringVar(&endpoints, "endpoints", "http://127.0.0.1:2379", "endpoints urls")
-	fs.Uint64Var(&allocID, "alloc-id ", 0, "please make sure alloced ID is safe")
+	fs.Uint64Var(&allocID, "alloc-id", 0, "please make sure alloced ID is safe")
 	fs.Uint64Var(&clusterID, "cluster-id", 0, "please make cluster ID match with tikv")
-	fs.StringVar(&caPath, "cacert", "", "path of file that contains list of trusted SSL CAs.")
-	fs.StringVar(&certPath, "cert", "", "path of file that contains list of trusted SSL CAs.")
-	fs.StringVar(&keyPath, "key", "", "path of file that contains X509 key in PEM format.")
+	fs.StringVar(&caPath, "cacert", "", "path of file that contains list of trusted SSL CAs")
+	fs.StringVar(&certPath, "cert", "", "path of file that contains list of trusted SSL CAs")
+	fs.StringVar(&keyPath, "key", "", "path of file that contains X509 key in PEM format")
 
 	if len(os.Args[1:]) == 0 {
 		fs.Usage()

--- a/tools/pd-recover/main.go
+++ b/tools/pd-recover/main.go
@@ -18,13 +18,13 @@ import (
 )
 
 var (
-	v         = flag.Bool("V", false, "print version information.")
-	endpoints = flag.String("endpoints", "http://127.0.0.1:2379", "endpoints urls")
-	allocID   = flag.Uint64("alloc-id", 0, "please make sure alloced ID is safe")
-	clusterID = flag.Uint64("cluster-id", 0, "please make cluster ID match with tikv")
-	caPath    = flag.String("cacert", "", "path of file that contains list of trusted SSL CAs.")
-	certPath  = flag.String("cert", "", "path of file that contains X509 certificate in PEM format.")
-	keyPath   = flag.String("key", "", "path of file that contains X509 key in PEM format.")
+	v         bool
+	endpoints string
+	allocID   uint64
+	clusterID uint64
+	caPath    string
+	certPath  string
+	keyPath   string
 )
 
 const (
@@ -41,30 +41,45 @@ func exitErr(err error) {
 }
 
 func main() {
-	flag.Parse()
-	if *v {
+	fs := flag.NewFlagSet("pd-recover", flag.ExitOnError)
+	fs.BoolVar(&v, "V", false, "print version information.")
+	fs.StringVar(&endpoints, "endpoints", "http://127.0.0.1:2379", "endpoints urls")
+	fs.Uint64Var(&allocID, "alloc-id ", 0, "please make sure alloced ID is safe")
+	fs.Uint64Var(&clusterID, "cluster-id", 0, "please make cluster ID match with tikv")
+	fs.StringVar(&caPath, "cacert", "", "path of file that contains list of trusted SSL CAs.")
+	fs.StringVar(&certPath, "cert", "", "path of file that contains list of trusted SSL CAs.")
+	fs.StringVar(&keyPath, "key", "", "path of file that contains X509 key in PEM format.")
+
+	if len(os.Args[1:]) == 0 {
+		fs.Usage()
+		return
+	}
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		exitErr(err)
+	}
+	if v {
 		server.PrintPDInfo()
 		return
 	}
-	if *clusterID == 0 {
+	if clusterID == 0 {
 		fmt.Println("please specify safe cluster-id")
 		return
 	}
-	if *allocID == 0 {
+	if allocID == 0 {
 		fmt.Println("please specify safe alloc-id")
 		return
 	}
 
-	rootPath := path.Join(pdRootPath, strconv.FormatUint(*clusterID, 10))
+	rootPath := path.Join(pdRootPath, strconv.FormatUint(clusterID, 10))
 	clusterRootPath := path.Join(rootPath, "raft")
 	raftBootstrapTimeKey := path.Join(clusterRootPath, "status", "raft_bootstrap_time")
 
-	urls := strings.Split(*endpoints, ",")
+	urls := strings.Split(endpoints, ",")
 
 	tlsInfo := transport.TLSInfo{
-		CertFile:      *certPath,
-		KeyFile:       *keyPath,
-		TrustedCAFile: *caPath,
+		CertFile:      certPath,
+		KeyFile:       keyPath,
+		TrustedCAFile: caPath,
 	}
 	tlsConfig, err := tlsInfo.ClientConfig()
 	if err != nil {
@@ -85,14 +100,14 @@ func main() {
 
 	var ops []clientv3.Op
 	// recover cluster_id
-	ops = append(ops, clientv3.OpPut(pdClusterIDPath, string(typeutil.Uint64ToBytes(*clusterID))))
+	ops = append(ops, clientv3.OpPut(pdClusterIDPath, string(typeutil.Uint64ToBytes(clusterID))))
 	// recover alloc_id
 	allocIDPath := path.Join(rootPath, "alloc_id")
-	ops = append(ops, clientv3.OpPut(allocIDPath, string(typeutil.Uint64ToBytes(*allocID))))
+	ops = append(ops, clientv3.OpPut(allocIDPath, string(typeutil.Uint64ToBytes(allocID))))
 
 	// recover bootstrap
 	// recover meta of cluster
-	clusterMeta := metapb.Cluster{Id: *clusterID}
+	clusterMeta := metapb.Cluster{Id: clusterID}
 	clusterValue, err := clusterMeta.Marshal()
 	if err != nil {
 		exitErr(err)


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Closes #2402.

### What is changed and how it works?
This PR does three things:
- change `make` target to compile pd-recover together
- add pd-recover to the docker image
- add `-V` parameter to show the version of pd-recover

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- Fix the issue that pd-recover is not included in the docker image