### PR TITLE
pdctl: fix the default config output of shuffle region scheduler

### DIFF
--- a/tests/pdctl/scheduler/scheduler_test.go
+++ b/tests/pdctl/scheduler/scheduler_test.go
@@ -231,6 +231,8 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 	mustExec([]string{"-u", pdAddr, "scheduler", "config", "shuffle-region-scheduler", "set-roles", "learner"}, nil)
 	mustExec([]string{"-u", pdAddr, "scheduler", "config", "shuffle-region-scheduler", "show-roles"}, &roles)
 	c.Assert(roles, DeepEquals, []string{"learner"})
+	mustExec([]string{"-u", pdAddr, "scheduler", "config", "shuffle-region-scheduler"}, &roles)
+	c.Assert(roles, DeepEquals, []string{"learner"})
 
 	// test echo
 	echo := pdctl.GetEcho([]string{"-u", pdAddr, "scheduler", "add", "balance-region-scheduler"})

--- a/tools/pd-ctl/pdctl/command/scheduler.go
+++ b/tools/pd-ctl/pdctl/command/scheduler.go
@@ -439,7 +439,7 @@ func NewConfigSchedulerCommand() *cobra.Command {
 func newConfigHotRegionCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "balance-hot-region-scheduler",
-		Short: "show evict-leader-scheduler config",
+		Short: "evict-leader-scheduler config",
 		Run:   listSchedulerConfigCommandFunc,
 	}
 	c.AddCommand(&cobra.Command{
@@ -456,7 +456,7 @@ func newConfigHotRegionCommand() *cobra.Command {
 func newConfigEvictLeaderCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "evict-leader-scheduler",
-		Short: "show evict-leader-scheduler config",
+		Short: "evict-leader-scheduler config",
 		Run:   listSchedulerConfigCommandFunc,
 	}
 	c.AddCommand(&cobra.Command{
@@ -474,7 +474,7 @@ func newConfigEvictLeaderCommand() *cobra.Command {
 func newConfigGrantLeaderCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "grant-leader-scheduler",
-		Short: "show grant-leader-scheduler config",
+		Short: "grant-leader-scheduler config",
 		Run:   listSchedulerConfigCommandFunc,
 	}
 	c.AddCommand(&cobra.Command{
@@ -493,10 +493,11 @@ func newConfigShuffleRegionCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "shuffle-region-scheduler",
 		Short: "shuffle-region-scheduler config",
+		Run:   showShuffleRegionSchedulerRolesCommandFunc,
 	}
 	c.AddCommand(&cobra.Command{
 		Use:   "show-roles",
-		Short: "show affected roles (leader,follower,learner)",
+		Short: "show affected roles (leader, follower, learner)",
 		Run:   showShuffleRegionSchedulerRolesCommandFunc,
 	}, &cobra.Command{
 		Use:   "set-roles [leader,][follower,][learner]",
@@ -594,7 +595,11 @@ func showShuffleRegionSchedulerRolesCommandFunc(cmd *cobra.Command, args []strin
 		cmd.Println(cmd.UsageString())
 		return
 	}
-	path := path.Join(schedulerConfigPrefix, cmd.Parent().Name(), "roles")
+	p := cmd.Name()
+	if p == "show-roles" {
+		p = cmd.Parent().Name()
+	}
+	path := path.Join(schedulerConfigPrefix, p, "roles")
 	r, err := doRequest(cmd, path, http.MethodGet)
 	if err != nil {
 		cmd.Println(err)


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fix #2356.

### What is changed and how it works?
This PR adds default output for shuffle-region-scheduler when using `scheduler config` subcommand.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- Fix the issue that there is no default output when using `scheduler config shuffle-region-scheduler` in pd-ctl.