### PR TITLE
*: add edtion information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ DEADLOCK_DISABLE := $$(\
 BUILD_FLAGS ?=
 BUILD_TAGS ?=
 BUILD_CGO_ENABLED := 0
+EDITION ?= Community
 
 ifneq ($(SWAGGER), 0)
 	BUILD_TAGS += swagger_server
@@ -54,6 +55,7 @@ LDFLAGS += -X "$(PD_PKG)/server.PDReleaseVersion=$(shell git describe --tags --d
 LDFLAGS += -X "$(PD_PKG)/server.PDBuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
 LDFLAGS += -X "$(PD_PKG)/server.PDGitHash=$(shell git rev-parse HEAD)"
 LDFLAGS += -X "$(PD_PKG)/server.PDGitBranch=$(shell git rev-parse --abbrev-ref HEAD)"
+LDFLAGS += -X "$(PD_PKG)/server.PDEdition=$(EDITION)"
 
 GOVER_MAJOR := $(shell go version | sed -E -e "s/.*go([0-9]+)[.]([0-9]+).*/\1/")
 GOVER_MINOR := $(shell go version | sed -E -e "s/.*go([0-9]+)[.]([0-9]+).*/\2/")

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ DEADLOCK_DISABLE := $$(\
 BUILD_FLAGS ?=
 BUILD_TAGS ?=
 BUILD_CGO_ENABLED := 0
-EDITION ?= Community
+PD_EDITION ?= Community
 
 ifneq ($(SWAGGER), 0)
 	BUILD_TAGS += swagger_server
@@ -55,7 +55,7 @@ LDFLAGS += -X "$(PD_PKG)/server.PDReleaseVersion=$(shell git describe --tags --d
 LDFLAGS += -X "$(PD_PKG)/server.PDBuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
 LDFLAGS += -X "$(PD_PKG)/server.PDGitHash=$(shell git rev-parse HEAD)"
 LDFLAGS += -X "$(PD_PKG)/server.PDGitBranch=$(shell git rev-parse --abbrev-ref HEAD)"
-LDFLAGS += -X "$(PD_PKG)/server.PDEdition=$(EDITION)"
+LDFLAGS += -X "$(PD_PKG)/server.PDEdition=$(PD_EDITION)"
 
 GOVER_MAJOR := $(shell go version | sed -E -e "s/.*go([0-9]+)[.]([0-9]+).*/\1/")
 GOVER_MINOR := $(shell go version | sed -E -e "s/.*go([0-9]+)[.]([0-9]+).*/\2/")

--- a/server/util.go
+++ b/server/util.go
@@ -42,12 +42,14 @@ var (
 	PDBuildTS        = "None"
 	PDGitHash        = "None"
 	PDGitBranch      = "None"
+	PDEdition        = "None"
 )
 
 // LogPDInfo prints the PD version information.
 func LogPDInfo() {
 	log.Info("Welcome to Placement Driver (PD)")
 	log.Info("PD", zap.String("release-version", PDReleaseVersion))
+	log.Info("PD", zap.String("edition", PDEdition))
 	log.Info("PD", zap.String("git-hash", PDGitHash))
 	log.Info("PD", zap.String("git-branch", PDGitBranch))
 	log.Info("PD", zap.String("utc-build-time", PDBuildTS))
@@ -56,6 +58,7 @@ func LogPDInfo() {
 // PrintPDInfo prints the PD version information without log info.
 func PrintPDInfo() {
 	fmt.Println("Release Version:", PDReleaseVersion)
+	fmt.Println("Edition:", PDEdition)
 	fmt.Println("Git Commit Hash:", PDGitHash)
 	fmt.Println("Git Branch:", PDGitBranch)
 	fmt.Println("UTC Build Time: ", PDBuildTS)


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
ref https://github.com/pingcap/tidb/pull/17170

needs to distinguish `Enterprise` and `Community` editions after v4.0.0 GA, and print the edition information in the log.

### What is changed and how it works?

- add a compile option.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)
```
❯ ./bin/pd-server -V
Release Version: v4.0.0-rc-49-g0e3d2188-dirty
Edition: Community
Git Commit Hash: 0e3d21884c952afe96af96b8c4f0ef851d5a9204
Git Branch: edition
UTC Build Time:  2020-05-13 09:56:14
```

### Release note

- add the edtion infromation.