### PR TITLE
config: resolve data path to absolute directory

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -253,6 +253,13 @@ func adjustSchedulers(v *SchedulerConfigs, defValue SchedulerConfigs) {
 	}
 }
 
+func adjustPath(p *string) {
+	absPath, err := filepath.Abs(*p)
+	if err != nil {
+		*p = absPath
+	}
+}
+
 // Parse parses flag definitions from the argument list.
 func (c *Config) Parse(arguments []string) error {
 	// Parse first to get config file.
@@ -382,6 +389,7 @@ func (c *Config) Adjust(meta *toml.MetaData) error {
 		adjustString(&c.Name, fmt.Sprintf("%s-%s", defaultName, hostname))
 	}
 	adjustString(&c.DataDir, fmt.Sprintf("default.%s", c.Name))
+	adjustPath(&c.DataDir)
 
 	if err := c.Validate(); err != nil {
 		return err

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -255,7 +255,7 @@ func adjustSchedulers(v *SchedulerConfigs, defValue SchedulerConfigs) {
 
 func adjustPath(p *string) {
 	absPath, err := filepath.Abs(*p)
-	if err != nil {
+	if err == nil {
 		*p = absPath
 	}
 }


### PR DESCRIPTION
Signed-off-by: Breezewish <me@breeswish.org>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

This PR resolves data path to an absolute directory, like what [TiKV did](https://github.com/tikv/tikv/blob/007556d3bc0ae058d08caed39e71c4ddd4de4195/src/storage/config.rs#L59).

This make PD instance to display correctly in TiDB Dashboard since TiDB Dashboard uses the data-directory to determine which disk information need to be displayed. Other paths are untouched for now.

### What is changed and how it works?

Resolve to absolute directory in config adjust.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test : After this change TiDB Dashboard becomes normal

- Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

Resolve data directory to absolute path.