### PR TITLE
Improve the heartbeat processing by not remove region from the tree

### DIFF
--- a/server/core/region.go
+++ b/server/core/region.go
@@ -580,7 +580,7 @@ func (r *RegionsInfo) GetRegion(regionID uint64) *RegionInfo {
 // SetRegion sets the RegionInfo with regionID
 func (r *RegionsInfo) SetRegion(region *RegionInfo) []*RegionInfo {
 	if origin := r.regions.Get(region.GetID()); origin != nil {
-		if bytes.Compare(origin.GetStartKey(), region.GetStartKey()) != 0 || bytes.Compare(origin.GetEndKey(), region.GetEndKey()) != 0 {
+		if !bytes.Equal(origin.GetStartKey(), region.GetStartKey()) || !bytes.Equal(origin.GetEndKey(), region.GetEndKey()) {
 			r.removeRegionFromTreeAndMap(origin)
 		}
 		if r.shouldRemoveFromSubTree(region, origin) {
@@ -612,8 +612,8 @@ func (r *RegionsInfo) AddRegion(region *RegionInfo) []*RegionInfo {
 	if origin := r.GetRegion(region.GetID()); origin != nil {
 		if regionOld := r.tree.find(region); regionOld != nil {
 			// Update to tree.
-			if bytes.Compare(regionOld.region.GetStartKey(), region.GetStartKey()) == 0 &&
-				bytes.Compare(regionOld.region.GetEndKey(), region.GetEndKey()) == 0 &&
+			if bytes.Equal(regionOld.region.GetStartKey(), region.GetStartKey()) &&
+				bytes.Equal(regionOld.region.GetEndKey(), region.GetEndKey()) &&
 				regionOld.region.GetID() == region.GetID() {
 				regionOld.region = region
 				treeNeedAdd = false

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -607,7 +607,9 @@ func (r *RegionsInfo) GetOverlaps(region *RegionInfo) []*RegionInfo {
 
 // AddRegion adds RegionInfo to regionTree and regionMap, also update leaders and followers by region peers
 func (r *RegionsInfo) AddRegion(region *RegionInfo) []*RegionInfo {
+	// the regions which are overlapped with the specified region range.
 	var overlaps []*RegionInfo
+	// when the value is true, add the region to the tree. otherwise use the region replace the origin region in the tree.
 	treeNeedAdd := true
 	if origin := r.GetRegion(region.GetID()); origin != nil {
 		if regionOld := r.tree.find(region); regionOld != nil {

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -178,6 +178,30 @@ func (*testRegionKey) TestSetRegion(c *C) {
 	checkRegions(c, regions)
 	c.Assert(regions.tree.length(), Equals, 97)
 	c.Assert(len(regions.GetRegions()), Equals, 97)
+
+	// Test remove overlaps.
+	region = region.Clone(WithStartKey([]byte(fmt.Sprintf("%20d", 175))), WithNewRegionID(201))
+	c.Assert(regions.GetRegion(21), NotNil)
+	c.Assert(regions.GetRegion(18), NotNil)
+	regions.SetRegion(region)
+	checkRegions(c, regions)
+	c.Assert(regions.tree.length(), Equals, 96)
+	c.Assert(len(regions.GetRegions()), Equals, 96)
+	c.Assert(regions.GetRegion(201), NotNil)
+	c.Assert(regions.GetRegion(21), IsNil)
+	c.Assert(regions.GetRegion(18), IsNil)
+
+	// Test update keys and size of region.
+	region = region.Clone()
+	region.approximateKeys = 20
+	region.approximateSize = 30
+	regions.SetRegion(region)
+	checkRegions(c, regions)
+	c.Assert(regions.tree.length(), Equals, 96)
+	c.Assert(len(regions.GetRegions()), Equals, 96)
+	c.Assert(regions.GetRegion(201), NotNil)
+	c.Assert(regions.regions.totalKeys, Equals, int64(20))
+	c.Assert(regions.regions.totalSize, Equals, int64(30))
 }
 
 func (*testRegionKey) TestShouldRemoveFromSubTree(c *C) {


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
UCP: #2431 
Improve the heartbeat processing

### What is changed and how it works?
When removing the region, try not to remove the region from the region tree,

The test conditions are: 1 million region 20store 0.1 region-update-ratio, 10heartbeat-rounds. The average heartbeat is the average of the last 9 times.

the improve percent like this:
no.|improve content |related code |average heartbeat/s | improve percent
---|---|---|---|---
1|   master branch |     |   101652 | 0%    
2|use ShallowClone when UpdateStoreStatus.|   store.go 666: newStore := store.ShallowClone(SetLeaderCount(leaderCount),  | 124109   |     22%
3|use reduce the number of updates when update related stores.|   cluster.go 572-583: c.updateStoreStatusLocked(key),  | 132076   |     7.8%
4|try not to remove the region from the subTree.|   region.go 580-584: shouldRemoveFromSubTree,  | 151024   |     18.6%
5|try not to remove the region from the tree.|   region.go 610-629: AddRegion,  | 168702   |     17.4%


Tests <!-- At least one of them must be included. -->

 - Unit test
