### PR TITLE
Improve the heartbeat processing by reduce the number of getOverlaps.

### DIFF
--- a/server/core/basic_cluster.go
+++ b/server/core/basic_cluster.go
@@ -14,6 +14,7 @@
 package core
 
 import (
+	"bytes"
 	"sync"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -288,13 +289,15 @@ func (bc *BasicCluster) TakeStore(storeID uint64) *StoreInfo {
 // PreCheckPutRegion checks if the region is valid to put.
 func (bc *BasicCluster) PreCheckPutRegion(region *RegionInfo) (*RegionInfo, error) {
 	bc.RLock()
-	for _, item := range bc.Regions.GetOverlaps(region) {
-		if region.GetRegionEpoch().GetVersion() < item.GetRegionEpoch().GetVersion() {
-			bc.RUnlock()
-			return nil, ErrRegionIsStale(region.GetMeta(), item.GetMeta())
+	origin := bc.Regions.GetRegion(region.GetID())
+	if origin == nil || !bytes.Equal(origin.GetStartKey(), region.GetStartKey()) || !bytes.Equal(origin.GetEndKey(), region.GetEndKey()) {
+		for _, item := range bc.Regions.GetOverlaps(region) {
+			if region.GetRegionEpoch().GetVersion() < item.GetRegionEpoch().GetVersion() {
+				bc.RUnlock()
+				return nil, ErrRegionIsStale(region.GetMeta(), item.GetMeta())
+			}
 		}
 	}
-	origin := bc.Regions.GetRegion(region.GetID())
 	bc.RUnlock()
 	if origin == nil {
 		return nil, nil


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
UCP: #2430 
Improve the heartbeat processing

### What is changed and how it works?
When call the method of PreCheckPutRegion, reduce the number of calls to the method getOverlaps.

The test conditions are: 1 million region 20store 0.1 region-update-ratio, 10heartbeat-rounds. The average heartbeat is the average of the last 9 times.

the improve percent like this:
no.|improve content |related code |average heartbeat/s | improve percent
---|---|---|---|---
1|   master branch |     |   101652 | 0%    
2|use ShallowClone when UpdateStoreStatus.|   store.go 666: newStore := store.ShallowClone(),  | 124109   |     22%
3|use reduce the number of updates when update related stores.|   cluster.go 572-583: c.updateStoreStatusLocked(key),  | 132076   |     7.8%
4|try not to remove the region from the subTree.|   region.go 580-584: shouldRemoveFromSubTree,  | 151024   |     18.6%
5|try not to remove the region from the tree.|   region.go 610-629: AddRegion,  | 168702   |     17.4%
6|reduce the number of calls to the method getOverlaps.|   basic_cluster.go 292-297: PreCheckPutRegion,  | 203152   |     33.9%


Tests <!-- At least one of them must be included. -->

 - Unit test

