### PR TITLE
schedule: combine store limit and store balance rate

### DIFF
--- a/conf/simconfig.toml
+++ b/conf/simconfig.toml
@@ -29,4 +29,3 @@ leader-schedule-limit = 32
 region-schedule-limit = 128
 replica-schedule-limit = 32
 merge-schedule-limit = 32
-store-balance-rate = 512.0

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/pd/v4/server/core"
 	"github.com/pingcap/pd/v4/server/kv"
 	"github.com/pingcap/pd/v4/server/schedule/placement"
+	"github.com/pingcap/pd/v4/server/schedule/storelimit"
 	"github.com/pingcap/pd/v4/server/statistics"
 	"go.uber.org/zap"
 )
@@ -203,6 +204,8 @@ func (mc *Cluster) AddLeaderStore(storeID uint64, leaderCount int, leaderSizes .
 		core.SetLeaderSize(leaderSize),
 		core.SetLastHeartbeatTS(time.Now()),
 	)
+	mc.SetStoreLimit(storeID, storelimit.AddPeer, 60)
+	mc.SetStoreLimit(storeID, storelimit.RemovePeer, 60)
 	mc.PutStore(store)
 }
 
@@ -218,6 +221,8 @@ func (mc *Cluster) AddRegionStore(storeID uint64, regionCount int) {
 		core.SetRegionSize(int64(regionCount)*10),
 		core.SetLastHeartbeatTS(time.Now()),
 	)
+	mc.SetStoreLimit(storeID, storelimit.AddPeer, 60)
+	mc.SetStoreLimit(storeID, storelimit.RemovePeer, 60)
 	mc.PutStore(store)
 }
 
@@ -253,6 +258,8 @@ func (mc *Cluster) AddLabelsStore(storeID uint64, regionCount int, labels map[st
 		core.SetRegionSize(int64(regionCount)*10),
 		core.SetLastHeartbeatTS(time.Now()),
 	)
+	mc.SetStoreLimit(storeID, storelimit.AddPeer, 60)
+	mc.SetStoreLimit(storeID, storelimit.RemovePeer, 60)
 	mc.PutStore(store)
 }
 
@@ -545,6 +552,11 @@ func (mc *Cluster) GetHotRegionScheduleLimit() uint64 {
 // GetMaxReplicas mocks method.
 func (mc *Cluster) GetMaxReplicas() int {
 	return mc.ScheduleOptions.GetMaxReplicas()
+}
+
+// GetStoreLimitByType mocks method.
+func (mc *Cluster) GetStoreLimitByType(storeID uint64, typ storelimit.Type) float64 {
+	return mc.ScheduleOptions.GetStoreLimitByType(storeID, typ)
 }
 
 // CheckLabelProperty checks label property.

--- a/pkg/mock/mockoption/mockoption.go
+++ b/pkg/mock/mockoption/mockoption.go
@@ -117,7 +117,6 @@ func NewScheduleOptions() *ScheduleOptions {
 	mso.TolerantSizeRatio = defaultTolerantSizeRatio
 	mso.LowSpaceRatio = defaultLowSpaceRatio
 	mso.HighSpaceRatio = defaultHighSpaceRatio
-	mso.StoreLimitMode = defaultStoreLimitMode
 	mso.EnableRemoveDownReplica = true
 	mso.EnableReplaceOfflineReplica = true
 	mso.EnableMakeUpReplica = true

--- a/pkg/mock/mockoption/mockoption.go
+++ b/pkg/mock/mockoption/mockoption.go
@@ -129,7 +129,7 @@ func NewScheduleOptions() *ScheduleOptions {
 	return mso
 }
 
-// SetStoreLimit is's only used to test.
+// SetStoreLimit mocks method
 func (mso *ScheduleOptions) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePerMin float64) {
 	var sc StoreLimitConfig
 	if _, ok := mso.StoreLimit[storeID]; ok {
@@ -151,7 +151,7 @@ func (mso *ScheduleOptions) SetStoreLimit(storeID uint64, typ storelimit.Type, r
 	mso.StoreLimit[storeID] = sc
 }
 
-// SetAllStoresLimit is's only used to test.
+// SetAllStoresLimit mocks method
 func (mso *ScheduleOptions) SetAllStoresLimit(typ storelimit.Type, ratePerMin float64) {
 	switch typ {
 	case storelimit.AddPeer:

--- a/pkg/mock/mockoption/mockoption.go
+++ b/pkg/mock/mockoption/mockoption.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/v4/server/core"
+	"github.com/pingcap/pd/v4/server/schedule/storelimit"
 )
 
 const (
@@ -33,7 +34,6 @@ const (
 	defaultReplicaScheduleLimit        = 64
 	defaultMergeScheduleLimit          = 8
 	defaultHotRegionScheduleLimit      = 4
-	defaultStoreBalanceRate            = 60
 	defaultTolerantSizeRatio           = 2.5
 	defaultLowSpaceRatio               = 0.8
 	defaultHighSpaceRatio              = 0.6
@@ -43,8 +43,14 @@ const (
 	defaultLeaderSchedulePolicy        = "count"
 	defaultEnablePlacementRules        = false
 	defaultKeyType                     = "table"
-	defaultStoreLimitMode              = "manual"
+	defaultStoreLimit                  = 60
 )
+
+// StoreLimitConfig is a mock of StoreLimitConfig.
+type StoreLimitConfig struct {
+	AddPeer    float64 `toml:"add-peer" json:"add-peer"`
+	RemovePeer float64 `toml:"remove-peer" json:"remove-peer"`
+}
 
 // ScheduleOptions is a mock of ScheduleOptions
 // which implements Options interface
@@ -54,7 +60,7 @@ type ScheduleOptions struct {
 	ReplicaScheduleLimit         uint64
 	MergeScheduleLimit           uint64
 	HotRegionScheduleLimit       uint64
-	StoreBalanceRate             float64
+	StoreLimit                   map[uint64]StoreLimitConfig
 	MaxSnapshotCount             uint64
 	MaxPendingPeerCount          uint64
 	MaxMergeRegionSize           uint64
@@ -97,7 +103,6 @@ func NewScheduleOptions() *ScheduleOptions {
 	mso.ReplicaScheduleLimit = defaultReplicaScheduleLimit
 	mso.MergeScheduleLimit = defaultMergeScheduleLimit
 	mso.HotRegionScheduleLimit = defaultHotRegionScheduleLimit
-	mso.StoreBalanceRate = defaultStoreBalanceRate
 	mso.MaxSnapshotCount = defaultMaxSnapshotCount
 	mso.MaxMergeRegionSize = defaultMaxMergeRegionSize
 	mso.MaxMergeRegionKeys = defaultMaxMergeRegionKeys
@@ -120,7 +125,46 @@ func NewScheduleOptions() *ScheduleOptions {
 	mso.EnableLocationReplacement = true
 	mso.LeaderSchedulePolicy = defaultLeaderSchedulePolicy
 	mso.KeyType = defaultKeyType
+	mso.StoreLimit = make(map[uint64]StoreLimitConfig)
 	return mso
+}
+
+// SetStoreLimit is's only used to test.
+func (mso *ScheduleOptions) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePerMin float64) {
+	var sc StoreLimitConfig
+	if _, ok := mso.StoreLimit[storeID]; ok {
+		switch typ {
+		case storelimit.AddPeer:
+			sc = StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: mso.StoreLimit[storeID].RemovePeer}
+		case storelimit.RemovePeer:
+			sc = StoreLimitConfig{AddPeer: mso.StoreLimit[storeID].AddPeer, RemovePeer: ratePerMin}
+		}
+	} else {
+		switch typ {
+		case storelimit.AddPeer:
+			sc = StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: defaultStoreLimit}
+		case storelimit.RemovePeer:
+			sc = StoreLimitConfig{AddPeer: defaultStoreLimit, RemovePeer: ratePerMin}
+		}
+	}
+
+	mso.StoreLimit[storeID] = sc
+}
+
+// SetAllStoresLimit is's only used to test.
+func (mso *ScheduleOptions) SetAllStoresLimit(typ storelimit.Type, ratePerMin float64) {
+	switch typ {
+	case storelimit.AddPeer:
+		for storeID := range mso.StoreLimit {
+			sc := StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: mso.StoreLimit[storeID].RemovePeer}
+			mso.StoreLimit[storeID] = sc
+		}
+	case storelimit.RemovePeer:
+		for storeID := range mso.StoreLimit {
+			sc := StoreLimitConfig{AddPeer: mso.StoreLimit[storeID].AddPeer, RemovePeer: ratePerMin}
+			mso.StoreLimit[storeID] = sc
+		}
+	}
 }
 
 // GetLeaderScheduleLimit mocks method
@@ -148,9 +192,20 @@ func (mso *ScheduleOptions) GetHotRegionScheduleLimit() uint64 {
 	return mso.HotRegionScheduleLimit
 }
 
-// GetStoreBalanceRate mocks method
-func (mso *ScheduleOptions) GetStoreBalanceRate() float64 {
-	return mso.StoreBalanceRate
+// GetStoreLimitByType mocks method
+func (mso *ScheduleOptions) GetStoreLimitByType(storeID uint64, typ storelimit.Type) float64 {
+	limit, ok := mso.StoreLimit[storeID]
+	if !ok {
+		return 0
+	}
+	switch typ {
+	case storelimit.AddPeer:
+		return limit.AddPeer
+	case storelimit.RemovePeer:
+		return limit.RemovePeer
+	default:
+		panic("no such limit type")
+	}
 }
 
 // GetMaxSnapshotCount mocks method
@@ -283,7 +338,7 @@ func (mso *ScheduleOptions) GetKeyType() core.KeyType {
 	return core.StringToKeyType(mso.KeyType)
 }
 
-// GetStoreLimitMode returns the limit mode of store.
-func (mso *ScheduleOptions) GetStoreLimitMode() string {
-	return mso.StoreLimitMode
+// CheckLabelProperty mocks method
+func (mso *ScheduleOptions) CheckLabelProperty(typ string, labels []*metapb.StoreLabel) bool {
+	return true
 }

--- a/server/api/store.go
+++ b/server/api/store.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pingcap/pd/v4/server"
 	"github.com/pingcap/pd/v4/server/config"
 	"github.com/pingcap/pd/v4/server/core"
-	"github.com/pingcap/pd/v4/server/schedule"
 	"github.com/pingcap/pd/v4/server/schedule/storelimit"
 	"github.com/pkg/errors"
 	"github.com/unrolled/render"
@@ -361,8 +360,8 @@ func (h *storeHandler) SetLimit(w http.ResponseWriter, r *http.Request) {
 		h.rd.JSON(w, http.StatusBadRequest, "rate unset")
 		return
 	}
-	rate, ok := rateVal.(float64)
-	if !ok || rate < 0 {
+	ratePerMin, ok := rateVal.(float64)
+	if !ok || ratePerMin < 0 {
 		h.rd.JSON(w, http.StatusBadRequest, "badformat rate")
 		return
 	}
@@ -373,7 +372,7 @@ func (h *storeHandler) SetLimit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.SetStoreLimit(storeID, rate/schedule.StoreBalanceBaseTime, typeValue); err != nil {
+	if err := h.SetStoreLimit(storeID, ratePerMin, typeValue); err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -431,8 +430,8 @@ func (h *storesHandler) SetAllLimit(w http.ResponseWriter, r *http.Request) {
 		h.rd.JSON(w, http.StatusBadRequest, "rate unset")
 		return
 	}
-	rate, ok := rateVal.(float64)
-	if !ok || rate < 0 {
+	ratePerMin, ok := rateVal.(float64)
+	if !ok || ratePerMin < 0 {
 		h.rd.JSON(w, http.StatusBadRequest, "badformat rate")
 		return
 	}
@@ -443,7 +442,7 @@ func (h *storesHandler) SetAllLimit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.SetAllStoresLimit(rate/schedule.StoreBalanceBaseTime, typeValue); err != nil {
+	if err := h.SetAllStoresLimit(ratePerMin, typeValue); err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -459,30 +458,8 @@ func (h *storesHandler) SetAllLimit(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /stores/limit [get]
 func (h *storesHandler) GetAllLimit(w http.ResponseWriter, r *http.Request) {
-	typeName := r.URL.Query().Get("type")
-	typeValue, err := parseStoreLimitType(typeName)
-	if err != nil {
-		h.rd.JSON(w, http.StatusBadRequest, err.Error())
-		return
-	}
-	limits, err := h.GetAllStoresLimit(typeValue)
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	type LimitResp struct {
-		Rate float64 `json:"rate"`
-		Mode string  `json:"mode"`
-	}
-	resp := make(map[uint64]*LimitResp)
-	for s, l := range limits {
-		resp[s] = &LimitResp{
-			Rate: l.Rate() * schedule.StoreBalanceBaseTime,
-			Mode: l.Mode().String(),
-		}
-	}
-
-	h.rd.JSON(w, http.StatusOK, resp)
+	limits := h.GetScheduleConfig().StoreLimit
+	h.rd.JSON(w, http.StatusOK, limits)
 }
 
 // @Tags store
@@ -609,7 +586,7 @@ func (filter *storeStateFilter) filter(stores []*metapb.Store) []*metapb.Store {
 
 func getStoreLimitType(input map[string]interface{}) (storelimit.Type, error) {
 	typeNameIface, ok := input["type"]
-	typeValue := storelimit.RegionAdd
+	typeValue := storelimit.AddPeer
 	var err error
 	if ok {
 		typeName, ok := typeNameIface.(string)
@@ -623,7 +600,7 @@ func getStoreLimitType(input map[string]interface{}) (storelimit.Type, error) {
 }
 
 func parseStoreLimitType(typeName string) (storelimit.Type, error) {
-	typeValue := storelimit.RegionAdd
+	typeValue := storelimit.AddPeer
 	var err error
 	if typeName != "" {
 		if value, ok := storelimit.TypeNameValue[typeName]; ok {

--- a/server/api/trend_test.go
+++ b/server/api/trend_test.go
@@ -20,7 +20,6 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/v4/server"
-	"github.com/pingcap/pd/v4/server/config"
 	"github.com/pingcap/pd/v4/server/core"
 	"github.com/pingcap/pd/v4/server/schedule/operator"
 )
@@ -30,7 +29,7 @@ var _ = Suite(&testTrendSuite{})
 type testTrendSuite struct{}
 
 func (s *testTrendSuite) TestTrend(c *C) {
-	svr, cleanup := mustNewServer(c, func(cfg *config.Config) { cfg.Schedule.StoreBalanceRate = 60 })
+	svr, cleanup := mustNewServer(c)
 	defer cleanup()
 	mustWaitLeader(c, []*server.Server{svr})
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -54,6 +54,7 @@ var backgroundJobInterval = 10 * time.Second
 const (
 	clientTimeout              = 3 * time.Second
 	defaultChangedRegionsLimit = 10000
+	defaultStoreLimit          = 15
 )
 
 // Server is the interface for cluster.
@@ -244,7 +245,7 @@ func (c *RaftCluster) Start(s Server) error {
 
 	c.coordinator = newCoordinator(c.ctx, cluster, s.GetHBStreams())
 	c.regionStats = statistics.NewRegionStatistics(c.opt)
-	c.limiter = NewStoreLimiter(c.coordinator.opController)
+	c.limiter = NewStoreLimiter(s.GetPersistOptions())
 	c.quit = make(chan struct{})
 
 	c.wg.Add(4)
@@ -967,8 +968,7 @@ func (c *RaftCluster) RemoveStore(storeID uint64) error {
 		zap.String("store-address", newStore.GetAddress()))
 	err := c.putStoreLocked(newStore)
 	if err == nil {
-		// set the remove peer limit of the store to unlimited
-		c.coordinator.opController.SetStoreLimit(store.GetID(), storelimit.Unlimited, storelimit.Manual, storelimit.RegionRemove)
+		c.SetStoreLimit(storeID, storelimit.RemovePeer, storelimit.Unlimited)
 	}
 	return err
 }
@@ -1004,7 +1004,7 @@ func (c *RaftCluster) BuryStore(storeID uint64, force bool) error {
 		zap.String("store-address", newStore.GetAddress()))
 	err := c.putStoreLocked(newStore)
 	if err == nil {
-		c.coordinator.opController.RemoveStoreLimit(store.GetID())
+		c.RemoveStoreLimit(storeID)
 	}
 	return err
 }
@@ -1132,7 +1132,7 @@ func (c *RaftCluster) RemoveTombStoneRecords() error {
 					zap.Error(err))
 				return err
 			}
-			c.coordinator.opController.RemoveStoreLimit(store.GetID())
+			c.RemoveStoreLimit(store.GetID())
 			log.Info("delete store succeeded",
 				zap.Stringer("store", store.GetMeta()))
 		}
@@ -1360,11 +1360,6 @@ func (c *RaftCluster) GetMergeScheduleLimit() uint64 {
 // GetHotRegionScheduleLimit returns the limit for hot region schedule.
 func (c *RaftCluster) GetHotRegionScheduleLimit() uint64 {
 	return c.opt.GetHotRegionScheduleLimit()
-}
-
-// GetStoreBalanceRate returns the balance rate of a store.
-func (c *RaftCluster) GetStoreBalanceRate() float64 {
-	return c.opt.GetStoreBalanceRate()
 }
 
 // GetTolerantSizeRatio gets the tolerant size ratio.
@@ -1677,6 +1672,42 @@ func (c *RaftCluster) PauseOrResumeScheduler(name string, t int64) error {
 // GetStoreLimiter returns the dynamic adjusting limiter
 func (c *RaftCluster) GetStoreLimiter() *StoreLimiter {
 	return c.limiter
+}
+
+// GetStoreLimitByType returns the store limit for a given store ID and type.
+func (c *RaftCluster) GetStoreLimitByType(storeID uint64, typ storelimit.Type) float64 {
+	return c.opt.GetStoreLimitByType(storeID, typ)
+}
+
+// GetAllStoresLimit returns all store limit
+func (c *RaftCluster) GetAllStoresLimit() map[uint64]config.StoreLimitConfig {
+	return c.opt.GetAllStoresLimit()
+}
+
+// AddStoreLimit add a store limit for a given store ID.
+func (c *RaftCluster) AddStoreLimit(storeID uint64) {
+	cfg := c.opt.GetScheduleConfig().Clone()
+	sc := config.StoreLimitConfig{
+		AddPeer:    defaultStoreLimit,
+		RemovePeer: defaultStoreLimit,
+	}
+	cfg.StoreLimit[storeID] = sc
+	c.opt.SetScheduleConfig(cfg)
+}
+
+// RemoveStoreLimit remove a store limit for a given store ID.
+func (c *RaftCluster) RemoveStoreLimit(storeID uint64) {
+	cfg := c.opt.GetScheduleConfig().Clone()
+	for _, limitType := range storelimit.TypeNameValue {
+		c.AttachAvailableFunc(storeID, limitType, nil)
+	}
+	delete(cfg.StoreLimit, storeID)
+	c.opt.SetScheduleConfig(cfg)
+}
+
+// SetStoreLimit sets a store limit for a given type and rate.
+func (c *RaftCluster) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePerMin float64) {
+	c.opt.SetStoreLimit(storeID, typ, ratePerMin)
 }
 
 var healthURL = "/pd/api/v1/ping"

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -54,7 +54,6 @@ var backgroundJobInterval = 10 * time.Second
 const (
 	clientTimeout              = 3 * time.Second
 	defaultChangedRegionsLimit = 10000
-	defaultStoreLimit          = 15
 )
 
 // Server is the interface for cluster.
@@ -1688,8 +1687,8 @@ func (c *RaftCluster) GetAllStoresLimit() map[uint64]config.StoreLimitConfig {
 func (c *RaftCluster) AddStoreLimit(storeID uint64) {
 	cfg := c.opt.GetScheduleConfig().Clone()
 	sc := config.StoreLimitConfig{
-		AddPeer:    defaultStoreLimit,
-		RemovePeer: defaultStoreLimit,
+		AddPeer:    config.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
+		RemovePeer: config.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
 	}
 	cfg.StoreLimit[storeID] = sc
 	c.opt.SetScheduleConfig(cfg)

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1710,6 +1710,11 @@ func (c *RaftCluster) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePer
 	c.opt.SetStoreLimit(storeID, typ, ratePerMin)
 }
 
+// SetAllStoresLimit sets all store limit for a given type and rate.
+func (c *RaftCluster) SetAllStoresLimit(typ storelimit.Type, ratePerMin float64) {
+	c.opt.SetAllStoresLimit(typ, ratePerMin)
+}
+
 var healthURL = "/pd/api/v1/ping"
 
 // CheckHealth checks if members are healthy.

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -656,7 +656,6 @@ type testCluster struct {
 func newTestScheduleConfig() (*config.ScheduleConfig, *config.PersistOptions, error) {
 	cfg := config.NewConfig()
 	cfg.Schedule.TolerantSizeRatio = 5
-	cfg.Schedule.StoreBalanceRate = 60
 	if err := cfg.Adjust(nil); err != nil {
 		return nil, nil, err
 	}

--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -546,7 +546,7 @@ func (c *coordinator) pauseOrResumeScheduler(name string, t int64) error {
 	}
 	var err error
 	for _, sc := range s {
-		var delayUntil int64 = 0
+		var delayUntil int64
 		if t > 0 {
 			delayUntil = time.Now().Unix() + t
 		}

--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -67,6 +67,9 @@ func (c *testCluster) addRegionStore(storeID uint64, regionCount int, regionSize
 		core.SetRegionSize(int64(regionSize)),
 		core.SetLastHeartbeatTS(time.Now()),
 	)
+
+	c.SetStoreLimit(storeID, storelimit.AddPeer, 60)
+	c.SetStoreLimit(storeID, storelimit.RemovePeer, 60)
 	c.Lock()
 	defer c.Unlock()
 	return c.putStoreLocked(newStore)
@@ -103,6 +106,9 @@ func (c *testCluster) addLeaderStore(storeID uint64, leaderCount int) error {
 		core.SetLeaderSize(int64(leaderCount)*10),
 		core.SetLastHeartbeatTS(time.Now()),
 	)
+
+	c.SetStoreLimit(storeID, storelimit.AddPeer, 60)
+	c.SetStoreLimit(storeID, storelimit.RemovePeer, 60)
 	c.Lock()
 	defer c.Unlock()
 	return c.putStoreLocked(newStore)
@@ -907,15 +913,12 @@ func (s *testOperatorControllerSuite) TestOperatorCount(c *C) {
 }
 
 func (s *testOperatorControllerSuite) TestStoreOverloaded(c *C) {
-	tc, co, cleanup := prepare(func(cfg *config.ScheduleConfig) {
-		// scheduling one time needs 60 seconds
-		// and thus it's large enough to make sure that only schedule one time
-		cfg.StoreBalanceRate = 1
-	}, nil, nil, c)
+	tc, co, cleanup := prepare(nil, nil, nil, c)
 	defer cleanup()
 	oc := co.opController
 	lb, err := schedule.CreateScheduler(schedulers.BalanceRegionType, oc, tc.storage, schedule.ConfigSliceDecoder(schedulers.BalanceRegionType, []string{"", ""}))
 	c.Assert(err, IsNil)
+	opt := tc.GetOpt()
 	c.Assert(tc.addRegionStore(4, 100), IsNil)
 	c.Assert(tc.addRegionStore(3, 100), IsNil)
 	c.Assert(tc.addRegionStore(2, 100), IsNil)
@@ -935,9 +938,9 @@ func (s *testOperatorControllerSuite) TestStoreOverloaded(c *C) {
 
 	// reset all stores' limit
 	// scheduling one time needs 1/10 seconds
-	oc.SetAllStoresLimit(10, storelimit.Manual, storelimit.RegionAdd)
-	oc.SetAllStoresLimit(10, storelimit.Manual, storelimit.RegionRemove)
-
+	opt.SetAllStoresLimit(storelimit.AddPeer, 600)
+	opt.SetAllStoresLimit(storelimit.RemovePeer, 600)
+	time.Sleep(1 * time.Second)
 	for i := 0; i < 10; i++ {
 		op1 := lb.Schedule(tc)[0]
 		c.Assert(op1, NotNil)
@@ -952,10 +955,7 @@ func (s *testOperatorControllerSuite) TestStoreOverloaded(c *C) {
 }
 
 func (s *testOperatorControllerSuite) TestStoreOverloadedWithReplace(c *C) {
-	tc, co, cleanup := prepare(func(cfg *config.ScheduleConfig) {
-		// scheduling one time needs 2 seconds
-		cfg.StoreBalanceRate = 30
-	}, nil, nil, c)
+	tc, co, cleanup := prepare(nil, nil, nil, c)
 	defer cleanup()
 	oc := co.opController
 	lb, err := schedule.CreateScheduler(schedulers.BalanceRegionType, oc, tc.storage, schedule.ConfigSliceDecoder(schedulers.BalanceRegionType, []string{"", ""}))

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -715,6 +715,7 @@ const (
 	defaultHotRegionCacheHitsThreshold = 3
 	defaultSchedulerMaxWaitingOperator = 5
 	defaultLeaderSchedulePolicy        = "count"
+	defaultStoreLimitMode              = "manual"
 )
 
 func (c *ScheduleConfig) adjust(meta *configMetaData) error {
@@ -759,6 +760,9 @@ func (c *ScheduleConfig) adjust(meta *configMetaData) error {
 	}
 	if !meta.IsDefined("leader-schedule-policy") {
 		adjustString(&c.LeaderSchedulePolicy, defaultLeaderSchedulePolicy)
+	}
+	if !meta.IsDefined("store-limit-mode") {
+		adjustString(&c.StoreLimitMode, defaultStoreLimitMode)
 	}
 	adjustFloat64(&c.LowSpaceRatio, defaultLowSpaceRatio)
 	adjustFloat64(&c.HighSpaceRatio, defaultHighSpaceRatio)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -824,25 +824,7 @@ func (c *ScheduleConfig) Deprecated() error {
 	return nil
 }
 
-var deprecateConfigs = []string{
-	"disable-remove-down-replica",
-	"disable-replace-offline-replica",
-	"disable-make-up-replica",
-	"disable-remove-extra-replica",
-	"disable-location-replacement",
-}
-
-// IsDeprecated returns if a config is deprecated.
-func IsDeprecated(config string) bool {
-	for _, t := range deprecateConfigs {
-		if t == config {
-			return true
-		}
-	}
-	return false
-}
-
-// StoreLimitConfig ...
+// StoreLimitConfig is a config about scheduling rate limit of different types for a store.
 type StoreLimitConfig struct {
 	AddPeer    float64 `toml:"add-peer" json:"add-peer"`
 	RemovePeer float64 `toml:"remove-peer" json:"remove-peer"`

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -715,7 +715,6 @@ const (
 	defaultHotRegionCacheHitsThreshold = 3
 	defaultSchedulerMaxWaitingOperator = 5
 	defaultLeaderSchedulePolicy        = "count"
-	defaultStoreLimitMode              = "manual"
 )
 
 func (c *ScheduleConfig) adjust(meta *configMetaData) error {
@@ -760,9 +759,6 @@ func (c *ScheduleConfig) adjust(meta *configMetaData) error {
 	}
 	if !meta.IsDefined("leader-schedule-policy") {
 		adjustString(&c.LeaderSchedulePolicy, defaultLeaderSchedulePolicy)
-	}
-	if !meta.IsDefined("store-limit-mode") {
-		adjustString(&c.StoreLimitMode, defaultStoreLimitMode)
 	}
 	adjustFloat64(&c.LowSpaceRatio, defaultLowSpaceRatio)
 	adjustFloat64(&c.HighSpaceRatio, defaultHighSpaceRatio)

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/pd/v4/server/core"
 	"github.com/pingcap/pd/v4/server/kv"
 	"github.com/pingcap/pd/v4/server/schedule"
+	"github.com/pingcap/pd/v4/server/schedule/storelimit"
 )
 
 // PersistOptions wraps all configurations that need to persist to storage and
@@ -175,6 +176,50 @@ func (o *PersistOptions) SetSplitMergeInterval(splitMergeInterval time.Duration)
 	o.SetScheduleConfig(v)
 }
 
+// SetStoreLimit sets a store limit for a given type and rate.
+func (o *PersistOptions) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePerMin float64) {
+	v := o.GetScheduleConfig().Clone()
+	var sc StoreLimitConfig
+	var rate float64
+	switch typ {
+	case storelimit.AddPeer:
+		if _, ok := v.StoreLimit[storeID]; !ok {
+			rate = defaultStoreLimit
+		} else {
+			rate = v.StoreLimit[storeID].RemovePeer
+		}
+		sc = StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: rate}
+	case storelimit.RemovePeer:
+		if _, ok := v.StoreLimit[storeID]; !ok {
+			rate = defaultStoreLimit
+		} else {
+			rate = v.StoreLimit[storeID].AddPeer
+		}
+		sc = StoreLimitConfig{AddPeer: rate, RemovePeer: ratePerMin}
+	}
+	v.StoreLimit[storeID] = sc
+	o.SetScheduleConfig(v)
+}
+
+// SetAllStoresLimit sets all store limit for a given type and rate.
+func (o *PersistOptions) SetAllStoresLimit(typ storelimit.Type, ratePerMin float64) {
+	v := o.GetScheduleConfig().Clone()
+	switch typ {
+	case storelimit.AddPeer:
+		for storeID := range v.StoreLimit {
+			sc := StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: v.StoreLimit[storeID].RemovePeer}
+			v.StoreLimit[storeID] = sc
+		}
+	case storelimit.RemovePeer:
+		for storeID := range v.StoreLimit {
+			sc := StoreLimitConfig{AddPeer: v.StoreLimit[storeID].AddPeer, RemovePeer: ratePerMin}
+			v.StoreLimit[storeID] = sc
+		}
+	}
+
+	o.SetScheduleConfig(v)
+}
+
 // IsOneWayMergeEnabled returns if a region can only be merged into the next region of it.
 func (o *PersistOptions) IsOneWayMergeEnabled() bool {
 	return o.GetScheduleConfig().EnableOneWayMerge
@@ -220,9 +265,30 @@ func (o *PersistOptions) GetHotRegionScheduleLimit() uint64 {
 	return o.GetScheduleConfig().HotRegionScheduleLimit
 }
 
-// GetStoreBalanceRate returns the balance rate of a store.
-func (o *PersistOptions) GetStoreBalanceRate() float64 {
-	return o.GetScheduleConfig().StoreBalanceRate
+// GetStoreLimit returns the limit of a store.
+func (o *PersistOptions) GetStoreLimit(storeID uint64) StoreLimitConfig {
+	if limit, ok := o.GetScheduleConfig().StoreLimit[storeID]; ok {
+		return limit
+	}
+	return StoreLimitConfig{0, 0}
+}
+
+// GetStoreLimitByType returns the limit of a store with a given type.
+func (o *PersistOptions) GetStoreLimitByType(storeID uint64, typ storelimit.Type) float64 {
+	limit := o.GetStoreLimit(storeID)
+	switch typ {
+	case storelimit.AddPeer:
+		return limit.AddPeer
+	case storelimit.RemovePeer:
+		return limit.RemovePeer
+	default:
+		panic("no such limit type")
+	}
+}
+
+// GetAllStoresLimit returns the limit of all stores.
+func (o *PersistOptions) GetAllStoresLimit() map[uint64]StoreLimitConfig {
+	return o.GetScheduleConfig().StoreLimit
 }
 
 // GetStoreLimitMode returns the limit mode of store.

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -184,14 +184,14 @@ func (o *PersistOptions) SetStoreLimit(storeID uint64, typ storelimit.Type, rate
 	switch typ {
 	case storelimit.AddPeer:
 		if _, ok := v.StoreLimit[storeID]; !ok {
-			rate = defaultStoreLimit
+			rate = DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
 		} else {
 			rate = v.StoreLimit[storeID].RemovePeer
 		}
 		sc = StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: rate}
 	case storelimit.RemovePeer:
 		if _, ok := v.StoreLimit[storeID]; !ok {
-			rate = defaultStoreLimit
+			rate = DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
 		} else {
 			rate = v.StoreLimit[storeID].AddPeer
 		}

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -235,6 +235,7 @@ func (s *Server) PutStore(ctx context.Context, request *pdpb.PutStoreRequest) (*
 	log.Info("put store ok", zap.Stringer("store", store))
 	rc.OnStoreVersionChange()
 	CheckPDVersion(s.persistOptions)
+	rc.AddStoreLimit(store.GetId())
 
 	return &pdpb.PutStoreResponse{
 		Header:            s.header(),

--- a/server/handler.go
+++ b/server/handler.go
@@ -422,6 +422,7 @@ func (h *Handler) SetAllStoresLimit(ratePerMin float64, limitType storelimit.Typ
 	cfg := h.GetScheduleConfig().Clone()
 	switch limitType {
 	case storelimit.AddPeer:
+		config.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, ratePerMin)
 		for storeID := range cfg.StoreLimit {
 			sc := config.StoreLimitConfig{
 				AddPeer:    ratePerMin,
@@ -430,6 +431,7 @@ func (h *Handler) SetAllStoresLimit(ratePerMin float64, limitType storelimit.Typ
 			cfg.StoreLimit[storeID] = sc
 		}
 	case storelimit.RemovePeer:
+		config.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, ratePerMin)
 		for storeID := range cfg.StoreLimit {
 			sc := config.StoreLimitConfig{
 				AddPeer:    cfg.StoreLimit[storeID].AddPeer,

--- a/server/handler.go
+++ b/server/handler.go
@@ -418,32 +418,56 @@ func (h *Handler) GetHistory(start time.Time) ([]operator.OpHistory, error) {
 }
 
 // SetAllStoresLimit is used to set limit of all stores.
-func (h *Handler) SetAllStoresLimit(rate float64, limitType storelimit.Type) error {
-	c, err := h.GetOperatorController()
-	if err != nil {
-		return err
+func (h *Handler) SetAllStoresLimit(ratePerMin float64, limitType storelimit.Type) error {
+	cfg := h.GetScheduleConfig().Clone()
+	switch limitType {
+	case storelimit.AddPeer:
+		for storeID := range cfg.StoreLimit {
+			sc := config.StoreLimitConfig{
+				AddPeer:    ratePerMin,
+				RemovePeer: cfg.StoreLimit[storeID].RemovePeer,
+			}
+			cfg.StoreLimit[storeID] = sc
+		}
+	case storelimit.RemovePeer:
+		for storeID := range cfg.StoreLimit {
+			sc := config.StoreLimitConfig{
+				AddPeer:    cfg.StoreLimit[storeID].AddPeer,
+				RemovePeer: ratePerMin,
+			}
+			cfg.StoreLimit[storeID] = sc
+		}
 	}
-	c.SetAllStoresLimit(rate, storelimit.Manual, limitType)
-	return nil
+	return h.s.SetScheduleConfig(*cfg)
 }
 
 // GetAllStoresLimit is used to get limit of all stores.
-func (h *Handler) GetAllStoresLimit(limitType storelimit.Type) (map[uint64]*storelimit.StoreLimit, error) {
-	c, err := h.GetOperatorController()
+func (h *Handler) GetAllStoresLimit(limitType storelimit.Type) (map[uint64]config.StoreLimitConfig, error) {
+	c, err := h.GetRaftCluster()
 	if err != nil {
 		return nil, err
 	}
-	return c.GetAllStoresLimit(limitType), nil
+	return c.GetAllStoresLimit(), nil
 }
 
 // SetStoreLimit is used to set the limit of a store.
 func (h *Handler) SetStoreLimit(storeID uint64, rate float64, limitType storelimit.Type) error {
-	c, err := h.GetOperatorController()
-	if err != nil {
-		return err
+	cfg := h.GetScheduleConfig()
+	switch limitType {
+	case storelimit.AddPeer:
+		sc := config.StoreLimitConfig{
+			AddPeer:    rate,
+			RemovePeer: cfg.StoreLimit[storeID].RemovePeer,
+		}
+		cfg.StoreLimit[storeID] = sc
+	case storelimit.RemovePeer:
+		sc := config.StoreLimitConfig{
+			AddPeer:    cfg.StoreLimit[storeID].AddPeer,
+			RemovePeer: rate,
+		}
+		cfg.StoreLimit[storeID] = sc
 	}
-	c.SetStoreLimit(storeID, rate, storelimit.Manual, limitType)
-	return nil
+	return h.s.SetScheduleConfig(*cfg)
 }
 
 // AddTransferLeaderOperator adds an operator to transfer leader to the store.

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -134,11 +134,11 @@ func (f *storeLimitFilter) Type() string {
 }
 
 func (f *storeLimitFilter) Source(opt opt.Options, store *core.StoreInfo) bool {
-	return store.IsAvailable(storelimit.RegionRemove)
+	return store.IsAvailable(storelimit.RemovePeer)
 }
 
 func (f *storeLimitFilter) Target(opt opt.Options, store *core.StoreInfo) bool {
-	return store.IsAvailable(storelimit.RegionAdd)
+	return store.IsAvailable(storelimit.AddPeer)
 }
 
 type stateFilter struct{ scope string }
@@ -393,7 +393,7 @@ func (f StoreStateFilter) filterMoveRegion(opt opt.Options, isSource bool, store
 		return false
 	}
 
-	if (isSource && !store.IsAvailable(storelimit.RegionRemove)) || (!isSource && !store.IsAvailable(storelimit.RegionAdd)) {
+	if (isSource && !store.IsAvailable(storelimit.RemovePeer)) || (!isSource && !store.IsAvailable(storelimit.AddPeer)) {
 		return false
 	}
 

--- a/server/schedule/operator/operator_test.go
+++ b/server/schedule/operator/operator_test.go
@@ -156,7 +156,7 @@ func (s *testOperatorSuite) TestInfluence(c *C) {
 		LeaderCount: 0,
 		RegionSize:  50,
 		RegionCount: 1,
-		StepCost:    map[storelimit.Type]int64{storelimit.RegionAdd: 1000},
+		StepCost:    map[storelimit.Type]int64{storelimit.AddPeer: 1000},
 	})
 
 	TransferLeader{FromStore: 1, ToStore: 2}.Influence(opInfluence, region)
@@ -172,7 +172,7 @@ func (s *testOperatorSuite) TestInfluence(c *C) {
 		LeaderCount: 1,
 		RegionSize:  50,
 		RegionCount: 1,
-		StepCost:    map[storelimit.Type]int64{storelimit.RegionAdd: 1000},
+		StepCost:    map[storelimit.Type]int64{storelimit.AddPeer: 1000},
 	})
 
 	RemovePeer{FromStore: 1}.Influence(opInfluence, region)
@@ -181,14 +181,14 @@ func (s *testOperatorSuite) TestInfluence(c *C) {
 		LeaderCount: -1,
 		RegionSize:  -50,
 		RegionCount: -1,
-		StepCost:    map[storelimit.Type]int64{storelimit.RegionRemove: 1000},
+		StepCost:    map[storelimit.Type]int64{storelimit.RemovePeer: 1000},
 	})
 	c.Assert(*storeOpInfluence[2], DeepEquals, StoreInfluence{
 		LeaderSize:  50,
 		LeaderCount: 1,
 		RegionSize:  50,
 		RegionCount: 1,
-		StepCost:    map[storelimit.Type]int64{storelimit.RegionAdd: 1000},
+		StepCost:    map[storelimit.Type]int64{storelimit.AddPeer: 1000},
 	})
 
 	MergeRegion{IsPassive: false}.Influence(opInfluence, region)
@@ -197,14 +197,14 @@ func (s *testOperatorSuite) TestInfluence(c *C) {
 		LeaderCount: -1,
 		RegionSize:  -50,
 		RegionCount: -1,
-		StepCost:    map[storelimit.Type]int64{storelimit.RegionRemove: 1000},
+		StepCost:    map[storelimit.Type]int64{storelimit.RemovePeer: 1000},
 	})
 	c.Assert(*storeOpInfluence[2], DeepEquals, StoreInfluence{
 		LeaderSize:  50,
 		LeaderCount: 1,
 		RegionSize:  50,
 		RegionCount: 1,
-		StepCost:    map[storelimit.Type]int64{storelimit.RegionAdd: 1000},
+		StepCost:    map[storelimit.Type]int64{storelimit.AddPeer: 1000},
 	})
 
 	MergeRegion{IsPassive: true}.Influence(opInfluence, region)
@@ -213,14 +213,14 @@ func (s *testOperatorSuite) TestInfluence(c *C) {
 		LeaderCount: -2,
 		RegionSize:  -50,
 		RegionCount: -2,
-		StepCost:    map[storelimit.Type]int64{storelimit.RegionRemove: 1000},
+		StepCost:    map[storelimit.Type]int64{storelimit.RemovePeer: 1000},
 	})
 	c.Assert(*storeOpInfluence[2], DeepEquals, StoreInfluence{
 		LeaderSize:  50,
 		LeaderCount: 1,
 		RegionSize:  50,
 		RegionCount: 0,
-		StepCost:    map[storelimit.Type]int64{storelimit.RegionAdd: 1000},
+		StepCost:    map[storelimit.Type]int64{storelimit.AddPeer: 1000},
 	})
 }
 

--- a/server/schedule/operator/step.go
+++ b/server/schedule/operator/step.go
@@ -98,7 +98,7 @@ func (ap AddPeer) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
 	regionSize := region.GetApproximateSize()
 	to.RegionSize += regionSize
 	to.RegionCount++
-	to.AdjustStepCost(storelimit.RegionAdd, regionSize)
+	to.AdjustStepCost(storelimit.AddPeer, regionSize)
 }
 
 // AddLearner is an OpStep that adds a region learner peer.
@@ -137,7 +137,7 @@ func (al AddLearner) Influence(opInfluence OpInfluence, region *core.RegionInfo)
 	regionSize := region.GetApproximateSize()
 	to.RegionSize += regionSize
 	to.RegionCount++
-	to.AdjustStepCost(storelimit.RegionAdd, regionSize)
+	to.AdjustStepCost(storelimit.AddPeer, regionSize)
 }
 
 // PromoteLearner is an OpStep that promotes a region learner peer to normal voter.
@@ -197,7 +197,7 @@ func (rp RemovePeer) Influence(opInfluence OpInfluence, region *core.RegionInfo)
 	regionSize := region.GetApproximateSize()
 	from.RegionSize -= regionSize
 	from.RegionCount--
-	from.AdjustStepCost(storelimit.RegionRemove, regionSize)
+	from.AdjustStepCost(storelimit.RemovePeer, regionSize)
 }
 
 // MergeRegion is an OpStep that merge two regions.

--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -916,3 +916,30 @@ func (oc *OperatorController) GetLeaderSchedulePolicy() core.SchedulePolicy {
 	}
 	return oc.cluster.GetLeaderSchedulePolicy()
 }
+
+// CollectStoreLimitMetrics collects the metrics about store limit
+func (oc *OperatorController) CollectStoreLimitMetrics() {
+	oc.RLock()
+	defer oc.RUnlock()
+	if oc.storesLimit == nil {
+		return
+	}
+	stores := oc.cluster.GetStores()
+	for _, store := range stores {
+		if store != nil {
+			storeID := store.GetID()
+			storeIDStr := strconv.FormatUint(storeID, 10)
+			for n, v := range storelimit.TypeNameValue {
+				var storeLimit *storelimit.StoreLimit
+				if oc.storesLimit[storeID] == nil || oc.storesLimit[storeID][v] == nil {
+					// Set to 0 to represent the store limit of the specific type is not initialized.
+					storeLimitRateGauge.WithLabelValues(storeIDStr, n).Set(0)
+					continue
+				}
+				storeLimit = oc.storesLimit[storeID][v]
+				storeLimitAvailableGauge.WithLabelValues(storeIDStr, n).Set(float64(storeLimit.Available()) / float64(storelimit.RegionInfluence[v]))
+				storeLimitRateGauge.WithLabelValues(storeIDStr, n).Set(storeLimit.Rate() * StoreBalanceBaseTime)
+			}
+		}
+	}
+}

--- a/server/schedule/operator_controller_test.go
+++ b/server/schedule/operator_controller_test.go
@@ -543,12 +543,10 @@ func (t *testOperatorControllerSuite) TestStoreLimitWithMerge(c *C) {
 		newRegionInfo(4, "x", "", 10, 10, []uint64{109, 4}, []uint64{109, 4}),
 	}
 
-	tc.AddLeaderStore(1, 10)
-	tc.AddLeaderStore(2, 10)
-	tc.AddLeaderStore(3, 10)
-	tc.AddLeaderStore(4, 10)
-	tc.AddLeaderStore(5, 10)
-	tc.AddLeaderStore(6, 10)
+	for i := uint64(1); i <= 6; i++ {
+		tc.AddLeaderStore(i, 10)
+	}
+
 	for _, region := range regions {
 		tc.PutRegion(region)
 	}

--- a/server/schedule/operator_controller_test.go
+++ b/server/schedule/operator_controller_test.go
@@ -315,7 +315,8 @@ func (t *testOperatorControllerSuite) TestStoreLimit(c *C) {
 	for i := uint64(1); i <= 1000; i++ {
 		tc.AddLeaderRegion(i, i)
 	}
-	oc.SetStoreLimit(2, 1, storelimit.Manual, storelimit.RegionAdd)
+
+	tc.SetStoreLimit(2, storelimit.AddPeer, 60)
 	for i := uint64(1); i <= 5; i++ {
 		op := operator.NewOperator("test", "test", 1, &metapb.RegionEpoch{}, operator.OpRegion, operator.AddPeer{ToStore: 2, PeerID: i})
 		c.Assert(oc.AddOperator(op), IsTrue)
@@ -325,13 +326,13 @@ func (t *testOperatorControllerSuite) TestStoreLimit(c *C) {
 	c.Assert(oc.AddOperator(op), IsFalse)
 	c.Assert(oc.RemoveOperator(op), IsFalse)
 
-	oc.SetStoreLimit(2, 2, storelimit.Manual, storelimit.RegionAdd)
+	tc.SetStoreLimit(2, storelimit.AddPeer, 120)
 	for i := uint64(1); i <= 10; i++ {
 		op = operator.NewOperator("test", "test", i, &metapb.RegionEpoch{}, operator.OpRegion, operator.AddPeer{ToStore: 2, PeerID: i})
 		c.Assert(oc.AddOperator(op), IsTrue)
 		checkRemoveOperatorSuccess(c, oc, op)
 	}
-	oc.SetAllStoresLimit(1, storelimit.Manual, storelimit.RegionAdd)
+	tc.SetAllStoresLimit(storelimit.AddPeer, 60)
 	for i := uint64(1); i <= 5; i++ {
 		op = operator.NewOperator("test", "test", i, &metapb.RegionEpoch{}, operator.OpRegion, operator.AddPeer{ToStore: 2, PeerID: i})
 		c.Assert(oc.AddOperator(op), IsTrue)
@@ -341,7 +342,7 @@ func (t *testOperatorControllerSuite) TestStoreLimit(c *C) {
 	c.Assert(oc.AddOperator(op), IsFalse)
 	c.Assert(oc.RemoveOperator(op), IsFalse)
 
-	oc.SetStoreLimit(2, 1, storelimit.Manual, storelimit.RegionRemove)
+	tc.SetStoreLimit(2, storelimit.RemovePeer, 60)
 	for i := uint64(1); i <= 5; i++ {
 		op := operator.NewOperator("test", "test", 1, &metapb.RegionEpoch{}, operator.OpRegion, operator.RemovePeer{FromStore: 2})
 		c.Assert(oc.AddOperator(op), IsTrue)
@@ -351,13 +352,13 @@ func (t *testOperatorControllerSuite) TestStoreLimit(c *C) {
 	c.Assert(oc.AddOperator(op), IsFalse)
 	c.Assert(oc.RemoveOperator(op), IsFalse)
 
-	oc.SetStoreLimit(2, 2, storelimit.Manual, storelimit.RegionRemove)
+	tc.SetStoreLimit(2, storelimit.RemovePeer, 120)
 	for i := uint64(1); i <= 10; i++ {
 		op = operator.NewOperator("test", "test", i, &metapb.RegionEpoch{}, operator.OpRegion, operator.RemovePeer{FromStore: 2})
 		c.Assert(oc.AddOperator(op), IsTrue)
 		checkRemoveOperatorSuccess(c, oc, op)
 	}
-	oc.SetAllStoresLimit(1, storelimit.Manual, storelimit.RegionRemove)
+	tc.SetAllStoresLimit(storelimit.RemovePeer, 60)
 	for i := uint64(1); i <= 5; i++ {
 		op = operator.NewOperator("test", "test", i, &metapb.RegionEpoch{}, operator.OpRegion, operator.RemovePeer{FromStore: 2})
 		c.Assert(oc.AddOperator(op), IsTrue)
@@ -543,16 +544,17 @@ func (t *testOperatorControllerSuite) TestStoreLimitWithMerge(c *C) {
 	}
 
 	tc.AddLeaderStore(1, 10)
+	tc.AddLeaderStore(2, 10)
+	tc.AddLeaderStore(3, 10)
 	tc.AddLeaderStore(4, 10)
 	tc.AddLeaderStore(5, 10)
+	tc.AddLeaderStore(6, 10)
 	for _, region := range regions {
 		tc.PutRegion(region)
 	}
 
 	mc := checker.NewMergeChecker(t.ctx, tc)
 	oc := NewOperatorController(t.ctx, tc, mockhbstream.NewHeartbeatStream())
-
-	cfg.StoreBalanceRate = 60
 
 	regions[2] = regions[2].Clone(
 		core.SetPeers([]*metapb.Peer{
@@ -591,54 +593,6 @@ func (t *testOperatorControllerSuite) TestStoreLimitWithMerge(c *C) {
 		c.Assert(ops, NotNil)
 		c.Assert(oc.AddOperator(ops...), IsFalse)
 	}
-}
-
-func (t *testOperatorControllerSuite) TestRemoveTombstone(c *C) {
-	var mu sync.Mutex
-	cfg := mockoption.NewScheduleOptions()
-	cfg.StoreBalanceRate = 1000
-	cfg.LocationLabels = []string{"zone", "rack"}
-	tc := mockcluster.NewCluster(cfg)
-	rc := checker.NewReplicaChecker(tc)
-	oc := NewOperatorController(t.ctx, tc, mockhbstream.NewHeartbeatStream())
-
-	tc.AddLabelsStore(1, 100, map[string]string{"zone": "zone1", "rack": "rack1"})
-	tc.AddLabelsStore(2, 100, map[string]string{"zone": "zone1", "rack": "rack1"})
-	tc.AddLabelsStore(3, 100, map[string]string{"zone": "zone2", "rack": "rack1"})
-	tc.AddLabelsStore(4, 10, map[string]string{"zone": "zone3", "rack": "rack1"})
-	peers := []*metapb.Peer{
-		{Id: 4, StoreId: 1},
-		{Id: 5, StoreId: 2},
-		{Id: 6, StoreId: 3},
-	}
-	regions := make([]*core.RegionInfo, 100)
-	for i := 2; i < 20; i++ {
-		r := core.NewRegionInfo(&metapb.Region{
-			Id:       uint64(i),
-			StartKey: []byte(fmt.Sprintf("%20d", i)),
-			EndKey:   []byte(fmt.Sprintf("%20d", i+1)),
-			Peers:    peers}, peers[0], core.SetApproximateSize(50*(1<<20)))
-		regions[i] = r
-		tc.PutRegion(r)
-	}
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		time.Sleep(100 * time.Millisecond)
-		mu.Lock()
-		defer mu.Unlock()
-		oc.RemoveStoreLimit(4)
-	}()
-	for i := 2; i < 20; i++ {
-		time.Sleep(10 * time.Millisecond)
-		mu.Lock()
-		op := rc.Check(regions[i])
-		mu.Unlock()
-		oc.AddOperator(op)
-		oc.RemoveOperator(op)
-	}
-	wg.Wait()
 }
 
 func newRegionInfo(id uint64, startKey, endKey string, size, keys int64, leader []uint64, peers ...[]uint64) *core.RegionInfo {
@@ -703,16 +657,4 @@ func (t *testOperatorControllerSuite) TestAddWaitingOperator(c *C) {
 
 	// no space left, new operator can not be added.
 	c.Assert(controller.AddWaitingOperator(addPeerOp(0)), Equals, 0)
-}
-
-func (t *testOperatorControllerSuite) TestAutoStoreLimitMode(c *C) {
-	opt := mockoption.NewScheduleOptions()
-	opt.StoreLimitMode = "auto"
-	tc := mockcluster.NewCluster(opt)
-	stream := mockhbstream.NewHeartbeatStreams(tc.ID, true /* no need to run */)
-	oc := NewOperatorController(t.ctx, tc, stream)
-
-	tc.AddLeaderStore(1, 10)
-	oc.SetStoreLimit(1, 10, storelimit.Auto, storelimit.RegionAdd)
-	oc.SetAllStoresLimitAuto(10, storelimit.RegionRemove)
 }

--- a/server/schedule/opt/opts.go
+++ b/server/schedule/opt/opts.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/pd/v4/server/core"
 	"github.com/pingcap/pd/v4/server/schedule/placement"
+	"github.com/pingcap/pd/v4/server/schedule/storelimit"
 	"github.com/pingcap/pd/v4/server/statistics"
 )
 
@@ -32,7 +33,8 @@ type Options interface {
 	GetHotRegionScheduleLimit() uint64
 
 	// store limit
-	GetStoreBalanceRate() float64
+	GetStoreLimitByType(storeID uint64, typ storelimit.Type) float64
+	SetAllStoresLimit(typ storelimit.Type, ratePerMin float64)
 
 	GetMaxSnapshotCount() uint64
 	GetMaxPendingPeerCount() uint64
@@ -63,8 +65,6 @@ type Options interface {
 	GetLeaderSchedulePolicy() core.SchedulePolicy
 	GetKeyType() core.KeyType
 
-	RemoveScheduler(name string) error
-
 	CheckLabelProperty(typ string, labels []*metapb.StoreLabel) bool
 }
 
@@ -87,6 +87,7 @@ type Cluster interface {
 
 	AllocID() (uint64, error)
 	FitRegion(*core.RegionInfo) *placement.RegionFit
+	RemoveScheduler(name string) error
 }
 
 // HeartbeatStream is an interface.

--- a/server/schedule/storelimit/store_limit.go
+++ b/server/schedule/storelimit/store_limit.go
@@ -28,54 +28,31 @@ const (
 
 // RegionInfluence represents the influence of a operator step, which is used by store limit.
 var RegionInfluence = map[Type]int64{
-	RegionAdd:    1000,
-	RegionRemove: 1000,
+	AddPeer:    1000,
+	RemovePeer: 1000,
 }
 
 // SmallRegionInfluence represents the influence of a operator step
 // when the region size is smaller than smallRegionThreshold, which is used by store limit.
 var SmallRegionInfluence = map[Type]int64{
-	RegionAdd:    200,
-	RegionRemove: 200,
+	AddPeer:    200,
+	RemovePeer: 200,
 }
-
-// Mode indicates the strategy to set store limit
-type Mode int
-
-// There are two modes supported now, "auto" indicates the value
-// is set by PD itself. "manual" means it is set by the user.
-// An auto set value can be overwrite by a manual set value.
-const (
-	Auto Mode = iota
-	Manual
-)
 
 // Type indicates the type of store limit
 type Type int
 
 const (
-	// RegionAdd indicates the type of store limit that limits the adding region rate
-	RegionAdd Type = iota
-	// RegionRemove indicates the type of store limit that limits the removing region rate
-	RegionRemove
+	// AddPeer indicates the type of store limit that limits the adding peer rate
+	AddPeer Type = iota
+	// RemovePeer indicates the type of store limit that limits the removing peer rate
+	RemovePeer
 )
 
 // TypeNameValue indicates the name of store limit type and the enum value
 var TypeNameValue = map[string]Type{
-	"region-add":    RegionAdd,
-	"region-remove": RegionRemove,
-}
-
-// String returns the representation of the store limit mode
-func (m Mode) String() string {
-	switch m {
-	case Auto:
-		return "auto"
-	case Manual:
-		return "manual"
-	}
-	// default to be auto
-	return "auto"
+	"add-peer":    AddPeer,
+	"remove-peer": RemovePeer,
 }
 
 // String returns the representation of the Type
@@ -91,26 +68,27 @@ func (t Type) String() string {
 // StoreLimit limits the operators of a store
 type StoreLimit struct {
 	bucket          *ratelimit.Bucket
-	mode            Mode
 	regionInfluence int64
+	ratePerSec      float64
 }
 
 // NewStoreLimit returns a StoreLimit object
-func NewStoreLimit(rate float64, mode Mode, regionInfluence int64) *StoreLimit {
+func NewStoreLimit(ratePerSec float64, regionInfluence int64) *StoreLimit {
 	capacity := regionInfluence
+	rate := ratePerSec
 	// unlimited
 	if rate >= Unlimited {
 		capacity = int64(Unlimited)
-	} else if rate > 1 {
-		capacity = int64(rate * float64(regionInfluence))
-		rate *= float64(regionInfluence)
+	} else if ratePerSec > 1 {
+		capacity = int64(ratePerSec * float64(regionInfluence))
+		ratePerSec *= float64(regionInfluence)
 	} else {
-		rate *= float64(regionInfluence)
+		ratePerSec *= float64(regionInfluence)
 	}
 	return &StoreLimit{
-		bucket:          ratelimit.NewBucketWithRate(rate, capacity),
-		mode:            mode,
+		bucket:          ratelimit.NewBucketWithRate(ratePerSec, capacity),
 		regionInfluence: regionInfluence,
+		ratePerSec:      rate,
 	}
 }
 
@@ -121,15 +99,10 @@ func (l *StoreLimit) Available() int64 {
 
 // Rate returns the fill rate of the bucket, in tokens per second.
 func (l *StoreLimit) Rate() float64 {
-	return l.bucket.Rate() / float64(l.regionInfluence)
+	return l.ratePerSec
 }
 
 // Take takes count tokens from the bucket without blocking.
 func (l *StoreLimit) Take(count int64) time.Duration {
 	return l.bucket.Take(count)
-}
-
-// Mode returns the store limit mode
-func (l *StoreLimit) Mode() Mode {
-	return l.mode
 }

--- a/server/schedule/storelimit/store_limit_scenes.go
+++ b/server/schedule/storelimit/store_limit_scenes.go
@@ -39,9 +39,9 @@ func DefaultScene(limitType Type) *Scene {
 
 	// change this if different type rate limit has different default scene
 	switch limitType {
-	case RegionAdd:
+	case AddPeer:
 		return defaultScene
-	case RegionRemove:
+	case RemovePeer:
 		return defaultScene
 	default:
 		return nil

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -343,10 +343,9 @@ func (s *testBalanceLeaderSchedulerSuite) TestLeaderWeight(c *C) {
 	// Weight:     0.5     0.9     1       2
 	// Region1:    L       F       F       F
 
-	s.tc.AddLeaderStore(1, 10)
-	s.tc.AddLeaderStore(2, 10)
-	s.tc.AddLeaderStore(3, 10)
-	s.tc.AddLeaderStore(4, 10)
+	for i := uint64(1); i <= 4; i++ {
+		s.tc.AddLeaderStore(i, 10)
+	}
 	s.tc.UpdateStoreLeaderWeight(1, 0.5)
 	s.tc.UpdateStoreLeaderWeight(2, 0.9)
 	s.tc.UpdateStoreLeaderWeight(3, 1)
@@ -411,10 +410,9 @@ func (s *testBalanceLeaderSchedulerSuite) TestBalanceSelector(c *C) {
 	// Leaders:    9    10   10   11
 	// Region1:    -    F    F    L
 	// Region2:    L    F    F    -
-	s.tc.AddLeaderStore(1, 10)
-	s.tc.AddLeaderStore(2, 10)
-	s.tc.AddLeaderStore(3, 10)
-	s.tc.AddLeaderStore(4, 10)
+	for i := uint64(1); i <= 4; i++ {
+		s.tc.AddLeaderStore(i, 10)
+	}
 	s.tc.AddLeaderRegion(1, 4, 2, 3)
 	s.tc.AddLeaderRegion(2, 1, 2, 3)
 	// The cluster is balanced.
@@ -459,10 +457,9 @@ func (s *testBalanceLeaderRangeSchedulerSuite) TestSingleRangeBalance(c *C) {
 	// Weight:     0.5     0.9     1       2
 	// Region1:    L       F       F       F
 
-	s.tc.AddLeaderStore(1, 10)
-	s.tc.AddLeaderStore(2, 10)
-	s.tc.AddLeaderStore(3, 10)
-	s.tc.AddLeaderStore(4, 10)
+	for i := uint64(1); i <= 4; i++ {
+		s.tc.AddLeaderStore(i, 10)
+	}
 	s.tc.UpdateStoreLeaderWeight(1, 0.5)
 	s.tc.UpdateStoreLeaderWeight(2, 0.9)
 	s.tc.UpdateStoreLeaderWeight(3, 1)
@@ -500,10 +497,9 @@ func (s *testBalanceLeaderRangeSchedulerSuite) TestMultiRangeBalance(c *C) {
 	// Weight:     0.5     0.9     1       2
 	// Region1:    L       F       F       F
 
-	s.tc.AddLeaderStore(1, 10)
-	s.tc.AddLeaderStore(2, 10)
-	s.tc.AddLeaderStore(3, 10)
-	s.tc.AddLeaderStore(4, 10)
+	for i := uint64(1); i <= 4; i++ {
+		s.tc.AddLeaderStore(i, 10)
+	}
 	s.tc.UpdateStoreLeaderWeight(1, 0.5)
 	s.tc.UpdateStoreLeaderWeight(2, 0.9)
 	s.tc.UpdateStoreLeaderWeight(3, 1)

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -812,7 +812,6 @@ func (s *testBalanceRegionSchedulerSuite) TestReplacePendingRegion(c *C) {
 
 func (s *testBalanceRegionSchedulerSuite) TestOpInfluence(c *C) {
 	opt := mockoption.NewScheduleOptions()
-	opt.StoreBalanceRate = 65536
 	tc := mockcluster.NewCluster(opt)
 	oc := schedule.NewOperatorController(s.ctx, tc, mockhbstream.NewHeartbeatStream())
 	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
@@ -823,6 +822,7 @@ func (s *testBalanceRegionSchedulerSuite) TestOpInfluence(c *C) {
 	tc.AddRegionStoreWithLeader(2, 8)
 	tc.AddRegionStoreWithLeader(3, 8)
 	tc.AddRegionStoreWithLeader(4, 16, 8)
+
 	// add 8 leader regions to store 4 and move them to store 3
 	// ensure store score without operator influence : store 4 > store 3
 	// and store score with operator influence : store 3 > store 4

--- a/server/statistics/schedule_options.go
+++ b/server/statistics/schedule_options.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/pingcap/pd/v4/server/core"
+	"github.com/pingcap/pd/v4/server/schedule/storelimit"
 )
 
 // ScheduleOptions is an interface to access configurations.
@@ -27,7 +28,7 @@ type ScheduleOptions interface {
 	GetLowSpaceRatio() float64
 	GetHighSpaceRatio() float64
 	GetTolerantSizeRatio() float64
-	GetStoreBalanceRate() float64
+	GetStoreLimitByType(storeID uint64, typ storelimit.Type) float64
 
 	GetSchedulerMaxWaitingOperator() uint64
 	GetLeaderScheduleLimit() uint64

--- a/server/statistics/store_collection.go
+++ b/server/statistics/store_collection.go
@@ -148,7 +148,6 @@ func (s *storeStatistics) Collect() {
 	configs["high-space-ratio"] = s.opt.GetHighSpaceRatio()
 	configs["low-space-ratio"] = s.opt.GetLowSpaceRatio()
 	configs["tolerant-size-ratio"] = s.opt.GetTolerantSizeRatio()
-	configs["store-balance-rate"] = s.opt.GetStoreBalanceRate()
 	configs["hot-region-schedule-limit"] = float64(s.opt.GetHotRegionScheduleLimit())
 	configs["hot-region-cache-hits-threshold"] = float64(s.opt.GetHotRegionCacheHitsThreshold())
 	configs["max-pending-peer-count"] = float64(s.opt.GetMaxPendingPeerCount())

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -89,6 +89,7 @@ func (s *configTestSuite) TestConfig(c *C) {
 	scheduleConfig := svr.GetScheduleConfig()
 	scheduleConfig.Schedulers = nil
 	scheduleConfig.SchedulersPayload = nil
+	scheduleConfig.StoreLimit = nil
 	c.Assert(&cfg.Schedule, DeepEquals, scheduleConfig)
 	c.Assert(&cfg.Replication, DeepEquals, svr.GetReplicationConfig())
 

--- a/tests/pdctl/operator/operator_test.go
+++ b/tests/pdctl/operator/operator_test.go
@@ -49,7 +49,6 @@ func (s *operatorTestSuite) TestOperator(c *C) {
 	cluster, err := tests.NewTestCluster(ctx, 1,
 		func(conf *config.Config) { conf.Replication.MaxReplicas = 2 },
 		func(conf *config.Config) { conf.Schedule.MaxStoreDownTime.Duration = time.Since(t) },
-		func(conf *config.Config) { conf.Schedule.StoreBalanceRate = 240 },
 	)
 	c.Assert(err, IsNil)
 	err = cluster.RunInitialServers()

--- a/tests/pdctl/store/store_test.go
+++ b/tests/pdctl/store/store_test.go
@@ -156,6 +156,8 @@ func (s *storeTestSuite) TestStore(c *C) {
 	c.Assert(err, IsNil)
 	limit := leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.AddPeer)
 	c.Assert(limit, Equals, float64(10))
+	limit = leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.RemovePeer)
+	c.Assert(limit, Equals, float64(10))
 
 	// store limit <store_id> <rate> <type>
 	args = []string{"-u", pdAddr, "store", "limit", "1", "5", "remove-peer"}
@@ -171,11 +173,17 @@ func (s *storeTestSuite) TestStore(c *C) {
 	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
 	c.Assert(err, IsNil)
 	limit1 := leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.AddPeer)
+	limit2 := leaderServer.GetRaftCluster().GetStoreLimitByType(2, storelimit.AddPeer)
 	limit3 := leaderServer.GetRaftCluster().GetStoreLimitByType(3, storelimit.AddPeer)
 	c.Assert(limit1, Equals, float64(20))
-	c.Assert(limit3, Equals, float64(20))
-	limit2 := leaderServer.GetRaftCluster().GetStoreLimitByType(2, storelimit.AddPeer)
 	c.Assert(limit2, Equals, float64(20))
+	c.Assert(limit3, Equals, float64(20))
+	limit1 = leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.RemovePeer)
+	limit2 = leaderServer.GetRaftCluster().GetStoreLimitByType(2, storelimit.RemovePeer)
+	limit3 = leaderServer.GetRaftCluster().GetStoreLimitByType(3, storelimit.RemovePeer)
+	c.Assert(limit1, Equals, float64(20))
+	c.Assert(limit2, Equals, float64(20))
+	c.Assert(limit3, Equals, float64(20))
 
 	// store limit all <rate> <type>
 	args = []string{"-u", pdAddr, "store", "limit", "all", "25", "remove-peer"}

--- a/tests/pdctl/store/store_test.go
+++ b/tests/pdctl/store/store_test.go
@@ -154,56 +154,54 @@ func (s *storeTestSuite) TestStore(c *C) {
 	args = []string{"-u", pdAddr, "store", "limit", "1", "10"}
 	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
 	c.Assert(err, IsNil)
-	limits := leaderServer.GetRaftCluster().GetOperatorController().GetAllStoresLimit(storelimit.RegionAdd)
-	c.Assert(limits[1].Rate()*60, Equals, float64(10))
+	limit := leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.AddPeer)
+	c.Assert(limit, Equals, float64(10))
 
 	// store limit <store_id> <rate> <type>
-	args = []string{"-u", pdAddr, "store", "limit", "1", "5", "region-remove"}
+	args = []string{"-u", pdAddr, "store", "limit", "1", "5", "remove-peer"}
 	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
 	c.Assert(err, IsNil)
-	limits = leaderServer.GetRaftCluster().GetOperatorController().GetAllStoresLimit(storelimit.RegionRemove)
-	c.Assert(limits[1].Rate()*60, Equals, float64(5))
-	limits = leaderServer.GetRaftCluster().GetOperatorController().GetAllStoresLimit(storelimit.RegionAdd)
-	c.Assert(limits[1].Rate()*60, Equals, float64(10))
+	limit = leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.RemovePeer)
+	c.Assert(limit, Equals, float64(5))
+	limit = leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.AddPeer)
+	c.Assert(limit, Equals, float64(10))
 
 	// store limit all <rate>
 	args = []string{"-u", pdAddr, "store", "limit", "all", "20"}
 	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
 	c.Assert(err, IsNil)
-	limits = leaderServer.GetRaftCluster().GetOperatorController().GetAllStoresLimit(storelimit.RegionAdd)
-	c.Assert(limits[3].Rate()*60, Equals, float64(20))
-	c.Assert(limits[1].Rate()*60, Equals, float64(20))
-	_, ok := limits[2]
-	c.Assert(ok, IsFalse)
+	limit1 := leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.AddPeer)
+	limit3 := leaderServer.GetRaftCluster().GetStoreLimitByType(3, storelimit.AddPeer)
+	c.Assert(limit1, Equals, float64(20))
+	c.Assert(limit3, Equals, float64(20))
+	limit2 := leaderServer.GetRaftCluster().GetStoreLimitByType(2, storelimit.AddPeer)
+	c.Assert(limit2, Equals, float64(20))
 
 	// store limit all <rate> <type>
-	args = []string{"-u", pdAddr, "store", "limit", "all", "25", "region-remove"}
+	args = []string{"-u", pdAddr, "store", "limit", "all", "25", "remove-peer"}
 	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
 	c.Assert(err, IsNil)
-	limits = leaderServer.GetRaftCluster().GetOperatorController().GetAllStoresLimit(storelimit.RegionRemove)
-	c.Assert(limits[3].Rate()*60, Equals, float64(25))
-	c.Assert(limits[1].Rate()*60, Equals, float64(25))
-	_, ok = limits[2]
-	c.Assert(ok, IsFalse)
+	limit1 = leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.RemovePeer)
+	limit3 = leaderServer.GetRaftCluster().GetStoreLimitByType(3, storelimit.RemovePeer)
+	c.Assert(limit1, Equals, float64(25))
+	c.Assert(limit3, Equals, float64(25))
+	limit2 = leaderServer.GetRaftCluster().GetStoreLimitByType(2, storelimit.RemovePeer)
+	c.Assert(limit2, Equals, float64(25))
+
 	// store limit <type>
-	echo := pdctl.GetEcho([]string{"-u", pdAddr, "store", "limit", "region-remove"})
-	allRegionAddLimit := make(map[string]map[string]interface{})
-	json.Unmarshal([]byte(echo), &allRegionAddLimit)
-	c.Assert(allRegionAddLimit["1"]["rate"].(float64), Equals, float64(25))
-	c.Assert(allRegionAddLimit["1"]["mode"].(string), Equals, "manual")
-	c.Assert(allRegionAddLimit["3"]["rate"].(float64), Equals, float64(25))
-	c.Assert(allRegionAddLimit["3"]["mode"].(string), Equals, "manual")
-	_, ok = allRegionAddLimit["2"]
-	c.Assert(ok, IsFalse)
-	// store limit
-	args = []string{"-u", pdAddr, "store", "limit"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
-	c.Assert(err, IsNil)
-	limits = leaderServer.GetRaftCluster().GetOperatorController().GetAllStoresLimit(storelimit.RegionAdd)
-	c.Assert(limits[1].Rate()*60, Equals, float64(20))
-	c.Assert(limits[3].Rate()*60, Equals, float64(20))
-	_, ok = limits[2]
-	c.Assert(ok, IsFalse)
+	echo := pdctl.GetEcho([]string{"-u", pdAddr, "store", "limit"})
+	allAddPeerLimit := make(map[string]map[string]interface{})
+	json.Unmarshal([]byte(echo), &allAddPeerLimit)
+	c.Assert(allAddPeerLimit["1"]["add-peer"].(float64), Equals, float64(20))
+	c.Assert(allAddPeerLimit["3"]["add-peer"].(float64), Equals, float64(20))
+	c.Assert(allAddPeerLimit["2"]["add-peer"].(float64), Equals, float64(20))
+
+	echo = pdctl.GetEcho([]string{"-u", pdAddr, "store", "limit", "remove-peer"})
+	allRemovePeerLimit := make(map[string]map[string]interface{})
+	json.Unmarshal([]byte(echo), &allRemovePeerLimit)
+	c.Assert(allRemovePeerLimit["1"]["remove-peer"].(float64), Equals, float64(25))
+	c.Assert(allRemovePeerLimit["3"]["remove-peer"].(float64), Equals, float64(25))
+	c.Assert(allRemovePeerLimit["2"]["remove-peer"].(float64), Equals, float64(25))
 
 	// store delete <store_id> command
 	c.Assert(storeInfo.Store.State, Equals, metapb.StoreState_Up)
@@ -241,9 +239,9 @@ func (s *storeTestSuite) TestStore(c *C) {
 	// It should be called after stores remove-tombstone.
 	echo = pdctl.GetEcho([]string{"-u", pdAddr, "stores", "show", "limit"})
 	c.Assert(strings.Contains(echo, "PANIC"), IsFalse)
-	echo = pdctl.GetEcho([]string{"-u", pdAddr, "stores", "show", "limit", "region-remove"})
+	echo = pdctl.GetEcho([]string{"-u", pdAddr, "stores", "show", "limit", "remove-peer"})
 	c.Assert(strings.Contains(echo, "PANIC"), IsFalse)
-	echo = pdctl.GetEcho([]string{"-u", pdAddr, "stores", "show", "limit", "region-add"})
+	echo = pdctl.GetEcho([]string{"-u", pdAddr, "stores", "show", "limit", "add-peer"})
 	c.Assert(strings.Contains(echo, "PANIC"), IsFalse)
 	// store limit-scene
 	args = []string{"-u", pdAddr, "store", "limit-scene"}
@@ -252,7 +250,7 @@ func (s *storeTestSuite) TestStore(c *C) {
 	scene := &storelimit.Scene{}
 	err = json.Unmarshal(output, scene)
 	c.Assert(err, IsNil)
-	c.Assert(scene, DeepEquals, storelimit.DefaultScene(storelimit.RegionAdd))
+	c.Assert(scene, DeepEquals, storelimit.DefaultScene(storelimit.AddPeer))
 
 	// store limit-scene <scene> <rate>
 	args = []string{"-u", pdAddr, "store", "limit-scene", "idle", "200"}
@@ -267,10 +265,10 @@ func (s *storeTestSuite) TestStore(c *C) {
 	c.Assert(scene.Idle, Equals, 200)
 
 	// store limit-scene <scene> <rate> <type>
-	args = []string{"-u", pdAddr, "store", "limit-scene", "idle", "100", "region-remove"}
+	args = []string{"-u", pdAddr, "store", "limit-scene", "idle", "100", "remove-peer"}
 	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
 	c.Assert(err, IsNil)
-	args = []string{"-u", pdAddr, "store", "limit-scene", "region-remove"}
+	args = []string{"-u", pdAddr, "store", "limit-scene", "remove-peer"}
 	scene = &storelimit.Scene{}
 	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
 	c.Assert(err, IsNil)

--- a/tools/pd-ctl/README.md
+++ b/tools/pd-ctl/README.md
@@ -644,16 +644,16 @@ Usage:
 >> store label 1 zone cn               // Set the value of the label with the "zone" key to "cn" for the store with the store id of 1
 >> store weight 1 5 10                 // Set the leader weight to 5 and region weight to 10 for the store with the store id of 1
 >> store remove-tombstone              // Remove stores that are in tombstone state
->> store limit                         // Show limits of adding peer operation for all stores
+>> store limit                         // Show limits of adding peer and removing peer operation for all stores
 >> store limit add-peer                // Show limits of adding peer operation for all stores
 >> store limit remove-peer             // Show limits of removing peer operation for all stores
->> store limit all 5                   // Limit 5 adding region operations per minute for all stores
->> store limit 1 5                     // Limit 5 adding region operations per minute for store 1
->> store limit all 5 add-peer          // Limit 5 adding region operations per minute for all stores
->> store limit 1 5 add-peer            // Limit 5 adding region operations per minute for store 1
->> store limit 1 5 remove-peer         // Limit 5 removing region operations per minute for store 1
->> store limit all 5 remove-peer       // Limit 5 removing region operations per minute for all stores
->> store limit-scene  // Show all limit scene
+>> store limit all 5                   // Limit 5 adding peer operations and 5 remove peer operations per minute for all stores
+>> store limit 1 5                     // Limit 5 adding peer operations and 5 remove peer operations per minute for store 1
+>> store limit all 5 add-peer          // Limit 5 adding peer operations per minute for all stores
+>> store limit 1 5 add-peer            // Limit 5 adding peer operations per minute for store 1
+>> store limit 1 5 remove-peer         // Limit 5 removing peer operations per minute for store 1
+>> store limit all 5 remove-peer       // Limit 5 removing peer operations per minute for all stores
+>> store limit-scene                   // Show all limit scene
 {
   "Idle": 100,
   "Low": 50,

--- a/tools/pd-ctl/README.md
+++ b/tools/pd-ctl/README.md
@@ -663,6 +663,10 @@ Usage:
 >> store limit-scene idle 100 // set rate to 100 in the idle scene
 ```
 
+> **Notice**
+>
+> When using `store limit` command, the original `region-add` and `region-remove` are deprecated, please use `add-peer` and `remove-peer`.
+
 ### `tso`
 
 Use this command to parse the physical and logical time of TSO.

--- a/tools/pd-ctl/README.md
+++ b/tools/pd-ctl/README.md
@@ -128,7 +128,6 @@ Usage:
     "replica-schedule-limit": 64,
     "scheduler-max-waiting-operator": 5,
     "split-merge-interval": "1h0m0s",
-    "store-balance-rate": 15,
     "store-limit-mode": "manual",
     "tolerant-size-ratio": 0
   }
@@ -645,16 +644,16 @@ Usage:
 >> store label 1 zone cn               // Set the value of the label with the "zone" key to "cn" for the store with the store id of 1
 >> store weight 1 5 10                 // Set the leader weight to 5 and region weight to 10 for the store with the store id of 1
 >> store remove-tombstone              // Remove stores that are in tombstone state
->> store limit                         // Show limits of adding region operation for all stores
->> store limit region-add              // Show limits of adding region operation for all stores
->> store limit region-remove           // Show limits of removing region operation for all stores
+>> store limit                         // Show limits of adding peer operation for all stores
+>> store limit add-peer                // Show limits of adding peer operation for all stores
+>> store limit remove-peer             // Show limits of removing peer operation for all stores
 >> store limit all 5                   // Limit 5 adding region operations per minute for all stores
 >> store limit 1 5                     // Limit 5 adding region operations per minute for store 1
->> store limit all 5 region-add        // Limit 5 adding region operations per minute for all stores
->> store limit 1 5 region-add          // Limit 5 adding region operations per minute for store 1
->> store limit 1 5 region-remove       // Limit 5 removing region operations per minute for store 1
->> store limit all 5 region-remove     // Limit 5 removing region operations per minute for all stores
->> store limit-scene  // Show all limit scene 
+>> store limit all 5 add-peer          // Limit 5 adding region operations per minute for all stores
+>> store limit 1 5 add-peer            // Limit 5 adding region operations per minute for store 1
+>> store limit 1 5 remove-peer         // Limit 5 removing region operations per minute for store 1
+>> store limit all 5 remove-peer       // Limit 5 removing region operations per minute for all stores
+>> store limit-scene  // Show all limit scene
 {
   "Idle": 100,
   "Low": 50,
@@ -675,7 +674,6 @@ Usage:
 system:  2017-10-09 05:50:59 +0800 CST
 logic:  120102
 ```
-
 
 ## Jq formatted JSON output usage
 

--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -217,6 +217,7 @@ func showConfigCommandFunc(cmd *cobra.Command, args []string) {
 
 	delete(scheduleConfig, "schedulers-v2")
 	delete(scheduleConfig, "schedulers-payload")
+	delete(scheduleConfig, "store-limit")
 	data["schedule"] = scheduleConfig
 	r, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {

--- a/tools/pd-ctl/pdctl/command/store_command.go
+++ b/tools/pd-ctl/pdctl/command/store_command.go
@@ -91,7 +91,7 @@ func NewStoreLimitCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "limit [<type>]|[<store_id>|<all> <limit> <type>]",
 		Short: "show or set a store's rate limit",
-		Long:  "show or set a store's rate limit, <type> can be 'region-add'(default) or 'region-remove'",
+		Long:  "show or set a store's rate limit, <type> can be 'add-peer'(default) or 'remove-peer'",
 		Run:   storeLimitCommandFunc,
 	}
 	return c
@@ -146,7 +146,7 @@ func NewShowStoresCommand() *cobra.Command {
 func NewShowAllStoresLimitCommand() *cobra.Command {
 	sc := &cobra.Command{
 		Use:        "limit <type>",
-		Short:      "show all stores' limit, <type> can be 'region-add'(default) or 'region-remove'",
+		Short:      "show all stores' limit, <type> can be 'add-peer'(default) or 'remove-peer'",
 		Deprecated: "use store limit instead",
 		Run:        showAllStoresLimitCommandFunc,
 	}
@@ -169,7 +169,7 @@ func NewSetAllLimitCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:        "limit <rate> <type>",
 		Short:      "set all store's rate limit",
-		Long:       "set all store's rate limit, <type> can be 'region-add'(default) or 'region-remove'",
+		Long:       "set all store's rate limit, <type> can be 'add-peer'(default) or 'remove-peer'",
 		Deprecated: "use store limit all <rate> instead",
 		Run:        setAllLimitCommandFunc,
 	}
@@ -180,7 +180,7 @@ func NewStoreLimitSceneCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "limit-scene [<type>]|[<scene> <rate> <type>]",
 		Short: "show or set the limit value for a scene",
-		Long:  "show or set the limit value for a scene, <type> can be 'region-add'(default) or 'region-remove'",
+		Long:  "show or set the limit value for a scene, <type> can be 'add-peer'(default) or 'remove-peer'",
 		Run:   storeLimitSceneCommandFunc,
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Close #2245.

### What is changed and how it works?
This PR mainly does these things:
- remove store-balance-rate
- persist store limit in schedule config
- change the auto store limit policy
- rename `*region` to `*peer`
- move `RemoveScheduler` from `Options` to `Cluster` interface
- some updates for testing and doc.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note
