### PR TITLE
Allow publicPath to be root `/`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/opentracing/opentracing-go v1.0.2
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d
-	github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200526104639-b9db65c0422c
+	github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200526165651-52e570bf6f0a
 	github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12
 	github.com/pingcap/errcode v0.0.0-20180921232412-a1a7271709d9
 	github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d

--- a/go.sum
+++ b/go.sum
@@ -296,8 +296,6 @@ github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 h1:q2e307iGHPdTGp
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d h1:U+PMnTlV2tu7RuMK5etusZG3Cf+rpow5hqQByeCzJ2g=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d/go.mod h1:lXfE4PvvTW5xOjO6Mba8zDPyw8M93B6AQ7frTGnMlA8=
-github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200526104639-b9db65c0422c h1:fcgBHpxfazScQ8OE2YUVm1bmCeTaepNkDJ2a5sC9JB8=
-github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200526104639-b9db65c0422c/go.mod h1:c+hdTnQglVGcBvQwLZvCUYzvi1+1SYHfnWH/XlKI/BI=
 github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200526165651-52e570bf6f0a h1:FE7NgHM9ubPb7elnJUot9XBRLWDqhyXWIby5r1q1JXA=
 github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200526165651-52e570bf6f0a/go.mod h1:c+hdTnQglVGcBvQwLZvCUYzvi1+1SYHfnWH/XlKI/BI=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8 h1:USx2/E1bX46VG32FIw034Au6seQ2fY9NEILmNh/UlQg=

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,8 @@ github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d h1:U+PMnTlV2tu7RuMK5e
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d/go.mod h1:lXfE4PvvTW5xOjO6Mba8zDPyw8M93B6AQ7frTGnMlA8=
 github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200526104639-b9db65c0422c h1:fcgBHpxfazScQ8OE2YUVm1bmCeTaepNkDJ2a5sC9JB8=
 github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200526104639-b9db65c0422c/go.mod h1:c+hdTnQglVGcBvQwLZvCUYzvi1+1SYHfnWH/XlKI/BI=
+github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200526165651-52e570bf6f0a h1:FE7NgHM9ubPb7elnJUot9XBRLWDqhyXWIby5r1q1JXA=
+github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200526165651-52e570bf6f0a/go.mod h1:c+hdTnQglVGcBvQwLZvCUYzvi1+1SYHfnWH/XlKI/BI=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8 h1:USx2/E1bX46VG32FIw034Au6seQ2fY9NEILmNh/UlQg=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8/go.mod h1:B1+S9LNcuMyLH/4HMTViQOJevkGiik3wW2AN9zb2fNQ=
 github.com/pingcap/check v0.0.0-20191107115940-caf2b9e6ccf4 h1:iRtOAQ6FXkY/BGvst3CDfTva4nTqh6CL8WXvanLdbu0=

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -470,9 +470,6 @@ func (c *Config) Adjust(meta *toml.MetaData) error {
 		c.Dashboard.PublicPathPrefix = defaultPublicPathPrefix
 	}
 	c.Dashboard.PublicPathPrefix = strings.TrimRight(c.Dashboard.PublicPathPrefix, "/")
-	if c.Dashboard.PublicPathPrefix == "" {
-		c.Dashboard.PublicPathPrefix = "/"
-	}
 
 	return nil
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -466,9 +466,12 @@ func (c *Config) Adjust(meta *toml.MetaData) error {
 
 	c.ReplicationMode.adjust(configMetaData.Child("replication-mode"))
 
-	c.Dashboard.PublicPathPrefix = strings.TrimRight(c.Dashboard.PublicPathPrefix, "/")
 	if c.Dashboard.PublicPathPrefix == "" {
 		c.Dashboard.PublicPathPrefix = defaultPublicPathPrefix
+	}
+	c.Dashboard.PublicPathPrefix = strings.TrimRight(c.Dashboard.PublicPathPrefix, "/")
+	if c.Dashboard.PublicPathPrefix == "" {
+		c.Dashboard.PublicPathPrefix = "/"
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Breezewish <me@breeswish.org>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve? <!--add the issue link with summary if it exists-->

In https://github.com/pingcap/pd/pull/2454 we added publicPath support. However it has a problem that publicPath cannot be set to simply `/`.

### What is changed and how it works?

Add additional logic to allow publicPath to be `/`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Tested with: No configuration, configure with `/abc/def`, configure with `/`. All works fine.

Related changes

- Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

Support setting public path for the embedded Dashboard.