### PR TITLE
*: update the assignee rule

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,9 +1,10 @@
-addReviewers: true
-addAssignees: author
+addReviewers: false
+addAssignees: true
 numberOfReviewers: 0
 numberOfAssignees: 1
-useReviewGroups: true
-reviewGroups:
+useReviewGroups: false
+useAssigneeGroups: true
+assigneeGroups:
   scheduling:
     - nolouch
     - disksing
@@ -11,4 +12,7 @@ reviewGroups:
     - shafreeck
     - HunDunDM
     - rleungx
-useAssigneeGroups: false
+filterLabels:
+  # Run
+  include:
+    - contribution


### PR DESCRIPTION
### What problem does this PR solve? <!--add the issue link with summary if it exists-->
The current assignee rule is to assign a PR to its author. We need to choose an assignee randomly for a PR created by the contributor. Related to #2455.

### What is changed and how it works?
This PR modifies the rule of the assignee.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

### Release note <!-- bugfixes or new feature need a release note -->
- No release note