### PR TITLE
cluster: add suspect regions cache

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -15,6 +15,7 @@ package cache
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -52,6 +53,8 @@ func (s *testRegionCacheSuite) TestExpireRegionCache(c *C) {
 
 	c.Assert(cache.Len(), Equals, 3)
 
+	c.Assert(sortIDs(cache.GetKeys()), DeepEquals, []uint64{1, 2, 3})
+
 	time.Sleep(2 * time.Second)
 
 	value, ok = cache.Get(1)
@@ -67,6 +70,7 @@ func (s *testRegionCacheSuite) TestExpireRegionCache(c *C) {
 	c.Assert(value, Equals, 3.0)
 
 	c.Assert(cache.Len(), Equals, 2)
+	c.Assert(sortIDs(cache.GetKeys()), DeepEquals, []uint64{2, 3})
 
 	cache.Remove(2)
 
@@ -79,6 +83,13 @@ func (s *testRegionCacheSuite) TestExpireRegionCache(c *C) {
 	c.Assert(value, Equals, 3.0)
 
 	c.Assert(cache.Len(), Equals, 1)
+	c.Assert(sortIDs(cache.GetKeys()), DeepEquals, []uint64{3})
+}
+
+func sortIDs(ids []uint64) []uint64 {
+	ids = append(ids[:0:0], ids...)
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
 }
 
 func (s *testRegionCacheSuite) TestLRUCache(c *C) {

--- a/pkg/cache/ttl.go
+++ b/pkg/cache/ttl.go
@@ -83,6 +83,22 @@ func (c *TTL) Get(key uint64) (interface{}, bool) {
 	return item.value, true
 }
 
+// GetKeys returns all keys that are not expired.
+func (c *TTL) GetKeys() []uint64 {
+	c.RLock()
+	defer c.RUnlock()
+
+	var keys []uint64
+
+	now := time.Now()
+	for key, item := range c.items {
+		if item.expire.After(now) {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
 // Remove eliminates an item from cache.
 func (c *TTL) Remove(key uint64) {
 	c.Lock()
@@ -150,6 +166,11 @@ func NewIDTTL(ctx context.Context, gcInterval, ttl time.Duration) *TTLUint64 {
 // Put saves an ID in cache.
 func (c *TTLUint64) Put(id uint64) {
 	c.TTL.Put(id, nil)
+}
+
+// GetAll returns all ids.
+func (c *TTLUint64) GetAll() []uint64 {
+	return c.TTL.GetKeys()
 }
 
 // Exists checks if an ID exists in cache.

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -14,6 +14,7 @@
 package cluster
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -670,7 +671,7 @@ func newTestCluster(opt *config.PersistOptions) *testCluster {
 }
 
 func newTestRaftCluster(id id.Allocator, opt *config.PersistOptions, storage *core.Storage, basicCluster *core.BasicCluster) *RaftCluster {
-	rc := &RaftCluster{}
+	rc := &RaftCluster{ctx: context.TODO()}
 	rc.InitCluster(id, opt, storage, basicCluster)
 	return rc
 }

--- a/server/cluster/cluster_worker.go
+++ b/server/cluster/cluster_worker.go
@@ -137,6 +137,11 @@ func (c *RaftCluster) HandleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*
 		c.GetMergeChecker().RecordRegionSplit(recordRegions)
 	}
 
+	// If region splits during the scheduling process, regions with abnormal
+	// status may be left, and these regions need to be checked with higher
+	// priority.
+	c.AddSuspectRegions(recordRegions...)
+
 	resp := &pdpb.AskBatchSplitResponse{Ids: splitIDs}
 
 	return resp, nil

--- a/server/cluster/cluster_worker_test.go
+++ b/server/cluster/cluster_worker_test.go
@@ -19,6 +19,9 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	// Register schedulers
+	"github.com/pingcap/pd/v4/pkg/mock/mockid"
+	"github.com/pingcap/pd/v4/server/core"
+	"github.com/pingcap/pd/v4/server/kv"
 	_ "github.com/pingcap/pd/v4/server/schedulers"
 )
 
@@ -27,23 +30,27 @@ var _ = Suite(&testClusterWorkerSuite{})
 type testClusterWorkerSuite struct{}
 
 func (s *testClusterWorkerSuite) TestReportSplit(c *C) {
-	var cluster RaftCluster
+	_, opt, err := newTestScheduleConfig()
+	c.Assert(err, IsNil)
+	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 	left := &metapb.Region{Id: 1, StartKey: []byte("a"), EndKey: []byte("b")}
 	right := &metapb.Region{Id: 2, StartKey: []byte("b"), EndKey: []byte("c")}
-	_, err := cluster.HandleReportSplit(&pdpb.ReportSplitRequest{Left: left, Right: right})
+	_, err = cluster.HandleReportSplit(&pdpb.ReportSplitRequest{Left: left, Right: right})
 	c.Assert(err, IsNil)
 	_, err = cluster.HandleReportSplit(&pdpb.ReportSplitRequest{Left: right, Right: left})
 	c.Assert(err, NotNil)
 }
 
 func (s *testClusterWorkerSuite) TestReportBatchSplit(c *C) {
-	var cluster RaftCluster
+	_, opt, err := newTestScheduleConfig()
+	c.Assert(err, IsNil)
+	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 	regions := []*metapb.Region{
 		{Id: 1, StartKey: []byte(""), EndKey: []byte("a")},
 		{Id: 2, StartKey: []byte("a"), EndKey: []byte("b")},
 		{Id: 3, StartKey: []byte("b"), EndKey: []byte("c")},
 		{Id: 3, StartKey: []byte("c"), EndKey: []byte("")},
 	}
-	_, err := cluster.HandleBatchReportSplit(&pdpb.ReportBatchSplitRequest{Regions: regions})
+	_, err = cluster.HandleBatchReportSplit(&pdpb.ReportBatchSplitRequest{Regions: regions})
 	c.Assert(err, IsNil)
 }

--- a/server/cluster/cluster_worker_test.go
+++ b/server/cluster/cluster_worker_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
-	// Register schedulers
 	"github.com/pingcap/pd/v4/pkg/mock/mockid"
 	"github.com/pingcap/pd/v4/server/core"
 	"github.com/pingcap/pd/v4/server/kv"

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -669,7 +669,7 @@ func (s *clusterTestSuite) TestLoadClusterInfo(c *C) {
 	}
 	c.Assert(storage.Flush(), IsNil)
 
-	raftCluster = &cluster.RaftCluster{}
+	raftCluster = cluster.NewRaftCluster(s.ctx, svr.GetClusterRootPath(), svr.ClusterID(), syncer.NewRegionSyncer(svr), svr.GetClient(), svr.GetHTTPClient())
 	raftCluster.InitCluster(mockid.NewIDAllocator(), opt, storage, basicCluster)
 	raftCluster, err = raftCluster.LoadClusterInfo()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fix #2422

### What is changed and how it works?
- `raftCluster` maintains a cache, namely `suspectRegions`. It contains all regions that potentially broken and need to fix
- when region splits, add all sub regions to the cache (we can include more cases later, for example, operator timeout)
- when coordinator patrols all regions, it first checks suspect regions

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test

Related changes
- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->
- No release note