### PR TITLE
server: Fix bug for region_score with store's used_size is zero (#2471)

### DIFF
--- a/server/core/store.go
+++ b/server/core/store.go
@@ -274,7 +274,7 @@ func (s *StoreInfo) RegionScore(highSpaceRatio, lowSpaceRatio float64, delta int
 	used := float64(s.GetUsedSize()) / (1 << 20)
 	capacity := float64(s.GetCapacity()) / (1 << 20)
 
-	if s.GetRegionSize() == 0 {
+	if s.GetRegionSize() == 0 || used == 0 {
 		amplification = 1
 	} else {
 		// because of rocksdb compression, region size is larger than actual used size


### PR DESCRIPTION
manual cherry-pick #2471 to release-3.1

* * *

Signed-off-by: JaySon-Huang <tshent@qq.com>

### What problem does this PR solve? <!--add the issue link with summary if it exists-->
Fix #2470 

### What is changed and how it works?

If store's used size is zero, just set `amplification = 1` to avoid divide by zero error.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

- Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

- Fix bug that can not get store information when store's used size is zero