### PR TITLE
make operatorStepDuration metric thread-safe

### DIFF
--- a/server/schedule/operator/operator_test.go
+++ b/server/schedule/operator/operator_test.go
@@ -305,10 +305,10 @@ func (s *testOperatorSuite) TestStart(c *C) {
 		RemovePeer{FromStore: 2},
 	}
 	op := s.newTestOperator(1, OpLeader|OpRegion, steps...)
-	c.Assert(op.stepTime, Equals, int64(0))
+	c.Assert(op.GetStartTime().Nanosecond(), Equals, 0)
 	c.Assert(op.Status(), Equals, CREATED)
 	c.Assert(op.Start(), IsTrue)
-	c.Assert(op.stepTime, Not(Equals), 0)
+	c.Assert(op.GetStartTime().Nanosecond(), Not(Equals), 0)
 	c.Assert(op.Status(), Equals, STARTED)
 }
 


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Close https://github.com/pingcap/pd/issues/1665

### What is changed and how it works?
- get operator start time from OpStatusTracker directly
- record and observe the finish time of each operator step excatly once using CAS (Compare And Swap)
### Check List
Tests
- Unit test

### Release note
No release note 
