### PR TITLE
schedule/selector: remove BalanceSelector

### DIFF
--- a/server/schedule/selector/selector.go
+++ b/server/schedule/selector/selector.go
@@ -21,65 +21,6 @@ import (
 	"github.com/pingcap/pd/v4/server/schedule/opt"
 )
 
-// BalanceSelector selects source/target from store candidates based on their
-// resource scores.
-type BalanceSelector struct {
-	kind    core.ScheduleKind
-	filters []filter.Filter
-}
-
-// NewBalanceSelector creates a BalanceSelector instance.
-func NewBalanceSelector(kind core.ScheduleKind, filters []filter.Filter) *BalanceSelector {
-	return &BalanceSelector{
-		kind:    kind,
-		filters: filters,
-	}
-}
-
-// SelectSource selects the store that can pass all filters and has the maximal
-// resource score.
-func (s *BalanceSelector) SelectSource(opt opt.Options, stores []*core.StoreInfo, filters ...filter.Filter) *core.StoreInfo {
-	s.updateConfig(opt)
-	filters = append(filters, s.filters...)
-	var result *core.StoreInfo
-	for _, store := range stores {
-		if !filter.Source(opt, store, filters) {
-			continue
-		}
-		if result == nil ||
-			result.ResourceScore(s.kind, opt.GetHighSpaceRatio(), opt.GetLowSpaceRatio(), 0) <
-				store.ResourceScore(s.kind, opt.GetHighSpaceRatio(), opt.GetLowSpaceRatio(), 0) {
-			result = store
-		}
-	}
-	return result
-}
-
-// SelectTarget selects the store that can pass all filters and has the minimal
-// resource score.
-func (s *BalanceSelector) SelectTarget(opt opt.Options, stores []*core.StoreInfo, filters ...filter.Filter) *core.StoreInfo {
-	s.updateConfig(opt)
-	filters = append(filters, s.filters...)
-	var result *core.StoreInfo
-	for _, store := range stores {
-		if !filter.Target(opt, store, filters) {
-			continue
-		}
-		if result == nil ||
-			result.ResourceScore(s.kind, opt.GetHighSpaceRatio(), opt.GetLowSpaceRatio(), 0) >
-				store.ResourceScore(s.kind, opt.GetHighSpaceRatio(), opt.GetLowSpaceRatio(), 0) {
-			result = store
-		}
-	}
-	return result
-}
-
-func (s *BalanceSelector) updateConfig(opt opt.Options) {
-	if s.kind.Resource == core.LeaderKind {
-		s.kind.Policy = opt.GetLeaderSchedulePolicy()
-	}
-}
-
 // ReplicaSelector selects source/target store candidates based on their
 // distinct scores based on a region's peer stores.
 type ReplicaSelector struct {

--- a/server/schedule/selector/selector_test.go
+++ b/server/schedule/selector/selector_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pingcap/pd/v4/pkg/mock/mockcluster"
 	"github.com/pingcap/pd/v4/pkg/mock/mockoption"
 	"github.com/pingcap/pd/v4/server/core"
-	"github.com/pingcap/pd/v4/server/schedule/filter"
 )
 
 func Test(t *testing.T) {
@@ -50,45 +49,4 @@ func (s *testSelectorSuite) TestCompareStoreScore(c *C) {
 	c.Assert(compareStoreScore(s.tc, store1, 2, store3, 1), Equals, 1)
 	c.Assert(compareStoreScore(s.tc, store1, 1, store3, 1), Equals, 1)
 	c.Assert(compareStoreScore(s.tc, store1, 1, store3, 2), Equals, -1)
-}
-
-func (s *testSelectorSuite) TestScheduleConfig(c *C) {
-	filters := make([]filter.Filter, 0)
-	testScheduleConfig := func(selector *BalanceSelector, stores []*core.StoreInfo, expectSourceID, expectTargetID uint64) {
-		c.Assert(selector.SelectSource(s.tc, stores).GetID(), Equals, expectSourceID)
-		c.Assert(selector.SelectTarget(s.tc, stores).GetID(), Equals, expectTargetID)
-	}
-
-	kinds := []core.ScheduleKind{{
-		Resource: core.RegionKind,
-		Policy:   core.ByCount,
-	}, {
-		Resource: core.RegionKind,
-		Policy:   core.BySize,
-	}}
-
-	for _, kind := range kinds {
-		selector := NewBalanceSelector(kind, filters)
-		stores := []*core.StoreInfo{
-			core.NewStoreInfoWithSizeCount(1, 2, 3, 10, 5),
-			core.NewStoreInfoWithSizeCount(2, 2, 3, 4, 5),
-			core.NewStoreInfoWithSizeCount(3, 2, 3, 4, 5),
-			core.NewStoreInfoWithSizeCount(4, 2, 3, 2, 5),
-		}
-		testScheduleConfig(selector, stores, 1, 4)
-	}
-
-	selector := NewBalanceSelector(core.ScheduleKind{
-		Resource: core.LeaderKind,
-		Policy:   core.ByCount,
-	}, filters)
-	stores := []*core.StoreInfo{
-		core.NewStoreInfoWithSizeCount(1, 2, 20, 10, 25),
-		core.NewStoreInfoWithSizeCount(2, 2, 66, 10, 5),
-		core.NewStoreInfoWithSizeCount(3, 2, 6, 10, 5),
-		core.NewStoreInfoWithSizeCount(4, 2, 20, 10, 1),
-	}
-	testScheduleConfig(selector, stores, 2, 3)
-	s.tc.LeaderSchedulePolicy = core.BySize.String()
-	testScheduleConfig(selector, stores, 1, 4)
 }

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -357,6 +357,22 @@ func (s *testBalanceLeaderSchedulerSuite) TestLeaderWeight(c *C) {
 	testutil.CheckTransferLeader(c, s.schedule()[0], operator.OpKind(0), 1, 3)
 }
 
+func (s *testBalanceLeaderSchedulerSuite) TestBalancePolicy(c *C) {
+	// Stores:       1    2     3    4
+	// LeaderCount: 20   66     6   20
+	// LeaderSize:  66   20    20    6
+	s.tc.AddLeaderStore(1, 20, 60)
+	s.tc.AddLeaderStore(2, 66, 20)
+	s.tc.AddLeaderStore(3, 6, 20)
+	s.tc.AddLeaderStore(4, 20, 1)
+	s.tc.AddLeaderRegion(1, 2, 1, 3, 4)
+	s.tc.AddLeaderRegion(2, 1, 2, 3, 4)
+	s.tc.LeaderSchedulePolicy = "count"
+	testutil.CheckTransferLeader(c, s.schedule()[0], operator.OpKind(0), 2, 3)
+	s.tc.LeaderSchedulePolicy = "size"
+	testutil.CheckTransferLeader(c, s.schedule()[0], operator.OpKind(0), 1, 4)
+}
+
 func (s *testBalanceLeaderSchedulerSuite) TestBalanceSelector(c *C) {
 	// Stores:     1    2    3    4
 	// Leaders:    1    2    3   16

--- a/server/schedulers/label.go
+++ b/server/schedulers/label.go
@@ -66,7 +66,7 @@ type labelSchedulerConfig struct {
 type labelScheduler struct {
 	*BaseScheduler
 	conf     *labelSchedulerConfig
-	selector *selector.BalanceSelector
+	selector *selector.RandomSelector
 }
 
 // LabelScheduler is mainly based on the store's label information for scheduling.
@@ -76,11 +76,10 @@ func newLabelScheduler(opController *schedule.OperatorController, conf *labelSch
 	filters := []filter.Filter{
 		filter.StoreStateFilter{ActionScope: LabelName, TransferLeader: true},
 	}
-	kind := core.NewScheduleKind(core.LeaderKind, core.ByCount)
 	return &labelScheduler{
 		BaseScheduler: NewBaseScheduler(opController),
 		conf:          conf,
-		selector:      selector.NewBalanceSelector(kind, filters),
+		selector:      selector.NewRandomSelector(filters),
 	}
 }
 

--- a/server/schedulers/scheduler_test.go
+++ b/server/schedulers/scheduler_test.go
@@ -311,9 +311,9 @@ func (s *testRejectLeaderSuite) TestRejectLeader(c *C) {
 	sl, err := schedule.CreateScheduler(LabelType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(LabelType, []string{"", ""}))
 	c.Assert(err, IsNil)
 	op := sl.Schedule(tc)
-	testutil.CheckTransferLeader(c, op[0], operator.OpLeader, 1, 3)
+	testutil.CheckTransferLeaderFrom(c, op[0], operator.OpLeader, 1)
 
-	// If store3 is disconnected, transfer leader to store 2 instead.
+	// If store3 is disconnected, transfer leader to store 2.
 	tc.SetStoreDisconnect(3)
 	op = sl.Schedule(tc)
 	testutil.CheckTransferLeader(c, op[0], operator.OpLeader, 1, 2)


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
 The `BalanceSelector` is not used by `balance-leader-scheduler` and `balance-region-scheduler` any more. It is only used by `label-scheduler`. We can remove it.

### What is changed and how it works?
- remove `BalanceSelector`
- `label-scheduler` use `RandomSelector` instead of `BalanceSelector`. (`label-scheduler` don't need to care much about balance)
- migrate the test case that checks leader balance policy

### Check List
Tests
- Unit test

### Release note
- No release note
