### PR TITLE
pd-ctl: add subcommand for checking cluster status

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -147,10 +147,14 @@ func (c *RaftCluster) LoadClusterStatus() (*Status, error) {
 	if bootstrapTime != typeutil.ZeroTime {
 		isInitialized = c.isInitialized()
 	}
+	var replicationStatus string
+	if c.replicationMode != nil {
+		replicationStatus = c.replicationMode.GetReplicationStatus().String()
+	}
 	return &Status{
 		RaftBootstrapTime: bootstrapTime,
 		IsInitialized:     isInitialized,
-		ReplicationStatus: c.replicationMode.GetReplicationStatus().String(),
+		ReplicationStatus: replicationStatus,
 	}, nil
 }
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -121,6 +121,7 @@ type RaftCluster struct {
 type Status struct {
 	RaftBootstrapTime time.Time `json:"raft_bootstrap_time,omitempty"`
 	IsInitialized     bool      `json:"is_initialized"`
+	ReplicationStatus string    `json:"replication_status"`
 }
 
 // NewRaftCluster create a new cluster.
@@ -149,6 +150,7 @@ func (c *RaftCluster) LoadClusterStatus() (*Status, error) {
 	return &Status{
 		RaftBootstrapTime: bootstrapTime,
 		IsInitialized:     isInitialized,
+		ReplicationStatus: c.replicationMode.GetReplicationStatus().String(),
 	}, nil
 }
 

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -469,6 +469,12 @@ func (c *TestCluster) GetCluster() *metapb.Cluster {
 	return c.servers[leader].GetCluster()
 }
 
+// GetClusterStatus returns raft cluster status.
+func (c *TestCluster) GetClusterStatus() (*cluster.Status, error) {
+	leader := c.GetLeader()
+	return c.servers[leader].GetRaftCluster().LoadClusterStatus()
+}
+
 // GetEtcdClient returns the builtin etcd client.
 func (c *TestCluster) GetEtcdClient() *clientv3.Client {
 	leader := c.GetLeader()

--- a/tests/pdctl/cluster/cluster_test.go
+++ b/tests/pdctl/cluster/cluster_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/v4/server"
+	clusterpkg "github.com/pingcap/pd/v4/server/cluster"
 	"github.com/pingcap/pd/v4/tests"
 	"github.com/pingcap/pd/v4/tests/pdctl"
 )
@@ -63,13 +64,23 @@ func (s *clusterTestSuite) TestClusterAndPing(c *C) {
 	echo := pdctl.GetEcho([]string{"-u", pdAddr, "--cacert=ca.pem", "cluster"})
 	c.Assert(strings.Contains(echo, "no such file or directory"), IsTrue)
 
-	// cluster status
-	args = []string{"-u", pdAddr, "cluster", "status"}
+	// cluster info
+	args = []string{"-u", pdAddr, "cluster"}
 	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
 	c.Assert(err, IsNil)
 	ci = &metapb.Cluster{}
 	c.Assert(json.Unmarshal(output, ci), IsNil)
 	c.Assert(ci, DeepEquals, cluster.GetCluster())
+
+	// cluster status
+	args = []string{"-u", pdAddr, "cluster", "status"}
+	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	c.Assert(err, IsNil)
+	cs := &clusterpkg.Status{}
+	c.Assert(json.Unmarshal(output, cs), IsNil)
+	clusterStatus, err := cluster.GetClusterStatus()
+	c.Assert(err, IsNil)
+	c.Assert(ci, DeepEquals, clusterStatus)
 
 	// ping
 	args = []string{"-u", pdAddr, "ping"}

--- a/tests/pdctl/cluster/cluster_test.go
+++ b/tests/pdctl/cluster/cluster_test.go
@@ -82,7 +82,7 @@ func (s *clusterTestSuite) TestClusterAndPing(c *C) {
 	c.Assert(json.Unmarshal(output, cs), IsNil)
 	clusterStatus, err := cluster.GetClusterStatus()
 	c.Assert(err, IsNil)
-	c.Assert(ci, DeepEquals, clusterStatus)
+	c.Assert(cs, DeepEquals, clusterStatus)
 
 	// ping
 	args = []string{"-u", pdAddr, "ping"}

--- a/tests/pdctl/cluster/cluster_test.go
+++ b/tests/pdctl/cluster/cluster_test.go
@@ -47,6 +47,8 @@ func (s *clusterTestSuite) TestClusterAndPing(c *C) {
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
+	err = cluster.GetServer(cluster.GetLeader()).BootstrapCluster()
+	c.Assert(err, IsNil)
 	pdAddr := cluster.GetConfig().GetClientURL()
 	i := strings.Index(pdAddr, "//")
 	pdAddr = pdAddr[i+2:]

--- a/tools/pd-ctl/pdctl/command/cluster_command.go
+++ b/tools/pd-ctl/pdctl/command/cluster_command.go
@@ -20,6 +20,7 @@ import (
 )
 
 const clusterPrefix = "pd/api/v1/cluster"
+const clusterStatusPrefix = "pd/api/v1/cluster/status"
 
 // NewClusterCommand return a cluster subcommand of rootCmd
 func NewClusterCommand() *cobra.Command {
@@ -28,13 +29,33 @@ func NewClusterCommand() *cobra.Command {
 		Short: "show the cluster information",
 		Run:   showClusterCommandFunc,
 	}
+	cmd.AddCommand(NewClusterStatusCommand())
 	return cmd
+}
+
+// NewClusterStatusCommand return a cluster status subcommand of clusterCmd
+func NewClusterStatusCommand() *cobra.Command {
+	r := &cobra.Command{
+		Use:   "status",
+		Short: "show the cluster status",
+		Run:   showClusterStatusCommandFunc,
+	}
+	return r
 }
 
 func showClusterCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, clusterPrefix, http.MethodGet)
 	if err != nil {
 		cmd.Printf("Failed to get the cluster information: %s\n", err)
+		return
+	}
+	cmd.Println(r)
+}
+
+func showClusterStatusCommandFunc(cmd *cobra.Command, args []string) {
+	r, err := doRequest(cmd, clusterStatusPrefix, http.MethodGet)
+	if err != nil {
+		cmd.Printf("Failed to get the cluster status: %s\n", err)
 		return
 	}
 	cmd.Println(r)


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->
We need a way to check the replication_mode status (close https://github.com/pingcap/pd/issues/2444)

### What is changed and how it works?
Add a subcommand `pd-ctl cluster status` for checking the status.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)
  * `pd-ctl cluster status`

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
- Add a subcommand for checking cluster status
