### PR TITLE
scheduler: add opinfluence for balance leader scheduler

### DIFF
--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -161,7 +161,7 @@ func (l *balanceLeaderScheduler) Schedule(cluster opt.Cluster) []*operator.Opera
 			sourceAddress := source.GetAddress()
 			l.counter.WithLabelValues("high-score", sourceAddress, sourceStoreLabel).Inc()
 			for j := 0; j < balanceLeaderRetryLimit; j++ {
-				if ops := l.transferLeaderOut(cluster, source,opInfluence); len(ops) > 0 {
+				if ops := l.transferLeaderOut(cluster, source, opInfluence); len(ops) > 0 {
 					ops[0].Counters = append(ops[0].Counters, l.counter.WithLabelValues("transfer-out", sourceAddress, sourceStoreLabel))
 					return ops
 				}

--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -161,7 +161,7 @@ func (l *balanceLeaderScheduler) Schedule(cluster opt.Cluster) []*operator.Opera
 			sourceAddress := source.GetAddress()
 			l.counter.WithLabelValues("high-score", sourceAddress, sourceStoreLabel).Inc()
 			for j := 0; j < balanceLeaderRetryLimit; j++ {
-				if ops := l.transferLeaderOut(cluster, source); len(ops) > 0 {
+				if ops := l.transferLeaderOut(cluster, source,opInfluence); len(ops) > 0 {
 					ops[0].Counters = append(ops[0].Counters, l.counter.WithLabelValues("transfer-out", sourceAddress, sourceStoreLabel))
 					return ops
 				}
@@ -191,7 +191,7 @@ func (l *balanceLeaderScheduler) Schedule(cluster opt.Cluster) []*operator.Opera
 // transferLeaderOut transfers leader from the source store.
 // It randomly selects a health region from the source store, then picks
 // the best follower peer and transfers the leader.
-func (l *balanceLeaderScheduler) transferLeaderOut(cluster opt.Cluster, source *core.StoreInfo) []*operator.Operator {
+func (l *balanceLeaderScheduler) transferLeaderOut(cluster opt.Cluster, source *core.StoreInfo, opInfluence operator.OpInfluence) []*operator.Operator {
 	sourceID := source.GetID()
 	region := cluster.RandLeaderRegion(sourceID, l.conf.Ranges, opt.HealthRegion(cluster))
 	if region == nil {
@@ -203,7 +203,10 @@ func (l *balanceLeaderScheduler) transferLeaderOut(cluster opt.Cluster, source *
 	targets = filter.SelectTargetStores(targets, l.filters, cluster)
 	leaderSchedulePolicy := l.opController.GetLeaderSchedulePolicy()
 	sort.Slice(targets, func(i, j int) bool {
-		return targets[i].LeaderScore(leaderSchedulePolicy, 0) < targets[j].LeaderScore(leaderSchedulePolicy, 0)
+		kind := core.NewScheduleKind(core.LeaderKind, leaderSchedulePolicy)
+		iOp := opInfluence.GetStoreInfluence(targets[i].GetID()).ResourceProperty(kind)
+		jOp := opInfluence.GetStoreInfluence(targets[j].GetID()).ResourceProperty(kind)
+		return targets[i].LeaderScore(leaderSchedulePolicy, iOp) < targets[j].LeaderScore(leaderSchedulePolicy, jOp)
 	})
 	for _, target := range targets {
 		if op := l.createOperator(cluster, region, source, target); len(op) > 0 {

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -333,7 +333,7 @@ func (s *testBalanceLeaderSchedulerSuite) TestTransferLeaderOut(c *C) {
 				regions[op.RegionID()] = struct{}{}
 				tr := op.Step(0).(operator.TransferLeader)
 				c.Assert(tr.FromStore, Equals, uint64(4))
-				targets[tr.ToStore] --
+				targets[tr.ToStore]--
 			}
 		}
 	}

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -182,12 +182,13 @@ type testBalanceLeaderSchedulerSuite struct {
 	tc     *mockcluster.Cluster
 	lb     schedule.Scheduler
 	oc     *schedule.OperatorController
+	opt    *mockoption.ScheduleOptions
 }
 
 func (s *testBalanceLeaderSchedulerSuite) SetUpTest(c *C) {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
-	opt := mockoption.NewScheduleOptions()
-	s.tc = mockcluster.NewCluster(opt)
+	s.opt = mockoption.NewScheduleOptions()
+	s.tc = mockcluster.NewCluster(s.opt)
 	s.oc = schedule.NewOperatorController(s.ctx, nil, nil)
 	lb, err := schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"", ""}))
 	c.Assert(err, IsNil)
@@ -302,6 +303,34 @@ func (s *testBalanceLeaderSchedulerSuite) TestScheduleWithOpInfluence(c *C) {
 	s.tc.UpdateLeaderCount(4, 13)
 	s.tc.AddLeaderRegion(1, 4, 1, 2, 3)
 	c.Check(s.schedule(), IsNil)
+}
+
+func (s *testBalanceLeaderSchedulerSuite) TestTransferLeaderOut(c *C) {
+	// Stores:     1    2    3    4
+	// Leaders:    7    8    9   12
+	s.tc.AddLeaderStore(1, 7)
+	s.tc.AddLeaderStore(2, 8)
+	s.tc.AddLeaderStore(3, 9)
+	s.tc.AddLeaderStore(4, 12)
+	s.opt.TolerantSizeRatio = 0.1
+	for i := uint64(1); i <= 7; i++ {
+		s.tc.AddLeaderRegion(i, 4, 1, 2, 3)
+	}
+
+	// balance leader: 4->1, 4->1, 4->2
+	for i := 0; i < 3; i++ {
+		if len(s.schedule()) != 0 {
+			if op := s.schedule()[0]; op != nil {
+				s.oc.SetOperator(op)
+			}
+		}
+	}
+
+	// Stores:     1    2    3    4
+	// Leaders:    9    9    9    9
+	if len(s.schedule()) > 0 {
+		c.Check(s.schedule()[0], IsNil)
+	}
 }
 
 func (s *testBalanceLeaderSchedulerSuite) TestBalanceFilter(c *C) {


### PR DESCRIPTION
Signed-off-by: lhy1024 <admin@liudos.us>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->
We miss op influence when sort target store in balance leader scheduler. To fix #2571 

### What is changed and how it works?

add it

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note
- No release note 
