### PR TITLE
schedule: consider TiFlash when setting the store limit

### DIFF
--- a/server/api/store.go
+++ b/server/api/store.go
@@ -343,10 +343,17 @@ func (h *storeHandler) SetWeight(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /store/{id}/limit [post]
 func (h *storeHandler) SetLimit(w http.ResponseWriter, r *http.Request) {
+	rc := getCluster(r.Context())
 	vars := mux.Vars(r)
 	storeID, errParse := apiutil.ParseUint64VarsField(vars, "id")
 	if errParse != nil {
 		apiutil.ErrorResp(h.rd, w, errcode.NewInvalidInputErr(errParse))
+		return
+	}
+
+	store := rc.GetStore(storeID)
+	if store == nil {
+		h.rd.JSON(w, http.StatusInternalServerError, server.ErrStoreNotFound(storeID))
 		return
 	}
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1684,11 +1684,11 @@ func (c *RaftCluster) GetAllStoresLimit() map[uint64]config.StoreLimitConfig {
 }
 
 // AddStoreLimit add a store limit for a given store ID.
-func (c *RaftCluster) AddStoreLimit(storeID uint64) {
+func (c *RaftCluster) AddStoreLimit(storeID uint64, limit config.StoreLimit) {
 	cfg := c.opt.GetScheduleConfig().Clone()
 	sc := config.StoreLimitConfig{
-		AddPeer:    config.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
-		RemovePeer: config.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
+		AddPeer:    limit.GetDefaultStoreLimit(storelimit.AddPeer),
+		RemovePeer: limit.GetDefaultStoreLimit(storelimit.RemovePeer),
 	}
 	cfg.StoreLimit[storeID] = sc
 	c.opt.SetScheduleConfig(cfg)

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1684,11 +1684,17 @@ func (c *RaftCluster) GetAllStoresLimit() map[uint64]config.StoreLimitConfig {
 }
 
 // AddStoreLimit add a store limit for a given store ID.
-func (c *RaftCluster) AddStoreLimit(storeID uint64, limit config.StoreLimit) {
+func (c *RaftCluster) AddStoreLimit(storeID uint64, isTiFlashStore bool) {
 	cfg := c.opt.GetScheduleConfig().Clone()
 	sc := config.StoreLimitConfig{
-		AddPeer:    limit.GetDefaultStoreLimit(storelimit.AddPeer),
-		RemovePeer: limit.GetDefaultStoreLimit(storelimit.RemovePeer),
+		AddPeer:    config.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
+		RemovePeer: config.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
+	}
+	if isTiFlashStore {
+		sc = config.StoreLimitConfig{
+			AddPeer:    config.DefaultTiFlashStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
+			RemovePeer: config.DefaultTiFlashStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
+		}
 	}
 	cfg.StoreLimit[storeID] = sc
 	c.opt.SetScheduleConfig(cfg)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -218,8 +218,10 @@ const (
 var (
 	defaultRuntimeServices = []string{}
 	defaultLocationLabels  = []string{}
-	// DefaultStoreLimit is the default limit of add peer and remove peer.
+	// DefaultStoreLimit is the default store limit of add peer and remove peer.
 	DefaultStoreLimit StoreLimit = StoreLimit{AddPeer: 15, RemovePeer: 15}
+	// DefaultTiFlashStoreLimit is the default TiFlash store limit of add peer and remove peer.
+	DefaultTiFlashStoreLimit StoreLimit = StoreLimit{AddPeer: 30, RemovePeer: 30}
 )
 
 // StoreLimit is the default limit of adding peer and removing peer when putting stores.

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/pd/v4/server/cluster"
+	"github.com/pingcap/pd/v4/server/config"
 	"github.com/pingcap/pd/v4/server/core"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -235,7 +236,11 @@ func (s *Server) PutStore(ctx context.Context, request *pdpb.PutStoreRequest) (*
 	log.Info("put store ok", zap.Stringer("store", store))
 	rc.OnStoreVersionChange()
 	CheckPDVersion(s.persistOptions)
-	rc.AddStoreLimit(store.GetId())
+	if isTiFlashStore(store) {
+		rc.AddStoreLimit(store.GetId(), config.DefaultTiFlashStoreLimit)
+	} else {
+		rc.AddStoreLimit(store.GetId(), config.DefaultStoreLimit)
+	}
 
 	return &pdpb.PutStoreResponse{
 		Header:            s.header(),

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/pd/v4/server/cluster"
-	"github.com/pingcap/pd/v4/server/config"
 	"github.com/pingcap/pd/v4/server/core"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -237,9 +236,9 @@ func (s *Server) PutStore(ctx context.Context, request *pdpb.PutStoreRequest) (*
 	rc.OnStoreVersionChange()
 	CheckPDVersion(s.persistOptions)
 	if isTiFlashStore(store) {
-		rc.AddStoreLimit(store.GetId(), config.DefaultTiFlashStoreLimit)
+		rc.AddStoreLimit(store.GetId(), true /* isTiFlashStore*/)
 	} else {
-		rc.AddStoreLimit(store.GetId(), config.DefaultStoreLimit)
+		rc.AddStoreLimit(store.GetId(), false /* isTiFlashStore*/)
 	}
 
 	return &pdpb.PutStoreResponse{


### PR DESCRIPTION
# What problem does this PR solve?

Related to #2505.

### What is changed and how it works?

This PR adds a default limit config for TiFlash stores when calling `PutStore`.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- Set a suitable default store limit of the TiFlash stores
