### PR TITLE
filter, schedulers: split DistinctScoreFilter to LocatoinSafeguard and LocationImprover

### DIFF
--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -279,17 +279,33 @@ func (f *storageThresholdFilter) Target(opt opt.Options, store *core.StoreInfo) 
 	return !store.IsLowSpace(opt.GetLowSpaceRatio())
 }
 
+const (
+	locationSafeguard = "safeguard"
+	locationImprove   = "improve"
+)
+
 // distinctScoreFilter ensures that distinct score will not decrease.
 type distinctScoreFilter struct {
 	scope     string
 	labels    []string
 	stores    []*core.StoreInfo
+	policy    string
 	safeScore float64
 }
 
-// NewDistinctScoreFilter creates a filter that filters all stores that have
+// NewLocationSafeguard creates a filter that filters all stores that have
 // lower distinct score than specified store.
-func NewDistinctScoreFilter(scope string, labels []string, stores []*core.StoreInfo, source *core.StoreInfo) Filter {
+func NewLocationSafeguard(scope string, labels []string, stores []*core.StoreInfo, source *core.StoreInfo) Filter {
+	return newDistinctScoreFilter(scope, labels, stores, source, locationSafeguard)
+}
+
+// NewLocationImprover creates a filter that filters all stores that have
+// lower or equal distinct score than specified store.
+func NewLocationImprover(scope string, labels []string, stores []*core.StoreInfo, source *core.StoreInfo) Filter {
+	return newDistinctScoreFilter(scope, labels, stores, source, locationImprove)
+}
+
+func newDistinctScoreFilter(scope string, labels []string, stores []*core.StoreInfo, source *core.StoreInfo, policy string) Filter {
 	newStores := make([]*core.StoreInfo, 0, len(stores)-1)
 	for _, s := range stores {
 		if s.GetID() == source.GetID() {
@@ -303,6 +319,7 @@ func NewDistinctScoreFilter(scope string, labels []string, stores []*core.StoreI
 		labels:    labels,
 		stores:    newStores,
 		safeScore: core.DistinctScore(labels, newStores, source),
+		policy:    policy,
 	}
 }
 
@@ -319,7 +336,15 @@ func (f *distinctScoreFilter) Source(opt opt.Options, store *core.StoreInfo) boo
 }
 
 func (f *distinctScoreFilter) Target(opt opt.Options, store *core.StoreInfo) bool {
-	return core.DistinctScore(f.labels, f.stores, store) >= f.safeScore
+	score := core.DistinctScore(f.labels, f.stores, store)
+	switch f.policy {
+	case locationSafeguard:
+		return score >= f.safeScore
+	case locationImprove:
+		return score > f.safeScore
+	default:
+		return false
+	}
 }
 
 // StoreStateFilter is used to determine whether a store can be selected as the
@@ -330,6 +355,8 @@ type StoreStateFilter struct {
 	TransferLeader bool
 	// Set true if the schedule involves any move region operation.
 	MoveRegion bool
+	// Set true if allows temproary states.
+	AllowTemporaryStates bool
 }
 
 // Scope returns the scheduler or the checker which the filter acts on.

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -279,11 +279,6 @@ func (f *storageThresholdFilter) Target(opt opt.Options, store *core.StoreInfo) 
 	return !store.IsLowSpace(opt.GetLowSpaceRatio())
 }
 
-const (
-	locationSafeguard = "safeguard"
-	locationImprove   = "improve"
-)
-
 // distinctScoreFilter ensures that distinct score will not decrease.
 type distinctScoreFilter struct {
 	scope     string
@@ -292,6 +287,14 @@ type distinctScoreFilter struct {
 	policy    string
 	safeScore float64
 }
+
+const (
+	// policies used by distinctScoreFilter.
+	// 'safeguard' ensures replacement is NOT WORSE than before.
+	// 'improve' ensures replacement is BETTER than before.
+	locationSafeguard = "safeguard"
+	locationImprove   = "improve"
+)
 
 // NewLocationSafeguard creates a filter that filters all stores that have
 // lower distinct score than specified store.

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -355,8 +355,6 @@ type StoreStateFilter struct {
 	TransferLeader bool
 	// Set true if the schedule involves any move region operation.
 	MoveRegion bool
-	// Set true if allows temproary states.
-	AllowTemporaryStates bool
 }
 
 // Scope returns the scheduler or the checker which the filter acts on.

--- a/server/schedule/filter/filters_test.go
+++ b/server/schedule/filter/filters_test.go
@@ -46,6 +46,40 @@ func (s *testFiltersSuite) TestPendingPeerFilter(c *C) {
 	c.Assert(filter.Target(tc, newStore), IsTrue)
 }
 
+func (s *testFiltersSuite) TestDistinctScoreFilter(c *C) {
+	labels := []string{"zone", "rack", "host"}
+	allStores := []*core.StoreInfo{
+		core.NewStoreInfoWithLabel(1, 1, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"}),
+		core.NewStoreInfoWithLabel(2, 1, map[string]string{"zone": "z1", "rack": "r1", "host": "h2"}),
+		core.NewStoreInfoWithLabel(3, 1, map[string]string{"zone": "z1", "rack": "r2", "host": "h1"}),
+		core.NewStoreInfoWithLabel(4, 1, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"}),
+		core.NewStoreInfoWithLabel(5, 1, map[string]string{"zone": "z2", "rack": "r2", "host": "h1"}),
+		core.NewStoreInfoWithLabel(6, 1, map[string]string{"zone": "z3", "rack": "r1", "host": "h1"}),
+	}
+	testCases := []struct {
+		stores       []uint64
+		source       uint64
+		target       uint64
+		safeGuradRes bool
+		improverRes  bool
+	}{
+		{[]uint64{1, 2, 3}, 1, 4, true, true},
+		{[]uint64{1, 3, 4}, 1, 2, true, false},
+		{[]uint64{1, 4, 6}, 4, 2, false, false},
+	}
+
+	for _, tc := range testCases {
+		var stores []*core.StoreInfo
+		for _, id := range tc.stores {
+			stores = append(stores, allStores[id-1])
+		}
+		ls := NewLocationSafeguard("", labels, stores, allStores[tc.source-1])
+		li := NewLocationImprover("", labels, stores, allStores[tc.source-1])
+		c.Assert(ls.Target(mockoption.NewScheduleOptions(), allStores[tc.target-1]), Equals, tc.safeGuradRes)
+		c.Assert(li.Target(mockoption.NewScheduleOptions(), allStores[tc.target-1]), Equals, tc.improverRes)
+	}
+}
+
 func (s *testFiltersSuite) TestLabelConstraintsFilter(c *C) {
 	opt := mockoption.NewScheduleOptions()
 	tc := mockcluster.NewCluster(opt)

--- a/server/schedule/region_scatterer.go
+++ b/server/schedule/region_scatterer.go
@@ -183,7 +183,7 @@ func (r *RegionScatterer) selectPeerToReplace(stores map[uint64]*core.StoreInfo,
 	if r.cluster.IsPlacementRulesEnabled() {
 		scoreGuard = filter.NewRuleFitFilter(r.name, r.cluster, region, oldPeer.GetStoreId())
 	} else {
-		scoreGuard = filter.NewDistinctScoreFilter(r.name, r.cluster.GetLocationLabels(), regionStores, sourceStore)
+		scoreGuard = filter.NewLocationSafeguard(r.name, r.cluster.GetLocationLabels(), regionStores, sourceStore)
 	}
 
 	candidates := make([]*core.StoreInfo, 0, len(stores))

--- a/server/schedulers/adjacent_region.go
+++ b/server/schedulers/adjacent_region.go
@@ -325,7 +325,7 @@ func (l *balanceAdjacentRegionScheduler) dispersePeer(cluster opt.Cluster, regio
 	if cluster.IsPlacementRulesEnabled() {
 		scoreGuard = filter.NewRuleFitFilter(l.GetName(), cluster, region, leaderStoreID)
 	} else {
-		scoreGuard = filter.NewDistinctScoreFilter(l.GetName(), cluster.GetLocationLabels(), stores, source)
+		scoreGuard = filter.NewLocationSafeguard(l.GetName(), cluster.GetLocationLabels(), stores, source)
 	}
 	excludeStores := region.GetStoreIds()
 	for _, storeID := range l.cacheRegions.assignedStoreIds {

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -208,7 +208,7 @@ func (s *balanceRegionScheduler) transferPeer(cluster opt.Cluster, region *core.
 			}
 			target = checker.SelectStoreToReplacePeerByRule(s.GetName(), cluster, region, fit, rf, oldPeer, scoreGuard, excludeFilter)
 		} else {
-			scoreGuard := filter.NewDistinctScoreFilter(s.GetName(), cluster.GetLocationLabels(), stores, source)
+			scoreGuard := filter.NewLocationSafeguard(s.GetName(), cluster.GetLocationLabels(), stores, source)
 			replicaChecker := checker.NewReplicaChecker(cluster, s.GetName())
 			storeID, _ := replicaChecker.SelectBestReplacementStore(region, oldPeer, scoreGuard, excludeFilter)
 			if storeID != 0 {

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -786,7 +786,7 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*storeLoadDetail {
 			if srcStore == nil {
 				return nil
 			}
-			scoreGuard = filter.NewDistinctScoreFilter(bs.sche.GetName(), bs.cluster.GetLocationLabels(), bs.cluster.GetRegionStores(bs.cur.region), srcStore)
+			scoreGuard = filter.NewLocationSafeguard(bs.sche.GetName(), bs.cluster.GetLocationLabels(), bs.cluster.GetRegionStores(bs.cur.region), srcStore)
 		}
 
 		filters = []filter.Filter{

--- a/server/schedulers/shuffle_hot_region.go
+++ b/server/schedulers/shuffle_hot_region.go
@@ -172,7 +172,7 @@ func (s *shuffleHotRegionScheduler) randomSchedule(cluster opt.Cluster, loadDeta
 		if cluster.IsPlacementRulesEnabled() {
 			scoreGuard = filter.NewRuleFitFilter(s.GetName(), cluster, srcRegion, srcStoreID)
 		} else {
-			scoreGuard = filter.NewDistinctScoreFilter(s.GetName(), cluster.GetLocationLabels(), cluster.GetRegionStores(srcRegion), srcStore)
+			scoreGuard = filter.NewLocationSafeguard(s.GetName(), cluster.GetLocationLabels(), cluster.GetRegionStores(srcRegion), srcStore)
 		}
 
 		filters := []filter.Filter{

--- a/server/schedulers/shuffle_region.go
+++ b/server/schedulers/shuffle_region.go
@@ -154,7 +154,7 @@ func (s *shuffleRegionScheduler) scheduleAddPeer(cluster opt.Cluster, region *co
 	if cluster.IsPlacementRulesEnabled() {
 		scoreGuard = filter.NewRuleFitFilter(s.GetName(), cluster, region, oldPeer.GetStoreId())
 	} else {
-		scoreGuard = filter.NewDistinctScoreFilter(s.GetName(), cluster.GetLocationLabels(), cluster.GetRegionStores(region), cluster.GetStore(oldPeer.GetStoreId()))
+		scoreGuard = filter.NewLocationSafeguard(s.GetName(), cluster.GetLocationLabels(), cluster.GetRegionStores(region), cluster.GetStore(oldPeer.GetStoreId()))
 	}
 	excludedFilter := filter.NewExcludedFilter(s.GetName(), nil, region.GetStoreIds())
 


### PR DESCRIPTION
### What problem does this PR solve?
Enhance distinctScoreFilter to allow it can be used as score safe guard or improve placement.

### What is changed and how it works?
- add 2 different policies: `safeGuard` and `improve` (the improve policy will be used by replicaChecker later)
- add tests

### Check List
Tests
- Unit test

### Release note
- No release note
