### PR TITLE
api: fix the encoded path of region key (#2399)

### DIFF
--- a/server/api/region.go
+++ b/server/api/region.go
@@ -16,6 +16,7 @@ package api
 import (
 	"container/heap"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/gorilla/mux"
@@ -119,6 +120,11 @@ func (h *regionHandler) GetRegionByKey(w http.ResponseWriter, r *http.Request) {
 	}
 	vars := mux.Vars(r)
 	key := vars["key"]
+	key, err := url.QueryUnescape(key)
+	if err != nil {
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	regionInfo := cluster.GetRegionInfoByKey([]byte(key))
 	h.rd.JSON(w, http.StatusOK, NewRegionInfo(regionInfo))
 }

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -94,7 +94,7 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 
 	regionHandler := newRegionHandler(svr, rd)
 	router.HandleFunc("/api/v1/region/id/{id}", regionHandler.GetRegionByID).Methods("GET")
-	router.HandleFunc("/api/v1/region/key/{key}", regionHandler.GetRegionByKey).Methods("GET")
+	router.UseEncodedPath().HandleFunc("/api/v1/region/key/{key}", regionHandler.GetRegionByKey).Methods("GET")
 
 	srd := createStreamingRender()
 	regionsAllHandler := newRegionsHandler(svr, srd)

--- a/tests/pdctl/region/region_test.go
+++ b/tests/pdctl/region/region_test.go
@@ -235,6 +235,14 @@ func (s *regionTestSuite) TestRegion(c *C) {
 	c.Assert(json.Unmarshal(output, &regionInfo), IsNil)
 	c.Assert(&regionInfo, DeepEquals, api.NewRegionInfo(r2))
 
+	// issue #2351
+	args = []string{"-u", pdAddr, "region", "key", "--format=hex", "622f62"}
+	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	c.Assert(err, IsNil)
+	regionInfo = api.RegionInfo{}
+	c.Assert(json.Unmarshal(output, &regionInfo), IsNil)
+	c.Assert(&regionInfo, DeepEquals, api.NewRegionInfo(r2))
+
 	// region startkey --format=raw <key> command
 	args = []string{"-u", pdAddr, "region", "startkey", "--format=raw", "b", "2"}
 	_, output, err = pdctl.ExecuteCommandC(cmd, args...)


### PR DESCRIPTION
### What problem does this PR solve?

cherry-pick #2399.

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

This PR uses UseEncodedPath to solve the %2F problem.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

- Fix the 404 problem when using region key in pd-ctl
