### PR TITLE
api: extend AllocID() interface for TiDB server id allocation

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -708,7 +708,7 @@ func (c *client) AllocID(ctx context.Context, idType pdpb.AllocIDRequest_IDType)
 	start := time.Now()
 	defer func() { cmdDurationAllocID.Observe(time.Since(start).Seconds()) }()
 
-	ctx, cancel := context.WithTimeout(ctx, pdTimeout)
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	resp, err := c.leaderClient().AllocID(ctx, &pdpb.AllocIDRequest{
 		Header: c.requestHeader(),
 		IdType: idType,

--- a/client/client.go
+++ b/client/client.go
@@ -706,7 +706,7 @@ func (c *client) AllocID(ctx context.Context, idType pdpb.AllocIDRequest_IDType)
 	start := time.Now()
 	defer func() { cmdDurationAllocID.Observe(time.Since(start).Seconds()) }()
 
-	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	ctx, cancel := context.WithTimeout(ctx, pdTimeout)
 	resp, err := c.leaderClient().AllocID(ctx, &pdpb.AllocIDRequest{
 		Header: c.requestHeader(),
 		IdType: idType,

--- a/client/client.go
+++ b/client/client.go
@@ -85,6 +85,8 @@ type Client interface {
 	ScatterRegion(ctx context.Context, regionID uint64) error
 	// GetOperator gets the status of operator of the specified region.
 	GetOperator(ctx context.Context, regionID uint64) (*pdpb.GetOperatorResponse, error)
+	// AllocID allocates unique ID.
+	AllocID(ctx context.Context, idType pdpb.AllocIDRequest_IDType) (uint64, error)
 	// Close closes the client.
 	Close()
 }

--- a/client/metrics.go
+++ b/client/metrics.go
@@ -68,6 +68,7 @@ var (
 	cmdDurationUpdateServiceGCSafePoint = cmdDuration.WithLabelValues("update_service_gc_safe_point")
 	cmdDurationScatterRegion            = cmdDuration.WithLabelValues("scatter_region")
 	cmdDurationGetOperator              = cmdDuration.WithLabelValues("get_operator")
+	cmdDurationAllocID                  = cmdDuration.WithLabelValues("alloc_id")
 
 	cmdFailDurationGetRegion                  = cmdFailedDuration.WithLabelValues("get_region")
 	cmdFailDurationTSO                        = cmdFailedDuration.WithLabelValues("tso")
@@ -78,6 +79,7 @@ var (
 	cmdFailedDurationGetAllStores             = cmdFailedDuration.WithLabelValues("get_all_stores")
 	cmdFailedDurationUpdateGCSafePoint        = cmdFailedDuration.WithLabelValues("update_gc_safe_point")
 	cmdFailedDurationUpdateServiceGCSafePoint = cmdFailedDuration.WithLabelValues("update_service_gc_safe_point")
+	cmdFailedDurationAllocID                  = cmdFailedDuration.WithLabelValues("alloc_id")
 	requestDurationTSO                        = requestDuration.WithLabelValues("tso")
 )
 

--- a/go.mod
+++ b/go.mod
@@ -50,3 +50,5 @@ require (
 	google.golang.org/grpc v1.25.1
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
+
+replace github.com/pingcap/kvproto => github.com/pingyu/kvproto v0.0.0-20200620130450-f6224dbfde74

--- a/go.mod
+++ b/go.mod
@@ -51,4 +51,4 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
 
-replace github.com/pingcap/kvproto => github.com/pingyu/kvproto v0.0.0-20200620130450-f6224dbfde74
+replace github.com/pingcap/kvproto => github.com/pingyu/kvproto v0.0.0-20200625060901-6757a66da095

--- a/go.sum
+++ b/go.sum
@@ -288,10 +288,6 @@ github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011 h1:58naV4XMEqm0h
 github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d h1:F8vp38kTAckN+v8Jlc98uMBvKIzr1a+UhnLyVYn8Q5Q=
 github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d/go.mod h1:DNS3Qg7bEDhU6EXNHF+XSv/PGznQaMJ5FWvctpm6pQI=
-github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20200616092848-8037ca08f377 h1:KUUCELlkPNwYXdTu9kCcf1kMSFqz6I6i9F0nXfPO2vs=
-github.com/pingcap/kvproto v0.0.0-20200616092848-8037ca08f377/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9 h1:AJD9pZYm72vMgPcQDww9rkZ1DnWfl0pXV3BOWlkYIjA=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd h1:CV3VsP3Z02MVtdpTMfEgRJ4T9NGgGTxdHpJerent7rM=

--- a/go.sum
+++ b/go.sum
@@ -122,7 +122,6 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/goccy/go-graphviz v0.0.5 h1:qcjgvNiYbLyfLAq9LvyYBJ7sNMbQh9w4FoAzBDrYhYw=
 github.com/goccy/go-graphviz v0.0.5/go.mod h1:wXVsXxmyMQU6TN3zGRttjNn3h+iCAS7xQFC6TlNvLhk=
-github.com/gogo/protobuf v0.0.0-20180717141946-636bf0302bc9/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -137,7 +136,6 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903 h1:LbsanbbD6LieFkXbj9YNNBupiGHJgFeLpO0j0Fza1h8=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
-github.com/golang/protobuf v0.0.0-20180814211427-aa810b61a9c7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -303,9 +301,6 @@ github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIf
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20200408114249-ed3bd6f7fdb1 h1:PI8YpTl45F8ilNkrPtT4IdbcZB1SCEa+gK/U5GJYl3E=
 github.com/pingcap/sysutil v0.0.0-20200408114249-ed3bd6f7fdb1/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
-github.com/pingyu/kvproto v0.0.0-20200616092848-8037ca08f377 h1:NIAxg8kffgQuX7anNKnUiZaJyZ56hf1neAlqtuDucwU=
-github.com/pingyu/kvproto v0.0.0-20200620130450-f6224dbfde74 h1:RkXchCO6iqOiQIwWghWCAOpCVbQM9D+BsCdpEaC+wfQ=
-github.com/pingyu/kvproto v0.0.0-20200620130450-f6224dbfde74/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingyu/kvproto v0.0.0-20200625060901-6757a66da095 h1:jpWI2xl6gqsIwibVC7ZbogXK660UXGQSqRlqhCUb66c=
 github.com/pingyu/kvproto v0.0.0-20200625060901-6757a66da095/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -553,12 +548,10 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
-google.golang.org/genproto v0.0.0-20181004005441-af9cb2a35e7f/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c h1:hrpEMCZ2O7DR5gC1n2AJGVhrwiEjOi35+jxtIuZpTMo=
 google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
-google.golang.org/grpc v0.0.0-20180607172857-7a6a684ca69e/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=

--- a/go.sum
+++ b/go.sum
@@ -306,6 +306,8 @@ github.com/pingcap/sysutil v0.0.0-20200408114249-ed3bd6f7fdb1/go.mod h1:EB/852NM
 github.com/pingyu/kvproto v0.0.0-20200616092848-8037ca08f377 h1:NIAxg8kffgQuX7anNKnUiZaJyZ56hf1neAlqtuDucwU=
 github.com/pingyu/kvproto v0.0.0-20200620130450-f6224dbfde74 h1:RkXchCO6iqOiQIwWghWCAOpCVbQM9D+BsCdpEaC+wfQ=
 github.com/pingyu/kvproto v0.0.0-20200620130450-f6224dbfde74/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingyu/kvproto v0.0.0-20200625060901-6757a66da095 h1:jpWI2xl6gqsIwibVC7ZbogXK660UXGQSqRlqhCUb66c=
+github.com/pingyu/kvproto v0.0.0-20200625060901-6757a66da095/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,9 @@ github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIf
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20200408114249-ed3bd6f7fdb1 h1:PI8YpTl45F8ilNkrPtT4IdbcZB1SCEa+gK/U5GJYl3E=
 github.com/pingcap/sysutil v0.0.0-20200408114249-ed3bd6f7fdb1/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
+github.com/pingyu/kvproto v0.0.0-20200616092848-8037ca08f377 h1:NIAxg8kffgQuX7anNKnUiZaJyZ56hf1neAlqtuDucwU=
+github.com/pingyu/kvproto v0.0.0-20200620130450-f6224dbfde74 h1:RkXchCO6iqOiQIwWghWCAOpCVbQM9D+BsCdpEaC+wfQ=
+github.com/pingyu/kvproto v0.0.0-20200620130450-f6224dbfde74/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -156,7 +156,16 @@ func (s *Server) AllocID(ctx context.Context, request *pdpb.AllocIDRequest) (*pd
 	}
 
 	// We can use an allocator for all types ID allocation.
-	id, err := s.idAllocator.Alloc()
+	var (
+		id  uint64
+		err error
+	)
+	switch request.GetIdType() {
+	case pdpb.AllocIDRequest_SERVER_ID:
+		id, err = s.serverIDAllocator.Alloc()
+	default:
+		id, err = s.idAllocator.Alloc()
+	}
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, err.Error())
 	}

--- a/server/id/id.go
+++ b/server/id/id.go
@@ -42,11 +42,12 @@ type AllocatorImpl struct {
 	client   *clientv3.Client
 	rootPath string
 	member   string
+	keyName  string
 }
 
 // NewAllocatorImpl creates a new IDAllocator.
-func NewAllocatorImpl(client *clientv3.Client, rootPath string, member string) *AllocatorImpl {
-	return &AllocatorImpl{client: client, rootPath: rootPath, member: member}
+func NewAllocatorImpl(client *clientv3.Client, rootPath string, member string, keyName string) *AllocatorImpl {
+	return &AllocatorImpl{client: client, rootPath: rootPath, member: member, keyName: keyName}
 }
 
 // Alloc returns a new id.
@@ -107,11 +108,11 @@ func (alloc *AllocatorImpl) generate() (uint64, error) {
 		return 0, errors.New("generate id failed, we may not leader")
 	}
 
-	log.Info("idAllocator allocates a new id", zap.Uint64("alloc-id", end))
+	log.Info("idAllocator allocates a new id", zap.String("name", alloc.keyName), zap.Uint64("id", end))
 	idGauge.WithLabelValues("idalloc").Set(float64(end))
 	return end, nil
 }
 
 func (alloc *AllocatorImpl) getAllocIDPath() string {
-	return path.Join(alloc.rootPath, "alloc_id")
+	return path.Join(alloc.rootPath, alloc.keyName)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -111,6 +111,9 @@ type Server struct {
 	// store, region and peer, because we just need
 	// a unique ID.
 	idAllocator *id.AllocatorImpl
+	// for serverId allocator.
+	// The space of serverId is limited, so we use an individual allocator.
+	serverIDAllocator *id.AllocatorImpl
 	// for storage operation.
 	storage *core.Storage
 	// for baiscCluster operation.
@@ -345,6 +348,8 @@ func (s *Server) startServer(ctx context.Context) error {
 	s.member.SetMemberBinaryVersion(s.member.ID(), PDReleaseVersion)
 	s.member.SetMemberGitHash(s.member.ID(), PDGitHash)
 	s.idAllocator = id.NewAllocatorImpl(s.client, s.rootPath, s.member.MemberValue())
+	serverIDPath := path.Join(s.rootPath, "server_id")
+	s.serverIDAllocator = id.NewAllocatorImpl(s.client, serverIDPath, s.member.MemberValue())
 	s.tso = tso.NewTimestampOracle(
 		s.client,
 		s.rootPath,

--- a/server/server.go
+++ b/server/server.go
@@ -347,9 +347,8 @@ func (s *Server) startServer(ctx context.Context) error {
 	s.member.SetMemberDeployPath(s.member.ID())
 	s.member.SetMemberBinaryVersion(s.member.ID(), PDReleaseVersion)
 	s.member.SetMemberGitHash(s.member.ID(), PDGitHash)
-	s.idAllocator = id.NewAllocatorImpl(s.client, s.rootPath, s.member.MemberValue())
-	serverIDPath := path.Join(s.rootPath, "server_id")
-	s.serverIDAllocator = id.NewAllocatorImpl(s.client, serverIDPath, s.member.MemberValue())
+	s.idAllocator = id.NewAllocatorImpl(s.client, s.rootPath, s.member.MemberValue(), "alloc_id")
+	s.serverIDAllocator = id.NewAllocatorImpl(s.client, s.rootPath, s.member.MemberValue(), "alloc_server_id")
 	s.tso = tso.NewTimestampOracle(
 		s.client,
 		s.rootPath,


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Extend AllocID() interface for TiDB server id allocation, to support "global kill" across cluster.

<!-- Add the issue link with a summary if it exists. -->
Issue: https://github.com/pingcap/tidb/issues/8854
TiDB PR: https://github.com/pingcap/tidb/pull/17649

### What is changed and how it works?
Add AllocID() interface in client, and add another id allocator for server id allocation.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

TiDB acquires serverID from PD successful on startup.
```
...
[2020/06/25 15:46:38.580 +08:00] [INFO] [domain.go:740] ["acquire serverID"] [serverID=1026]
...
```

manual check by `etcdctl`:
```
etcdctl --endpoints=127.0.0.1:2379 get /pd/6804250861481915968/alloc_server_id --prefix
/pd/6804250861481915968/alloc_server_id
?
```

Related changes

- PR to update [`pingcap/kvproto`](https://github.com/pingcap/kvproto/pull/636)
- PR to update [`pingcap/tidb`](https://github.com/pingcap/tidb/pull/17649)

### Release note
- Extend AllocID() interface for TiDB server id allocation.
