### PR TITLE
operator: remove u64slice

### DIFF
--- a/server/schedule/operator/builder.go
+++ b/server/schedule/operator/builder.go
@@ -621,7 +621,7 @@ func (pm *peersMap) IDs() []uint64 {
 	for id := range pm.m {
 		ids = append(ids, id)
 	}
-	sort.Sort(u64Slice(ids))
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 	return ids
 }
 

--- a/server/schedule/operator/create_operator.go
+++ b/server/schedule/operator/create_operator.go
@@ -165,17 +165,3 @@ func CreateScatterRegionOperator(desc string, cluster Cluster, origin *core.Regi
 		SetLightWeight().
 		Build(0)
 }
-
-type u64Slice []uint64
-
-func (s u64Slice) Len() int {
-	return len(s)
-}
-
-func (s u64Slice) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-func (s u64Slice) Less(i, j int) bool {
-	return s[i] < s[j]
-}


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
now that Go has `sort.Slice`, we don't need define `u64slice` any more.

### Release note
- No release note
