### PR TITLE
server: adjust store disconnect log level and message

### DIFF
--- a/server/heartbeat_streams.go
+++ b/server/heartbeat_streams.go
@@ -118,7 +118,7 @@ func (s *heartbeatStreams) run() {
 				storeAddress := store.GetAddress()
 				storeLabel := strconv.FormatUint(storeID, 10)
 				if err := stream.Send(keepAlive); err != nil {
-					log.Error("send keepalive message fail",
+					log.Warn("send keepalive message fail, store maybe disconnected",
 						zap.Uint64("target-store-id", storeID),
 						zap.Error(err))
 					delete(s.streams, storeID)


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
When store disconnected, the log message looks critical.

### What is changed and how it works?
Adjust log level and reword.

### Check List

<!-- Remove the items that are not applicable. -->

Tests
- no test

### Release note
- No release note
