### PR TITLE
api: prevent store limit from changing to zero

### DIFF
--- a/server/api/store.go
+++ b/server/api/store.go
@@ -368,8 +368,8 @@ func (h *storeHandler) SetLimit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ratePerMin, ok := rateVal.(float64)
-	if !ok || ratePerMin < 0 {
-		h.rd.JSON(w, http.StatusBadRequest, "badformat rate")
+	if !ok || ratePerMin <= 0 {
+		h.rd.JSON(w, http.StatusBadRequest, "invalid rate which should be larger than 0")
 		return
 	}
 
@@ -440,8 +440,8 @@ func (h *storesHandler) SetAllLimit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ratePerMin, ok := rateVal.(float64)
-	if !ok || ratePerMin < 0 {
-		h.rd.JSON(w, http.StatusBadRequest, "badformat rate")
+	if !ok || ratePerMin <= 0 {
+		h.rd.JSON(w, http.StatusBadRequest, "invalid rate which should be larger than 0")
 		return
 	}
 

--- a/tests/pdctl/store/store_test.go
+++ b/tests/pdctl/store/store_test.go
@@ -196,6 +196,12 @@ func (s *storeTestSuite) TestStore(c *C) {
 	limit2 = leaderServer.GetRaftCluster().GetStoreLimitByType(2, storelimit.RemovePeer)
 	c.Assert(limit2, Equals, float64(25))
 
+	// store limit all 0
+	args = []string{"-u", pdAddr, "store", "limit", "all", "0"}
+	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "invalid"), IsTrue)
+
 	// store limit <type>
 	echo := pdctl.GetEcho([]string{"-u", pdAddr, "store", "limit"})
 	allAddPeerLimit := make(map[string]map[string]interface{})


### PR DESCRIPTION
### What problem does this PR solve?

Closes #2584.

### What is changed and how it works?

When setting the store limit, we first check if it is zero and reject the request if it is.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

- Prevent store limit from changing to zero