### PR TITLE
plugin: remove the extra path

### DIFF
--- a/server/api/plugin.go
+++ b/server/api/plugin.go
@@ -15,14 +15,12 @@ package api
 
 import (
 	"errors"
-	"net/http"
-	"os"
-	"strings"
-
 	"github.com/pingcap/pd/v4/pkg/apiutil"
 	"github.com/pingcap/pd/v4/server"
 	"github.com/pingcap/pd/v4/server/cluster"
 	"github.com/unrolled/render"
+	"net/http"
+	"os"
 )
 
 type pluginHandler struct {
@@ -71,11 +69,6 @@ func (h *pluginHandler) processPluginCommand(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	path := data["plugin-path"]
-	if !strings.HasPrefix(path, "./pd/plugin/") {
-		err := errors.New("plugin path must begin with ./pd/plugin/")
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
-		return
-	}
 	if exist, err := pathExists(path); !exist {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return

--- a/server/api/plugin.go
+++ b/server/api/plugin.go
@@ -15,12 +15,13 @@ package api
 
 import (
 	"errors"
+	"net/http"
+	"os"
+
 	"github.com/pingcap/pd/v4/pkg/apiutil"
 	"github.com/pingcap/pd/v4/server"
 	"github.com/pingcap/pd/v4/server/cluster"
 	"github.com/unrolled/render"
-	"net/http"
-	"os"
 )
 
 type pluginHandler struct {


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Function processPluginCommand specifies that the path prefix must be "./pd/plugin", and then determines whether there is a file under the path.

This limits the environment in which plugin can be loaded through pdctl or http.

For example, you need to create a path "pd/plugin" in the same directory as pdctl.
