### PR TITLE
config: improve scheduler config reload behavior

### DIFF
--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -672,8 +672,11 @@ func (s *testCoordinatorSuite) TestPersistScheduler(c *C) {
 	_, err = schedule.CreateScheduler(schedulers.AdjacentRegionType, oc, storage, schedule.ConfigJSONDecoder([]byte("null")))
 	c.Assert(err, IsNil)
 	// suppose we add a new default enable scheduler
-	newOpt.AddSchedulerCfg(schedulers.AdjacentRegionType, []string{})
-	c.Assert(newOpt.GetSchedulers(), HasLen, 5)
+	config.DefaultSchedulers = append(config.DefaultSchedulers, config.SchedulerConfig{Type: "adjacent-region"})
+	defer func() {
+		config.DefaultSchedulers = config.DefaultSchedulers[:len(config.DefaultSchedulers)-1]
+	}()
+	c.Assert(newOpt.GetSchedulers(), HasLen, 4)
 	c.Assert(newOpt.Reload(storage), IsNil)
 	// only remains 3 items with independent config.
 	sches, _, err = storage.LoadAllScheduleConfig()

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -768,7 +768,7 @@ func (c *ScheduleConfig) adjust(meta *configMetaData) error {
 	}
 	adjustFloat64(&c.LowSpaceRatio, defaultLowSpaceRatio)
 	adjustFloat64(&c.HighSpaceRatio, defaultHighSpaceRatio)
-	adjustSchedulers(&c.Schedulers, defaultSchedulers)
+	adjustSchedulers(&c.Schedulers, DefaultSchedulers)
 
 	for k, b := range c.migrateConfigurationMap() {
 		v, err := c.parseDeprecatedFlag(meta, k, *b[0], *b[1])
@@ -895,7 +895,10 @@ type SchedulerConfig struct {
 	ArgsPayload string   `toml:"args-payload" json:"args-payload"`
 }
 
-var defaultSchedulers = SchedulerConfigs{
+// DefaultSchedulers are the schedulers be created by default.
+// If these schedulers are not in the persistent configuration, they
+// will be created automatically when reloading.
+var DefaultSchedulers = SchedulerConfigs{
 	{Type: "balance-region"},
 	{Type: "balance-leader"},
 	{Type: "hot-region"},
@@ -904,7 +907,7 @@ var defaultSchedulers = SchedulerConfigs{
 
 // IsDefaultScheduler checks whether the scheduler is enable by default.
 func IsDefaultScheduler(typ string) bool {
-	for _, c := range defaultSchedulers {
+	for _, c := range DefaultSchedulers {
 		if typ == c.Type {
 			return true
 		}

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -62,17 +62,20 @@ func (s *testConfigSuite) TestReloadConfig(c *C) {
 	opt.GetPDServerConfig().UseRegionStorage = true
 	c.Assert(opt.Persist(storage), IsNil)
 
-	// suppose we add a new default enable scheduler "adjacent-region"
-	defaultSchedulers := []string{"balance-region", "balance-leader", "hot-region", "label", "adjacent-region"}
+	// Add a new default enable scheduler "adjacent-region"
+	DefaultSchedulers = append(DefaultSchedulers, SchedulerConfig{Type: "adjacent-region"})
+	defer func() {
+		DefaultSchedulers = DefaultSchedulers[:len(DefaultSchedulers)-1]
+	}()
+
 	newOpt, err := newTestScheduleOption()
 	c.Assert(err, IsNil)
-	newOpt.AddSchedulerCfg("adjacent-region", []string{})
 	c.Assert(newOpt.Reload(storage), IsNil)
 	schedulers := newOpt.GetSchedulers()
 	c.Assert(schedulers, HasLen, 5)
 	c.Assert(newOpt.IsUseRegionStorage(), IsTrue)
 	for i, s := range schedulers {
-		c.Assert(s.Type, Equals, defaultSchedulers[i])
+		c.Assert(s.Type, Equals, DefaultSchedulers[i].Type)
 		c.Assert(s.Disable, IsFalse)
 	}
 	c.Assert(newOpt.GetMaxReplicas(), Equals, 5)

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -481,14 +481,7 @@ func (o *PersistOptions) Persist(storage *core.Storage) error {
 
 // Reload reloads the configuration from the storage.
 func (o *PersistOptions) Reload(storage *core.Storage) error {
-	cfg := &Config{
-		Schedule:        *o.GetScheduleConfig().Clone(),
-		Replication:     *o.GetReplicationConfig().clone(),
-		PDServerCfg:     *o.GetPDServerConfig().Clone(),
-		ReplicationMode: *o.GetReplicationModeConfig().Clone(),
-		LabelProperty:   o.GetLabelPropertyConfig().Clone(),
-		ClusterVersion:  *o.GetClusterVersion(),
-	}
+	cfg := &Config{}
 	isExist, err := storage.LoadConfig(cfg)
 	if err != nil {
 		return err

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/pd/v4/pkg/slice"
 	"github.com/pingcap/pd/v4/pkg/typeutil"
 	"github.com/pingcap/pd/v4/server/core"
 	"github.com/pingcap/pd/v4/server/kv"
@@ -486,7 +487,7 @@ func (o *PersistOptions) Reload(storage *core.Storage) error {
 	if err != nil {
 		return err
 	}
-	o.adjustScheduleCfg(cfg)
+	o.adjustScheduleCfg(&cfg.Schedule)
 	if isExist {
 		o.schedule.Store(&cfg.Schedule)
 		o.replication.Store(&cfg.Replication)
@@ -498,33 +499,16 @@ func (o *PersistOptions) Reload(storage *core.Storage) error {
 	return nil
 }
 
-func (o *PersistOptions) adjustScheduleCfg(persistentCfg *Config) {
-	scheduleCfg := o.GetScheduleConfig().Clone()
-	for i, s := range scheduleCfg.Schedulers {
-		for _, ps := range persistentCfg.Schedule.Schedulers {
-			if s.Type == ps.Type && reflect.DeepEqual(s.Args, ps.Args) {
-				scheduleCfg.Schedulers[i].Disable = ps.Disable
-				break
-			}
+func (o *PersistOptions) adjustScheduleCfg(scheduleCfg *ScheduleConfig) {
+	// In case we add new default schedulers.
+	for _, ps := range DefaultSchedulers {
+		if slice.NoneOf(scheduleCfg.Schedulers, func(i int) bool {
+			return scheduleCfg.Schedulers[i].Type == ps.Type
+		}) {
+			scheduleCfg.Schedulers = append(scheduleCfg.Schedulers, ps)
 		}
 	}
-	restoredSchedulers := make([]SchedulerConfig, 0, len(persistentCfg.Schedule.Schedulers))
-	for _, ps := range persistentCfg.Schedule.Schedulers {
-		needRestore := true
-		for _, s := range scheduleCfg.Schedulers {
-			if s.Type == ps.Type && reflect.DeepEqual(s.Args, ps.Args) {
-				needRestore = false
-				break
-			}
-		}
-		if needRestore {
-			restoredSchedulers = append(restoredSchedulers, ps)
-		}
-	}
-	scheduleCfg.Schedulers = append(scheduleCfg.Schedulers, restoredSchedulers...)
-	persistentCfg.Schedule.Schedulers = scheduleCfg.Schedulers
-	persistentCfg.Schedule.MigrateDeprecatedFlags()
-	o.SetScheduleConfig(scheduleCfg)
+	scheduleCfg.MigrateDeprecatedFlags()
 }
 
 // CheckLabelProperty checks the label property.


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Stale scheduler may appear after PD leader change, caused by the reload behavior that it merges in-memory config with persist config.

### What is changed and how it works?
Drop in-memory state and merge default schedulers with persist configuration.

### Check List

<!-- Remove the items that are not applicable. -->

Tests
- Unit test
- Manually test

```
start 3pd + 1tikv
add evict-leader-scheduler-1
remove evict-leader-scheduler-1
kill pd1
show schedulers
make sure there is no evict-leader-scheduler-1
```

### Release note
- Fix the problem of stale scheduler after leader change

