### PR TITLE
misc: fix the deploy path not being updated

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -902,6 +902,7 @@ func (c *RaftCluster) PutStore(store *metapb.Store, force bool) error {
 			core.SetStoreVersion(store.GitHash, store.Version),
 			core.SetStoreLabels(labels),
 			core.SetStoreStartTime(store.StartTimestamp),
+			core.SetStoreDeployPath(store.DeployPath),
 		)
 	}
 	if err = c.checkStoreLabels(s); err != nil {

--- a/server/core/store_option.go
+++ b/server/core/store_option.go
@@ -64,6 +64,15 @@ func SetStoreVersion(githash, version string) StoreCreateOption {
 	}
 }
 
+// SetStoreDeployPath sets the deploy path for the store.
+func SetStoreDeployPath(deployPath string) StoreCreateOption {
+	return func(store *StoreInfo) {
+		meta := proto.Clone(store.meta).(*metapb.Store)
+		meta.DeployPath = deployPath
+		store.meta = meta
+	}
+}
+
 // SetStoreState sets the state for the store.
 func SetStoreState(state metapb.StoreState) StoreCreateOption {
 	return func(store *StoreInfo) {


### PR DESCRIPTION

### What problem does this PR solve?

Closes #2595.

### What is changed and how it works?

This PR updates the existed store's deploy path when `Putstore` is called after restarting.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

- Fix the issue that the deploy path of the store is not updated if the deploy directory is moved
