### PR TITLE
placement: fix placement location issue

### DIFF
--- a/server/schedule/placement/fit.go
+++ b/server/schedule/placement/fit.go
@@ -14,6 +14,7 @@
 package placement
 
 import (
+	"math"
 	"sort"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -85,9 +86,9 @@ type RuleFit struct {
 	// different Role from configuration (the Role can be migrated to target role
 	// by scheduling).
 	PeersWithDifferentRole []*metapb.Peer
-	// IsolationLevel indicates at which level of labeling these Peers are
-	// isolated. A larger value indicates a higher isolation level.
-	IsolationLevel int
+	// IsolationScore indicates at which level of labeling these Peers are
+	// isolated. A larger value is better.
+	IsolationScore float64
 }
 
 // IsSatisfied returns if the rule is properly satisfied.
@@ -105,9 +106,9 @@ func compareRuleFit(a, b *RuleFit) int {
 		return -1
 	case len(a.PeersWithDifferentRole) < len(b.PeersWithDifferentRole):
 		return 1
-	case a.IsolationLevel < b.IsolationLevel:
+	case a.IsolationScore < b.IsolationScore:
 		return -1
-	case a.IsolationLevel > b.IsolationLevel:
+	case a.IsolationScore > b.IsolationScore:
 		return 1
 	default:
 		return 0
@@ -159,7 +160,7 @@ func fitRule(peers []*fitPeer, rule *Rule) *RuleFit {
 }
 
 func newRuleFit(rule *Rule, peers []*fitPeer) *RuleFit {
-	rf := &RuleFit{Rule: rule, IsolationLevel: isolationLevel(peers, rule.LocationLabels)}
+	rf := &RuleFit{Rule: rule, IsolationScore: isolationScore(peers, rule.LocationLabels)}
 	for _, p := range peers {
 		rf.Peers = append(rf.Peers, p.Peer)
 		if !p.matchRoleStrict(rule.Role) {
@@ -236,28 +237,24 @@ func iterPeersRecr(peers []*fitPeer, index int, out []*fitPeer, f func()) {
 	}
 }
 
-func isolationLevel(peers []*fitPeer, labels []string) int {
-	if len(labels) == 0 || len(peers) == 0 {
+func isolationScore(peers []*fitPeer, labels []string) float64 {
+	var score float64
+	if len(labels) == 0 || len(peers) <= 1 {
 		return 0
 	}
-	if len(peers) == 1 {
-		return len(labels)
-	}
-	if len(peers) == 2 {
-		for l, label := range labels {
-			if peers[0].store.GetLabelValue(label) != peers[1].store.GetLabelValue(label) {
-				return len(labels) - l
+	// NOTE: following loop is partially duplicated with `core.DistinctScore`.
+	// The reason not to call it directly is that core.DistinctScore only
+	// accepts `[]StoreInfo` not `[]*fitPeer` and I don't want alloc slice
+	// here because it is kind of hot path.
+	// After Go supports generics, we will be enable to do some refactor and
+	// reuse `core.DistinctScore`.
+	const replicaBaseScore = 100
+	for i, p1 := range peers {
+		for _, p2 := range peers[i:] {
+			if index := p1.store.CompareLocation(p2.store, labels); index != -1 {
+				score += math.Pow(replicaBaseScore, float64(len(labels)-index-1))
 			}
 		}
-		return 0
 	}
-
-	// TODO: brute force can be improved.
-	level := len(labels)
-	iterPeers(peers, 2, func(pair []*fitPeer) {
-		if l := isolationLevel(pair, labels); l < level {
-			level = l
-		}
-	})
-	return level
+	return score
 }

--- a/server/schedule/placement/fit.go
+++ b/server/schedule/placement/fit.go
@@ -250,7 +250,7 @@ func isolationScore(peers []*fitPeer, labels []string) float64 {
 	// reuse `core.DistinctScore`.
 	const replicaBaseScore = 100
 	for i, p1 := range peers {
-		for _, p2 := range peers[i:] {
+		for _, p2 := range peers[i+1:] {
 			if index := p1.store.CompareLocation(p2.store, labels); index != -1 {
 				score += math.Pow(replicaBaseScore, float64(len(labels)-index-1))
 			}

--- a/server/schedule/placement/fit_test.go
+++ b/server/schedule/placement/fit_test.go
@@ -54,8 +54,7 @@ func (s *testFitSuite) TestFitByLocation(c *C) {
 		count          int          // default: len(peerStoreID)
 		role           PeerRoleType // default: Voter
 		// expect result:
-		expectedPeers          []uint64 // default: same as peerStoreID
-		expectedIsolationLevel int      // default: 0
+		expectedPeers []uint64 // default: same as peerStoreID
 	}
 
 	cases := []Case{
@@ -65,59 +64,59 @@ func (s *testFitSuite) TestFitByLocation(c *C) {
 		{peerStoreID: []uint64{1111, 1112, 1113}, count: 3, expectedPeers: []uint64{1111, 1112, 1113}},
 		{peerStoreID: []uint64{1111, 1112, 1113}, count: 5, expectedPeers: []uint64{1111, 1112, 1113}},
 		// test isolation level
-		{peerStoreID: []uint64{1111}, locationLabels: "zone,rack,host", expectedIsolationLevel: 3},
-		{peerStoreID: []uint64{1111}, locationLabels: "zone,rack", expectedIsolationLevel: 2},
-		{peerStoreID: []uint64{1111}, locationLabels: "zone", expectedIsolationLevel: 1},
-		{peerStoreID: []uint64{1111}, locationLabels: "", expectedIsolationLevel: 0},
-		{peerStoreID: []uint64{1111, 2111}, locationLabels: "zone,rack,host", expectedIsolationLevel: 3},
-		{peerStoreID: []uint64{1111, 2222, 3333}, locationLabels: "zone,rack,host", expectedIsolationLevel: 3},
-		{peerStoreID: []uint64{1111, 1211, 3111}, locationLabels: "zone,rack,host", expectedIsolationLevel: 2},
-		{peerStoreID: []uint64{1111, 1121, 3111}, locationLabels: "zone,rack,host", expectedIsolationLevel: 1},
-		{peerStoreID: []uint64{1111, 1121, 1122}, locationLabels: "zone,rack,host", expectedIsolationLevel: 0},
+		{peerStoreID: []uint64{1111}, locationLabels: "zone,rack,host"},
+		{peerStoreID: []uint64{1111}, locationLabels: "zone,rack"},
+		{peerStoreID: []uint64{1111}, locationLabels: "zone"},
+		{peerStoreID: []uint64{1111}, locationLabels: ""},
+		{peerStoreID: []uint64{1111, 2111}, locationLabels: "zone,rack,host"},
+		{peerStoreID: []uint64{1111, 2222, 3333}, locationLabels: "zone,rack,host"},
+		{peerStoreID: []uint64{1111, 1211, 3111}, locationLabels: "zone,rack,host"},
+		{peerStoreID: []uint64{1111, 1121, 3111}, locationLabels: "zone,rack,host"},
+		{peerStoreID: []uint64{1111, 1121, 1122}, locationLabels: "zone,rack,host"},
 		// test best location
 		{
-			peerStoreID:            []uint64{1111, 1112, 1113, 2111, 2222, 3222, 3333},
-			locationLabels:         "zone,rack,host",
-			count:                  3,
-			expectedPeers:          []uint64{1111, 2111, 3222},
-			expectedIsolationLevel: 3,
+			peerStoreID:    []uint64{1111, 1112, 1113, 2111, 2222, 3222, 3333},
+			locationLabels: "zone,rack,host",
+			count:          3,
+			expectedPeers:  []uint64{1111, 2111, 3222},
 		},
 		{
-			peerStoreID:            []uint64{1111, 1121, 1211, 2111, 2211},
-			locationLabels:         "zone,rack,host",
-			count:                  3,
-			expectedPeers:          []uint64{1111, 1211, 2111},
-			expectedIsolationLevel: 2,
+			peerStoreID:    []uint64{1111, 1121, 1211, 2111, 2211},
+			locationLabels: "zone,rack,host",
+			count:          3,
+			expectedPeers:  []uint64{1111, 1211, 2111},
+		},
+		{
+			peerStoreID:    []uint64{1111, 1211, 1311, 1411, 2111, 2211, 2311, 3111},
+			locationLabels: "zone,rack,host",
+			count:          5,
+			expectedPeers:  []uint64{1111, 1211, 2111, 2211, 3111},
 		},
 		// test role match
 		{
-			peerStoreID:            []uint64{1111, 1112, 1113},
-			peerRole:               []PeerRoleType{Learner, Follower, Follower},
-			count:                  1,
-			expectedPeers:          []uint64{1112},
-			expectedIsolationLevel: 0,
+			peerStoreID:   []uint64{1111, 1112, 1113},
+			peerRole:      []PeerRoleType{Learner, Follower, Follower},
+			count:         1,
+			expectedPeers: []uint64{1112},
 		},
 		{
-			peerStoreID:            []uint64{1111, 1112, 1113},
-			peerRole:               []PeerRoleType{Learner, Follower, Follower},
-			count:                  2,
-			expectedPeers:          []uint64{1112, 1113},
-			expectedIsolationLevel: 0,
+			peerStoreID:   []uint64{1111, 1112, 1113},
+			peerRole:      []PeerRoleType{Learner, Follower, Follower},
+			count:         2,
+			expectedPeers: []uint64{1112, 1113},
 		},
 		{
-			peerStoreID:            []uint64{1111, 1112, 1113},
-			peerRole:               []PeerRoleType{Learner, Follower, Follower},
-			count:                  3,
-			expectedPeers:          []uint64{1112, 1113, 1111},
-			expectedIsolationLevel: 0,
+			peerStoreID:   []uint64{1111, 1112, 1113},
+			peerRole:      []PeerRoleType{Learner, Follower, Follower},
+			count:         3,
+			expectedPeers: []uint64{1112, 1113, 1111},
 		},
 		{
-			peerStoreID:            []uint64{1111, 1112, 1121, 1122, 1131, 1132, 1141, 1142},
-			peerRole:               []PeerRoleType{Follower, Learner, Learner, Learner, Learner, Follower, Follower, Follower},
-			locationLabels:         "zone,rack,host",
-			count:                  3,
-			expectedPeers:          []uint64{1111, 1132, 1141},
-			expectedIsolationLevel: 1,
+			peerStoreID:    []uint64{1111, 1112, 1121, 1122, 1131, 1132, 1141, 1142},
+			peerRole:       []PeerRoleType{Follower, Learner, Learner, Learner, Learner, Follower, Follower, Follower},
+			locationLabels: "zone,rack,host",
+			count:          3,
+			expectedPeers:  []uint64{1111, 1132, 1141},
 		},
 	}
 
@@ -159,6 +158,5 @@ func (s *testFitSuite) TestFitByLocation(c *C) {
 		}
 		sort.Slice(expectedPeers, func(i, j int) bool { return expectedPeers[i] < expectedPeers[j] })
 		c.Assert(selectedIDs, DeepEquals, expectedPeers)
-		c.Assert(ruleFit.IsolationLevel, Equals, cc.expectedIsolationLevel)
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?
Fix https://github.com/pingcap/pd/issues/2601

### What is changed and how it works?
Use `DistinctScore` way to compare placements.

### Check List
Tests
- Unit test

Related changes
- Need to cherry-pick to the release branch

### Release note
- Fix the issue that when enable placement rules, sometimes replicas of region may not be able to adjust to the best location
