### PR TITLE
tso: make follower fail fast for tso requests

### DIFF
--- a/server/tso/tso.go
+++ b/server/tso/tso.go
@@ -15,7 +15,6 @@ package tso
 
 import (
 	"path"
-	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -46,7 +45,6 @@ type TimestampOracle struct {
 	ts            unsafe.Pointer
 	lastSavedTime atomic.Value
 
-	mu    sync.RWMutex
 	lease *member.LeaderLease
 
 	rootPath      string

--- a/server/tso/tso.go
+++ b/server/tso/tso.go
@@ -273,7 +273,7 @@ func (t *TimestampOracle) GetRespTS(count uint32) (pdpb.Timestamp, error) {
 	for i := 0; i < maxRetryCount; i++ {
 		current := (*atomicObject)(atomic.LoadPointer(&t.ts))
 		if current == nil || current.physical == typeutil.ZeroTime {
-			return pdpb.Timestamp{}, errors.New("alloc timestamp failed, may be not leader")
+			return pdpb.Timestamp{}, errors.New("can not get timestamp, may be not leader")
 		}
 
 		resp.Physical = current.physical.UnixNano() / int64(time.Millisecond)

--- a/tests/server/tso/tso_test.go
+++ b/tests/server/tso/tso_test.go
@@ -53,46 +53,6 @@ func (s *testTsoSuite) TearDownSuite(c *C) {
 	s.cancel()
 }
 
-func (s *testTsoSuite) TestRequestFollower(c *C) {
-	cluster, err := tests.NewTestCluster(s.ctx, 2)
-	c.Assert(err, IsNil)
-	defer cluster.Destroy()
-
-	err = cluster.RunInitialServers()
-	c.Assert(err, IsNil)
-	cluster.WaitLeader()
-
-	var followerServer *tests.TestServer
-	for _, s := range cluster.GetServers() {
-		if s.GetConfig().Name != cluster.GetLeader() {
-			followerServer = s
-		}
-	}
-	c.Assert(followerServer, NotNil)
-
-	grpcPDClient := testutil.MustNewGrpcClient(c, followerServer.GetAddr())
-	clusterID := followerServer.GetClusterID()
-	req := &pdpb.TsoRequest{
-		Header: testutil.NewRequestHeader(clusterID),
-		Count:  1,
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	tsoClient, err := grpcPDClient.Tso(ctx)
-	c.Assert(err, IsNil)
-	defer tsoClient.CloseSend()
-
-	start := time.Now()
-	err = tsoClient.Send(req)
-	c.Assert(err, IsNil)
-	_, err = tsoClient.Recv()
-	c.Assert(err, NotNil)
-
-	// Requesting follower should fail fast, or the unavailable time will be
-	// too long.
-	c.Assert(time.Since(start), Less, time.Second)
-}
-
 func (s *testTsoSuite) testGetTimestamp(c *C, n int) *pdpb.Timestamp {
 	var err error
 	cluster, err := tests.NewTestCluster(s.ctx, 1)
@@ -208,6 +168,46 @@ func (s *testTsoSuite) TestTsoCount0(c *C) {
 	c.Assert(err, IsNil)
 	_, err = tsoClient.Recv()
 	c.Assert(err, NotNil)
+}
+
+func (s *testTsoSuite) TestRequestFollower(c *C) {
+	cluster, err := tests.NewTestCluster(s.ctx, 2)
+	c.Assert(err, IsNil)
+	defer cluster.Destroy()
+
+	err = cluster.RunInitialServers()
+	c.Assert(err, IsNil)
+	cluster.WaitLeader()
+
+	var followerServer *tests.TestServer
+	for _, s := range cluster.GetServers() {
+		if s.GetConfig().Name != cluster.GetLeader() {
+			followerServer = s
+		}
+	}
+	c.Assert(followerServer, NotNil)
+
+	grpcPDClient := testutil.MustNewGrpcClient(c, followerServer.GetAddr())
+	clusterID := followerServer.GetClusterID()
+	req := &pdpb.TsoRequest{
+		Header: testutil.NewRequestHeader(clusterID),
+		Count:  1,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tsoClient, err := grpcPDClient.Tso(ctx)
+	c.Assert(err, IsNil)
+	defer tsoClient.CloseSend()
+
+	start := time.Now()
+	err = tsoClient.Send(req)
+	c.Assert(err, IsNil)
+	_, err = tsoClient.Recv()
+	c.Assert(err, NotNil)
+
+	// Requesting follower should fail fast, or the unavailable time will be
+	// too long.
+	c.Assert(time.Since(start), Less, time.Second)
 }
 
 var _ = Suite(&testTimeFallBackSuite{})

--- a/tests/server/tso/tso_test.go
+++ b/tests/server/tso/tso_test.go
@@ -53,6 +53,46 @@ func (s *testTsoSuite) TearDownSuite(c *C) {
 	s.cancel()
 }
 
+func (s *testTsoSuite) TestRequestFollower(c *C) {
+	cluster, err := tests.NewTestCluster(s.ctx, 2)
+	c.Assert(err, IsNil)
+	defer cluster.Destroy()
+
+	err = cluster.RunInitialServers()
+	c.Assert(err, IsNil)
+	cluster.WaitLeader()
+
+	var followerServer *tests.TestServer
+	for _, s := range cluster.GetServers() {
+		if s.GetConfig().Name != cluster.GetLeader() {
+			followerServer = s
+		}
+	}
+	c.Assert(followerServer, NotNil)
+
+	grpcPDClient := testutil.MustNewGrpcClient(c, followerServer.GetAddr())
+	clusterID := followerServer.GetClusterID()
+	req := &pdpb.TsoRequest{
+		Header: testutil.NewRequestHeader(clusterID),
+		Count:  1,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tsoClient, err := grpcPDClient.Tso(ctx)
+	c.Assert(err, IsNil)
+	defer tsoClient.CloseSend()
+
+	start := time.Now()
+	err = tsoClient.Send(req)
+	c.Assert(err, IsNil)
+	_, err = tsoClient.Recv()
+	c.Assert(err, NotNil)
+
+	// Requesting follower should fail fast, or the unavailable time will be
+	// too long.
+	c.Assert(time.Since(start), Less, time.Second)
+}
+
 func (s *testTsoSuite) testGetTimestamp(c *C, n int) *pdpb.Timestamp {
 	var err error
 	cluster, err := tests.NewTestCluster(s.ctx, 1)


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
It takes too long (20s) for a follower PD to return an error to client. It may cause a longer unavailable time when PD leader changes.
Note: The client will not wait for 20s, but will timeout after 3 seconds.

### What is changed and how it works?
Check lease before alloc ts.

### Check List
Tests
- Unit test

Related changes
- Need to cherry-pick to the release branch

### Release note
- Fix the issue that the TSO request may take too long when PD leader switches
