### PR TITLE
cluster: change return value for getSchedulers

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1644,10 +1644,17 @@ func (c *RaftCluster) GetHotReadRegions() *statistics.StoreHotPeersInfos {
 }
 
 // GetSchedulers gets all schedulers.
-func (c *RaftCluster) GetSchedulers() map[string]*scheduleController {
+func (c *RaftCluster) GetSchedulers() []string {
 	c.RLock()
 	defer c.RUnlock()
 	return c.coordinator.getSchedulers()
+}
+
+// GetSchedulerHandlers gets all scheduler handlers.
+func (c *RaftCluster) GetSchedulerHandlers() map[string]http.Handler {
+	c.RLock()
+	defer c.RUnlock()
+	return c.coordinator.getSchedulerHandlers()
 }
 
 // AddScheduler adds a scheduler.
@@ -1669,6 +1676,13 @@ func (c *RaftCluster) PauseOrResumeScheduler(name string, t int64) error {
 	c.RLock()
 	defer c.RUnlock()
 	return c.coordinator.pauseOrResumeScheduler(name, t)
+}
+
+// IsSchedulerPaused checks if a scheduler is paused.
+func (c *RaftCluster) IsSchedulerPaused(name string) (bool, error) {
+	c.RLock()
+	defer c.RUnlock()
+	return c.coordinator.isSchedulerPaused(name)
 }
 
 // GetStoreLimiter returns the dynamic adjusting limiter

--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -16,6 +16,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -375,10 +376,24 @@ func (c *coordinator) getHotReadRegions() *statistics.StoreHotPeersInfos {
 	return nil
 }
 
-func (c *coordinator) getSchedulers() map[string]*scheduleController {
+func (c *coordinator) getSchedulers() []string {
 	c.RLock()
 	defer c.RUnlock()
-	return c.schedulers
+	names := make([]string, 0, len(c.schedulers))
+	for name := range c.schedulers {
+		names = append(names, name)
+	}
+	return names
+}
+
+func (c *coordinator) getSchedulerHandlers() map[string]http.Handler {
+	c.RLock()
+	defer c.RUnlock()
+	handlers := make(map[string]http.Handler, len(c.schedulers))
+	for name, scheduler := range c.schedulers {
+		handlers[name] = scheduler.Scheduler
+	}
+	return handlers
 }
 
 func (c *coordinator) collectSchedulerMetrics() {
@@ -553,6 +568,19 @@ func (c *coordinator) pauseOrResumeScheduler(name string, t int64) error {
 		atomic.StoreInt64(&sc.delayUntil, delayUntil)
 	}
 	return err
+}
+
+func (c *coordinator) isSchedulerPaused(name string) (bool, error) {
+	c.RLock()
+	defer c.RUnlock()
+	if c.cluster == nil {
+		return false, ErrNotBootstrapped
+	}
+	s, ok := c.schedulers[name]
+	if !ok {
+		return false, schedulers.ErrSchedulerNotFound
+	}
+	return s.IsPaused(), nil
 }
 
 func (c *coordinator) runScheduler(s *scheduleController) {


### PR DESCRIPTION
### What problem does this PR solve?

Close #2630.

### What is changed and how it works?

This PR changes the return value of `getSchedulers` from `map` to `[]string` and adds a new function named `GetSchedulerHandlers`.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

- Fix the issue that `getSchedulers` may cause a data race