### PR TITLE
cooridinator: fix the issue caused adeadlock when deleting scheduler 

### DIFF
--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -401,12 +401,13 @@ func (c *coordinator) resetSchedulerMetrics() {
 
 func (c *coordinator) collectHotSpotMetrics() {
 	c.RLock()
-	defer c.RUnlock()
 	// Collects hot write region metrics.
 	s, ok := c.schedulers[schedulers.HotRegionName]
 	if !ok {
+		c.RUnlock()
 		return
 	}
+	c.RUnlock()
 	stores := c.cluster.GetStores()
 	status := s.Scheduler.(hasHotStatus).GetHotWriteStatus()
 	pendings := s.Scheduler.(hasHotStatus).GetWritePendingInfluence()


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
The PD service cannot serve after remove the scheduler.
<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?
The main reason:

goroutine 1:
* To delete the schedule, call `func (c *RaftCluster) RemoveScheduler(name string)
* Hold RaftCluster write lock
* Wait for coordinator write lock

goroutine  2:
* Background thread, collect statistics continuously, call func (c *coordinator) collectHotSpotMetrics()
* Hold the coordinator read lock
* Call s.Scheduler.(hasHotStatus).GetHotWriteStatus() to wait for hotScheduler read lock

goroutine3:
* Scheduling process, scheduling, call func (h *hotScheduler) Schedule(cluster opt.Cluster)
* Hold hotScheduler write lock
* Call cluster.GetStoresStats() to wait for RaftCluster read lock

### Check List

- Manual test (add detailed scripts or steps below)

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
- fix the issue that caused deadlock when deleting scheduler 