### PR TITLE
service: Fix the issue that cannot update only TTL of the min service safepoint

### DIFF
--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -772,7 +772,7 @@ func (s *Server) UpdateServiceGCSafePoint(ctx context.Context, request *pdpb.Upd
 		return nil, err
 	}
 
-	if request.TTL > 0 && request.SafePoint > min.SafePoint {
+	if request.TTL > 0 && request.SafePoint >= min.SafePoint {
 		ssp := &core.ServiceSafePoint{
 			ServiceID: string(request.ServiceId),
 			ExpiredAt: time.Now().Unix() + request.TTL,


### PR DESCRIPTION
Signed-off-by: MyonKeminta <mk@mkmkm.me>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Fixes https://github.com/pingcap/pd/issues/2628

Do not skip updating service safepoint when the requested safepoint equals to the minimum safepoint currently.

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch
  - release-4.0

### Release note

* Fixes the issue that sometimes service safepoint can't be set properly, which may make BR and dumpling fail.
