### PR TITLE
schedule: merge package selector into filter

### DIFF
--- a/plugin/scheduler_example/evict_leader.go
+++ b/plugin/scheduler_example/evict_leader.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pingcap/pd/v4/server/schedule/filter"
 	"github.com/pingcap/pd/v4/server/schedule/operator"
 	"github.com/pingcap/pd/v4/server/schedule/opt"
-	"github.com/pingcap/pd/v4/server/schedule/selector"
 	"github.com/pingcap/pd/v4/server/schedulers"
 	"github.com/pkg/errors"
 	"github.com/unrolled/render"
@@ -220,7 +219,7 @@ func (s *evictLeaderScheduler) Schedule(cluster opt.Cluster) []*operator.Operato
 		if region == nil {
 			continue
 		}
-		target := selector.NewCandidates(cluster.GetFollowerStores(region)).
+		target := filter.NewCandidates(cluster.GetFollowerStores(region)).
 			FilterTarget(cluster, filter.StoreStateFilter{ActionScope: EvictLeaderName, TransferLeader: true}).
 			RandomPick()
 		if target == nil {

--- a/server/schedule/filter/candidates.go
+++ b/server/schedule/filter/candidates.go
@@ -11,14 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package selector
+package filter
 
 import (
 	"math/rand"
 	"sort"
 
 	"github.com/pingcap/pd/v4/server/core"
-	"github.com/pingcap/pd/v4/server/schedule/filter"
 	"github.com/pingcap/pd/v4/server/schedule/opt"
 )
 
@@ -34,14 +33,14 @@ func NewCandidates(stores []*core.StoreInfo) *StoreCandidates {
 }
 
 // FilterSource keeps stores that can pass all source filters.
-func (c *StoreCandidates) FilterSource(opt opt.Options, filters ...filter.Filter) *StoreCandidates {
-	c.Stores = filter.SelectSourceStores(c.Stores, filters, opt)
+func (c *StoreCandidates) FilterSource(opt opt.Options, filters ...Filter) *StoreCandidates {
+	c.Stores = SelectSourceStores(c.Stores, filters, opt)
 	return c
 }
 
 // FilterTarget keeps stores that can pass all target filters.
-func (c *StoreCandidates) FilterTarget(opt opt.Options, filters ...filter.Filter) *StoreCandidates {
-	c.Stores = filter.SelectTargetStores(c.Stores, filters, opt)
+func (c *StoreCandidates) FilterTarget(opt opt.Options, filters ...Filter) *StoreCandidates {
+	c.Stores = SelectTargetStores(c.Stores, filters, opt)
 	return c
 }
 

--- a/server/schedule/filter/candidates_test.go
+++ b/server/schedule/filter/candidates_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package selector
+package filter
 
 import (
 	. "github.com/pingcap/check"

--- a/server/schedule/filter/comparer.go
+++ b/server/schedule/filter/comparer.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package selector
+package filter
 
 import (
 	"github.com/pingcap/pd/v4/server/core"

--- a/server/schedulers/adjacent_region.go
+++ b/server/schedulers/adjacent_region.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/pd/v4/server/schedule/filter"
 	"github.com/pingcap/pd/v4/server/schedule/operator"
 	"github.com/pingcap/pd/v4/server/schedule/opt"
-	"github.com/pingcap/pd/v4/server/schedule/selector"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -293,7 +292,7 @@ func (l *balanceAdjacentRegionScheduler) disperseLeader(cluster opt.Cluster, bef
 			storesInfo = append(storesInfo, store)
 		}
 	}
-	target := selector.NewCandidates(storesInfo).
+	target := filter.NewCandidates(storesInfo).
 		FilterTarget(cluster, l.filters...).
 		RandomPick()
 	if target == nil {
@@ -332,7 +331,7 @@ func (l *balanceAdjacentRegionScheduler) dispersePeer(cluster opt.Cluster, regio
 		filter.NewExcludedFilter(l.GetName(), nil, excludeStores),
 		scoreGuard,
 	}
-	target := selector.NewCandidates(cluster.GetStores()).
+	target := filter.NewCandidates(cluster.GetStores()).
 		FilterTarget(cluster, filters...).
 		FilterTarget(cluster, l.filters...).
 		RandomPick()

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pingcap/pd/v4/server/schedule/filter"
 	"github.com/pingcap/pd/v4/server/schedule/operator"
 	"github.com/pingcap/pd/v4/server/schedule/opt"
-	"github.com/pingcap/pd/v4/server/schedule/selector"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -201,9 +200,9 @@ func (s *balanceRegionScheduler) transferPeer(cluster opt.Cluster, region *core.
 		filter.StoreStateFilter{ActionScope: s.GetName(), MoveRegion: true},
 	}
 
-	candidates := selector.NewCandidates(cluster.GetStores()).
+	candidates := filter.NewCandidates(cluster.GetStores()).
 		FilterTarget(cluster, filters...).
-		Sort(selector.RegionScoreComparer(cluster))
+		Sort(filter.RegionScoreComparer(cluster))
 
 	for _, target := range candidates.Stores {
 		regionID := region.GetID()

--- a/server/schedulers/evict_leader.go
+++ b/server/schedulers/evict_leader.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/pd/v4/server/schedule/filter"
 	"github.com/pingcap/pd/v4/server/schedule/operator"
 	"github.com/pingcap/pd/v4/server/schedule/opt"
-	"github.com/pingcap/pd/v4/server/schedule/selector"
 	"github.com/pkg/errors"
 	"github.com/unrolled/render"
 	"go.uber.org/zap"
@@ -223,7 +222,7 @@ func (s *evictLeaderScheduler) scheduleOnce(cluster opt.Cluster) []*operator.Ope
 			continue
 		}
 
-		target := selector.NewCandidates(cluster.GetFollowerStores(region)).
+		target := filter.NewCandidates(cluster.GetFollowerStores(region)).
 			FilterTarget(cluster, filter.StoreStateFilter{ActionScope: EvictLeaderName, TransferLeader: true}).
 			RandomPick()
 		if target == nil {

--- a/server/schedulers/label.go
+++ b/server/schedulers/label.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pingcap/pd/v4/server/schedule/filter"
 	"github.com/pingcap/pd/v4/server/schedule/operator"
 	"github.com/pingcap/pd/v4/server/schedule/opt"
-	"github.com/pingcap/pd/v4/server/schedule/selector"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -120,7 +119,7 @@ func (s *labelScheduler) Schedule(cluster opt.Cluster) []*operator.Operator {
 			}
 			f := filter.NewExcludedFilter(s.GetName(), nil, excludeStores)
 
-			target := selector.NewCandidates(cluster.GetFollowerStores(region)).
+			target := filter.NewCandidates(cluster.GetFollowerStores(region)).
 				FilterTarget(cluster, filter.StoreStateFilter{ActionScope: LabelName, TransferLeader: true}, f).
 				RandomPick()
 			if target == nil {

--- a/server/schedulers/random_merge.go
+++ b/server/schedulers/random_merge.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/pd/v4/server/schedule/filter"
 	"github.com/pingcap/pd/v4/server/schedule/operator"
 	"github.com/pingcap/pd/v4/server/schedule/opt"
-	"github.com/pingcap/pd/v4/server/schedule/selector"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -99,7 +98,7 @@ func (s *randomMergeScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
 func (s *randomMergeScheduler) Schedule(cluster opt.Cluster) []*operator.Operator {
 	schedulerCounter.WithLabelValues(s.GetName(), "schedule").Inc()
 
-	store := selector.NewCandidates(cluster.GetStores()).
+	store := filter.NewCandidates(cluster.GetStores()).
 		FilterSource(cluster, filter.StoreStateFilter{ActionScope: s.conf.Name, MoveRegion: true}).
 		RandomPick()
 	if store == nil {

--- a/server/schedulers/shuffle_leader.go
+++ b/server/schedulers/shuffle_leader.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pingcap/pd/v4/server/schedule/filter"
 	"github.com/pingcap/pd/v4/server/schedule/operator"
 	"github.com/pingcap/pd/v4/server/schedule/opt"
-	"github.com/pingcap/pd/v4/server/schedule/selector"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -105,7 +104,7 @@ func (s *shuffleLeaderScheduler) Schedule(cluster opt.Cluster) []*operator.Opera
 	// 1. random select a valid store.
 	// 2. transfer a leader to the store.
 	schedulerCounter.WithLabelValues(s.GetName(), "schedule").Inc()
-	targetStore := selector.NewCandidates(cluster.GetStores()).
+	targetStore := filter.NewCandidates(cluster.GetStores()).
 		FilterTarget(cluster, s.filters...).
 		RandomPick()
 	if targetStore == nil {

--- a/server/schedulers/shuffle_region.go
+++ b/server/schedulers/shuffle_region.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/pd/v4/server/schedule/filter"
 	"github.com/pingcap/pd/v4/server/schedule/operator"
 	"github.com/pingcap/pd/v4/server/schedule/opt"
-	"github.com/pingcap/pd/v4/server/schedule/selector"
 	"github.com/pkg/errors"
 )
 
@@ -124,7 +123,7 @@ func (s *shuffleRegionScheduler) Schedule(cluster opt.Cluster) []*operator.Opera
 }
 
 func (s *shuffleRegionScheduler) scheduleRemovePeer(cluster opt.Cluster) (*core.RegionInfo, *metapb.Peer) {
-	candidates := selector.NewCandidates(cluster.GetStores()).
+	candidates := filter.NewCandidates(cluster.GetStores()).
 		FilterSource(cluster, s.filters...).
 		Shuffle()
 
@@ -153,7 +152,7 @@ func (s *shuffleRegionScheduler) scheduleAddPeer(cluster opt.Cluster, region *co
 	scoreGuard := filter.NewPlacementSafeguard(s.GetName(), cluster, region, cluster.GetStore(oldPeer.GetStoreId()))
 	excludedFilter := filter.NewExcludedFilter(s.GetName(), nil, region.GetStoreIds())
 
-	target := selector.NewCandidates(cluster.GetStores()).
+	target := filter.NewCandidates(cluster.GetStores()).
 		FilterTarget(cluster, s.filters...).
 		FilterTarget(cluster, scoreGuard, excludedFilter).
 		RandomPick()


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
After switch to using `StoreCandidates`, there is, in fact, no selector in package `selector`.

### What is changed and how it works?
Remove package selector and move candidates files to package filter.

### Check List

Tests
- Unit test

### Release note
- No release note
