### PR TITLE
dashboard: update to v2020.07.15 and disable telemetry by default for non-community edition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OVERALLS := overalls
 
 GO_TOOLS_BIN_PATH := $(shell pwd)/.tools/bin
 PATH := $(GO_TOOLS_BIN_PATH):$(PATH)
-SHELL := env PATH=$(PATH) GOBIN=$(GO_TOOLS_BIN_PATH) /bin/bash
+SHELL := env PATH="$(PATH)" GOBIN="$(GO_TOOLS_BIN_PATH)" /bin/bash
 
 FAILPOINT_ENABLE  := $$(find $$PWD/ -type d | grep -vE "\.git" | xargs failpoint-ctl enable)
 FAILPOINT_DISABLE := $$(find $$PWD/ -type d | grep -vE "\.git" | xargs failpoint-ctl disable)
@@ -77,7 +77,7 @@ GOVER_MAJOR := $(shell go version | sed -E -e "s/.*go([0-9]+)[.]([0-9]+).*/\1/")
 GOVER_MINOR := $(shell go version | sed -E -e "s/.*go([0-9]+)[.]([0-9]+).*/\2/")
 GO111 := $(shell [ $(GOVER_MAJOR) -gt 1 ] || [ $(GOVER_MAJOR) -eq 1 ] && [ $(GOVER_MINOR) -ge 11 ]; echo $$?)
 ifeq ($(GO111), 1)
-$(error "go below 1.11 does not support modules")
+  $(error "go below 1.11 does not support modules")
 endif
 
 default: build
@@ -104,6 +104,7 @@ pd-server: export GO111MODULE=on
 pd-server: ${PD_SERVER_DEP}
 	CGO_ENABLED=$(BUILD_CGO_ENABLED) go build $(BUILD_FLAGS) -gcflags '$(GCFLAGS)' -ldflags '$(LDFLAGS)' -tags "$(BUILD_TAGS)" -o bin/pd-server cmd/pd-server/main.go
 
+pd-server-basic: export GO111MODULE=on
 pd-server-basic:
 	SWAGGER=0 DASHBOARD=0 make pd-server
 
@@ -114,10 +115,12 @@ install-go-tools:
 	@which golangci-lint >/dev/null 2>&1 || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GO_TOOLS_BIN_PATH) v1.27.0
 	@grep '_' tools.go | sed 's/"//g' | awk '{print $$2}' | xargs go install
 
+swagger-spec: export GO111MODULE=on
 swagger-spec: install-go-tools
 	go mod vendor
 	swag init --parseVendor -generalInfo server/api/router.go --exclude vendor/github.com/pingcap-incubator/tidb-dashboard --output docs/swagger
 
+dashboard-ui: export GO111MODULE=on
 dashboard-ui:
 	./scripts/embed-dashboard-ui.sh
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OVERALLS := overalls
 
 GO_TOOLS_BIN_PATH := $(shell pwd)/.tools/bin
 PATH := $(GO_TOOLS_BIN_PATH):$(PATH)
-SHELL := env PATH="$(PATH)" GOBIN="$(GO_TOOLS_BIN_PATH)" /bin/bash
+SHELL := env PATH='$(PATH)' GOBIN='$(GO_TOOLS_BIN_PATH)' /bin/bash
 
 FAILPOINT_ENABLE  := $$(find $$PWD/ -type d | grep -vE "\.git" | xargs failpoint-ctl enable)
 FAILPOINT_DISABLE := $$(find $$PWD/ -type d | grep -vE "\.git" | xargs failpoint-ctl disable)

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,13 @@ BUILD_TAGS ?=
 BUILD_CGO_ENABLED := 0
 PD_EDITION ?= Community
 
+# Ensure PD_EDITION is set to Community or Enterprise before running build process.
+ifneq "$(PD_EDITION)" "Community"
+ifneq "$(PD_EDITION)" "Enterprise"
+  $(error Please set the correct environment variable PD_EDITION before running `make`)
+endif
+endif
+
 ifneq ($(SWAGGER), 0)
 	BUILD_TAGS += swagger_server
 endif
@@ -51,11 +58,11 @@ ifeq ("$(WITH_RACE)", "1")
 	BUILD_CGO_ENABLED := 1
 endif
 
-LDFLAGS += -X "$(PD_PKG)/server.PDReleaseVersion=$(shell git describe --tags --dirty)"
-LDFLAGS += -X "$(PD_PKG)/server.PDBuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
-LDFLAGS += -X "$(PD_PKG)/server.PDGitHash=$(shell git rev-parse HEAD)"
-LDFLAGS += -X "$(PD_PKG)/server.PDGitBranch=$(shell git rev-parse --abbrev-ref HEAD)"
-LDFLAGS += -X "$(PD_PKG)/server.PDEdition=$(PD_EDITION)"
+LDFLAGS += -X "$(PD_PKG)/server/versioninfo.PDReleaseVersion=$(shell git describe --tags --dirty)"
+LDFLAGS += -X "$(PD_PKG)/server/versioninfo.PDBuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
+LDFLAGS += -X "$(PD_PKG)/server/versioninfo.PDGitHash=$(shell git rev-parse HEAD)"
+LDFLAGS += -X "$(PD_PKG)/server/versioninfo.PDGitBranch=$(shell git rev-parse --abbrev-ref HEAD)"
+LDFLAGS += -X "$(PD_PKG)/server/versioninfo.PDEdition=$(PD_EDITION)"
 
 ifneq ($(DASHBOARD), 0)
 	# Note: LDFLAGS must be evaluated lazily for these scripts to work correctly

--- a/conf/config.toml
+++ b/conf/config.toml
@@ -128,5 +128,5 @@ location-labels = []
 ## internally instead of result in a 307 redirection.
 # internal-proxy = false
 
-## When not disabled, usage data will be sent to PingCAP for improving user experience.
-# disable-telemetry = false
+## When enabled, usage data will be sent to PingCAP for improving user experience.
+# enable-telemetry = true

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/opentracing/opentracing-go v1.0.2
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d
-	github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200714163120-e507c79cc9ee
+	github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200715070228-47f5de8a6992
 	github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12
 	github.com/pingcap/errcode v0.0.0-20180921232412-a1a7271709d9
 	github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/opentracing/opentracing-go v1.0.2
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d
-	github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200710045508-523e95bc5ec9
+	github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200714163120-e507c79cc9ee
 	github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12
 	github.com/pingcap/errcode v0.0.0-20180921232412-a1a7271709d9
 	github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 h1:q2e307iGHPdTGp
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d h1:U+PMnTlV2tu7RuMK5etusZG3Cf+rpow5hqQByeCzJ2g=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d/go.mod h1:lXfE4PvvTW5xOjO6Mba8zDPyw8M93B6AQ7frTGnMlA8=
-github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200714163120-e507c79cc9ee h1:szGL0d3vJxNxRBP18InF98PE05Yi56TmTiMRANnyco8=
-github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200714163120-e507c79cc9ee/go.mod h1:9yaAM77sPfa5/f6sdxr3jSkKfIz463KRHyiFHiGjdes=
+github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200715070228-47f5de8a6992 h1:Zp+8RrZHu6HQabWA9smENTRS7AQS79cb5K0Cuduqn6Q=
+github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200715070228-47f5de8a6992/go.mod h1:9yaAM77sPfa5/f6sdxr3jSkKfIz463KRHyiFHiGjdes=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8 h1:USx2/E1bX46VG32FIw034Au6seQ2fY9NEILmNh/UlQg=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8/go.mod h1:B1+S9LNcuMyLH/4HMTViQOJevkGiik3wW2AN9zb2fNQ=
 github.com/pingcap/check v0.0.0-20191107115940-caf2b9e6ccf4 h1:iRtOAQ6FXkY/BGvst3CDfTva4nTqh6CL8WXvanLdbu0=

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 h1:q2e307iGHPdTGp
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d h1:U+PMnTlV2tu7RuMK5etusZG3Cf+rpow5hqQByeCzJ2g=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d/go.mod h1:lXfE4PvvTW5xOjO6Mba8zDPyw8M93B6AQ7frTGnMlA8=
-github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200710045508-523e95bc5ec9 h1:OVkInFrwXoqz39+8MTr7gxFzluagrtSsxOVOJRBKz2Q=
-github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200710045508-523e95bc5ec9/go.mod h1:9yaAM77sPfa5/f6sdxr3jSkKfIz463KRHyiFHiGjdes=
+github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200714163120-e507c79cc9ee h1:szGL0d3vJxNxRBP18InF98PE05Yi56TmTiMRANnyco8=
+github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200714163120-e507c79cc9ee/go.mod h1:9yaAM77sPfa5/f6sdxr3jSkKfIz463KRHyiFHiGjdes=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8 h1:USx2/E1bX46VG32FIw034Au6seQ2fY9NEILmNh/UlQg=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8/go.mod h1:B1+S9LNcuMyLH/4HMTViQOJevkGiik3wW2AN9zb2fNQ=
 github.com/pingcap/check v0.0.0-20191107115940-caf2b9e6ccf4 h1:iRtOAQ6FXkY/BGvst3CDfTva4nTqh6CL8WXvanLdbu0=

--- a/pkg/dashboard/adapter/config.go
+++ b/pkg/dashboard/adapter/config.go
@@ -32,7 +32,7 @@ func GenDashboardConfig(srv *server.Server) (*config.Config, error) {
 		DataDir:          cfg.DataDir,
 		PDEndPoint:       etcdCfg.ACUrls[0].String(),
 		PublicPathPrefix: cfg.Dashboard.PublicPathPrefix,
-		DisableTelemetry: cfg.Dashboard.DisableTelemetry,
+		EnableTelemetry:  cfg.Dashboard.EnableTelemetry,
 	}
 
 	if dashboardCfg.ClusterTLSConfig, err = cfg.Security.ToTLSConfig(); err != nil {

--- a/server/api/status.go
+++ b/server/api/status.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 
 	"github.com/pingcap/pd/v4/server"
+	"github.com/pingcap/pd/v4/server/versioninfo"
 	"github.com/unrolled/render"
 )
 
@@ -45,9 +46,9 @@ func newStatusHandler(svr *server.Server, rd *render.Render) *statusHandler {
 // @Router /status [get]
 func (h *statusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	version := status{
-		BuildTS:        server.PDBuildTS,
-		GitHash:        server.PDGitHash,
-		Version:        server.PDReleaseVersion,
+		BuildTS:        versioninfo.PDBuildTS,
+		GitHash:        versioninfo.PDGitHash,
+		Version:        versioninfo.PDReleaseVersion,
 		StartTimestamp: h.svr.StartTimestamp(),
 	}
 

--- a/server/api/status_test.go
+++ b/server/api/status_test.go
@@ -18,7 +18,7 @@ import (
 	"io/ioutil"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/pd/v4/server"
+	"github.com/pingcap/pd/v4/server/versioninfo"
 )
 
 var _ = Suite(&testStatusAPISuite{})
@@ -28,9 +28,9 @@ type testStatusAPISuite struct{}
 func checkStatusResponse(c *C, body []byte) {
 	got := status{}
 	c.Assert(json.Unmarshal(body, &got), IsNil)
-	c.Assert(got.BuildTS, Equals, server.PDBuildTS)
-	c.Assert(got.GitHash, Equals, server.PDGitHash)
-	c.Assert(got.Version, Equals, server.PDReleaseVersion)
+	c.Assert(got.BuildTS, Equals, versioninfo.PDBuildTS)
+	c.Assert(got.GitHash, Equals, versioninfo.PDGitHash)
+	c.Assert(got.Version, Equals, versioninfo.PDReleaseVersion)
 }
 
 func (s *testStatusAPISuite) TestStatus(c *C) {

--- a/server/api/version.go
+++ b/server/api/version.go
@@ -3,7 +3,7 @@ package api
 import (
 	"net/http"
 
-	"github.com/pingcap/pd/v4/server"
+	"github.com/pingcap/pd/v4/server/versioninfo"
 	"github.com/unrolled/render"
 )
 
@@ -27,7 +27,7 @@ func newVersionHandler(rd *render.Render) *versionHandler {
 // @Router /version [get]
 func (h *versionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	version := &version{
-		Version: server.PDReleaseVersion,
+		Version: versioninfo.PDReleaseVersion,
 	}
 	h.rd.JSON(w, http.StatusOK, version)
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1214,7 +1214,7 @@ type DashboardConfig struct {
 	InternalProxy    bool   `toml:"internal-proxy" json:"internal-proxy"`
 	EnableTelemetry  bool   `toml:"enable-telemetry" json:"enable-telemetry"`
 	// WARN: DisableTelemetry is deprecated.
-	DisableTelemetryDeprecated bool `toml:"disable-telemetry" json:"disable-telemetry,omitempty"`
+	DisableTelemetry bool `toml:"disable-telemetry" json:"disable-telemetry,omitempty"`
 }
 
 // ToTiDBTLSConfig generates tls config for connecting to TiDB, used by tidb-dashboard.
@@ -1238,7 +1238,7 @@ func (c *DashboardConfig) adjust(meta *configMetaData) {
 	if !meta.IsDefined("enable-telemetry") {
 		c.EnableTelemetry = defaultEnableTelemetry
 	}
-	c.EnableTelemetry = c.EnableTelemetry && !c.DisableTelemetryDeprecated
+	c.EnableTelemetry = c.EnableTelemetry && !c.DisableTelemetry
 }
 
 // ReplicationModeConfig is the configuration for the replication policy.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -26,21 +26,22 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pingcap/pd/v4/pkg/grpcutil"
+	"github.com/pingcap/pd/v4/pkg/metricutil"
+	"github.com/pingcap/pd/v4/pkg/typeutil"
+	"github.com/pingcap/pd/v4/server/schedule"
+	"github.com/pingcap/pd/v4/server/schedule/storelimit"
+	"github.com/pingcap/pd/v4/server/versioninfo"
+
 	"github.com/BurntSushi/toml"
 	"github.com/coreos/go-semver/semver"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
-	"github.com/pingcap/pd/v4/server/schedule/storelimit"
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/embed"
 	"go.etcd.io/etcd/pkg/transport"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-
-	"github.com/pingcap/pd/v4/pkg/grpcutil"
-	"github.com/pingcap/pd/v4/pkg/metricutil"
-	"github.com/pingcap/pd/v4/pkg/typeutil"
-	"github.com/pingcap/pd/v4/server/schedule"
 )
 
 // Config is the pd server configuration.
@@ -216,6 +217,7 @@ const (
 )
 
 var (
+	defaultEnableTelemetry = true
 	defaultRuntimeServices = []string{}
 	defaultLocationLabels  = []string{}
 	// DefaultStoreLimit is the default store limit of add peer and remove peer.
@@ -223,6 +225,16 @@ var (
 	// DefaultTiFlashStoreLimit is the default TiFlash store limit of add peer and remove peer.
 	DefaultTiFlashStoreLimit StoreLimit = StoreLimit{AddPeer: 30, RemovePeer: 30}
 )
+
+func init() {
+	initByLDFlags(versioninfo.PDEdition)
+}
+
+func initByLDFlags(edition string) {
+	if edition != versioninfo.CommunityEdition {
+		defaultEnableTelemetry = false
+	}
+}
 
 // StoreLimit is the default limit of adding peer and removing peer when putting stores.
 type StoreLimit struct {
@@ -322,18 +334,26 @@ func (c *Config) Parse(arguments []string) error {
 		}
 
 		// Backward compatibility for toml config
-		if c.LogFileDeprecated != "" && c.Log.File.Filename == "" {
-			c.Log.File.Filename = c.LogFileDeprecated
+		if c.LogFileDeprecated != "" {
 			msg := fmt.Sprintf("log-file in %s is deprecated, use [log.file] instead", c.configFile)
 			c.WarningMsgs = append(c.WarningMsgs, msg)
+			if c.Log.File.Filename == "" {
+				c.Log.File.Filename = c.LogFileDeprecated
+			}
 		}
-		if c.LogLevelDeprecated != "" && c.Log.Level == "" {
-			c.Log.Level = c.LogLevelDeprecated
+		if c.LogLevelDeprecated != "" {
 			msg := fmt.Sprintf("log-level in %s is deprecated, use [log] instead", c.configFile)
 			c.WarningMsgs = append(c.WarningMsgs, msg)
+			if c.Log.Level == "" {
+				c.Log.Level = c.LogLevelDeprecated
+			}
 		}
 		if meta.IsDefined("schedule", "disable-raft-learner") {
 			msg := fmt.Sprintf("disable-raft-learner in %s is deprecated", c.configFile)
+			c.WarningMsgs = append(c.WarningMsgs, msg)
+		}
+		if meta.IsDefined("dashboard", "disable-telemetry") {
+			msg := fmt.Sprintf("disable-telemetry in %s is deprecated", c.configFile)
 			c.WarningMsgs = append(c.WarningMsgs, msg)
 		}
 	}
@@ -506,6 +526,8 @@ func (c *Config) Adjust(meta *toml.MetaData) error {
 	if !configMetaData.IsDefined("enable-grpc-gateway") {
 		c.EnableGRPCGateway = defaultEnableGRPCGateway
 	}
+
+	c.Dashboard.adjust(configMetaData.Child("dashboard"))
 
 	c.ReplicationMode.adjust(configMetaData.Child("replication-mode"))
 
@@ -1185,16 +1207,18 @@ func (c *Config) GenEmbedEtcdConfig() (*embed.Config, error) {
 
 // DashboardConfig is the configuration for tidb-dashboard.
 type DashboardConfig struct {
-	TiDBCAPath       string `toml:"tidb-cacert-path" json:"tidb_cacert_path"`
-	TiDBCertPath     string `toml:"tidb-cert-path" json:"tidb_cert_path"`
-	TiDBKeyPath      string `toml:"tidb-key-path" json:"tidb_key_path"`
-	PublicPathPrefix string `toml:"public-path-prefix" json:"public_path_prefix"`
-	InternalProxy    bool   `toml:"internal-proxy" json:"internal_proxy"`
-	DisableTelemetry bool   `toml:"disable-telemetry" json:"disable_telemetry"`
+	TiDBCAPath       string `toml:"tidb-cacert-path" json:"tidb-cacert-path"`
+	TiDBCertPath     string `toml:"tidb-cert-path" json:"tidb-cert-path"`
+	TiDBKeyPath      string `toml:"tidb-key-path" json:"tidb-key-path"`
+	PublicPathPrefix string `toml:"public-path-prefix" json:"public-path-prefix"`
+	InternalProxy    bool   `toml:"internal-proxy" json:"internal-proxy"`
+	EnableTelemetry  bool   `toml:"enable-telemetry" json:"enable-telemetry"`
+	// WARN: DisableTelemetry is deprecated.
+	DisableTelemetryDeprecated bool `toml:"disable-telemetry" json:"disable-telemetry,omitempty"`
 }
 
 // ToTiDBTLSConfig generates tls config for connecting to TiDB, used by tidb-dashboard.
-func (c DashboardConfig) ToTiDBTLSConfig() (*tls.Config, error) {
+func (c *DashboardConfig) ToTiDBTLSConfig() (*tls.Config, error) {
 	if (len(c.TiDBCertPath) != 0 && len(c.TiDBKeyPath) != 0) || len(c.TiDBCAPath) != 0 {
 		tlsInfo := transport.TLSInfo{
 			CertFile:      c.TiDBCertPath,
@@ -1208,6 +1232,13 @@ func (c DashboardConfig) ToTiDBTLSConfig() (*tls.Config, error) {
 		return tlsConfig, nil
 	}
 	return nil, nil
+}
+
+func (c *DashboardConfig) adjust(meta *configMetaData) {
+	if !meta.IsDefined("enable-telemetry") {
+		c.EnableTelemetry = defaultEnableTelemetry
+	}
+	c.EnableTelemetry = c.EnableTelemetry && !c.DisableTelemetryDeprecated
 }
 
 // ReplicationModeConfig is the configuration for the replication policy.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -353,7 +353,7 @@ func (c *Config) Parse(arguments []string) error {
 			c.WarningMsgs = append(c.WarningMsgs, msg)
 		}
 		if meta.IsDefined("dashboard", "disable-telemetry") {
-			msg := fmt.Sprintf("disable-telemetry in %s is deprecated", c.configFile)
+			msg := fmt.Sprintf("disable-telemetry in %s is deprecated, use enable-telemetry instead", c.configFile)
 			c.WarningMsgs = append(c.WarningMsgs, msg)
 		}
 	}

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -342,6 +342,27 @@ tidb-cert-path = "/path/client.pem"
 	c.Assert(cfg.Dashboard.TiDBCAPath, Equals, "/path/ca.pem")
 	c.Assert(cfg.Dashboard.TiDBKeyPath, Equals, "/path/client-key.pem")
 	c.Assert(cfg.Dashboard.TiDBCertPath, Equals, "/path/client.pem")
+
+	// Test different editions
+	tests := []struct {
+		Edition         string
+		EnableTelemetry bool
+	}{
+		{"Community", true},
+		{"Enterprise", false},
+	}
+	originalDefaultEnableTelemetry := defaultEnableTelemetry
+	for _, test := range tests {
+		defaultEnableTelemetry = true
+		initByLDFlags(test.Edition)
+		cfg = NewConfig()
+		meta, err = toml.Decode(cfgData, &cfg)
+		c.Assert(err, IsNil)
+		err = cfg.Adjust(&meta)
+		c.Assert(err, IsNil)
+		c.Assert(cfg.Dashboard.EnableTelemetry, Equals, test.EnableTelemetry)
+	}
+	defaultEnableTelemetry = originalDefaultEnableTelemetry
 }
 
 func (s *testConfigSuite) TestReplicationMode(c *C) {

--- a/server/server.go
+++ b/server/server.go
@@ -50,6 +50,7 @@ import (
 	"github.com/pingcap/pd/v4/server/schedule"
 	"github.com/pingcap/pd/v4/server/schedule/opt"
 	"github.com/pingcap/pd/v4/server/tso"
+	"github.com/pingcap/pd/v4/server/versioninfo"
 	"github.com/pingcap/sysutil"
 	"github.com/pkg/errors"
 	"github.com/urfave/negroni"
@@ -342,8 +343,8 @@ func (s *Server) startServer(ctx context.Context) error {
 	s.rootPath = path.Join(pdRootPath, strconv.FormatUint(s.clusterID, 10))
 	s.member.MemberInfo(s.cfg, s.Name(), s.rootPath)
 	s.member.SetMemberDeployPath(s.member.ID())
-	s.member.SetMemberBinaryVersion(s.member.ID(), PDReleaseVersion)
-	s.member.SetMemberGitHash(s.member.ID(), PDGitHash)
+	s.member.SetMemberBinaryVersion(s.member.ID(), versioninfo.PDReleaseVersion)
+	s.member.SetMemberGitHash(s.member.ID(), versioninfo.PDGitHash)
 	s.idAllocator = id.NewAllocatorImpl(s.client, s.rootPath, s.member.MemberValue())
 	s.tso = tso.NewTimestampOracle(
 		s.client,

--- a/server/util.go
+++ b/server/util.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/pd/v4/pkg/typeutil"
 	"github.com/pingcap/pd/v4/server/cluster"
 	"github.com/pingcap/pd/v4/server/config"
+	"github.com/pingcap/pd/v4/server/versioninfo"
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/clientv3"
 	"go.uber.org/zap"
@@ -35,32 +36,23 @@ const (
 	requestTimeout = etcdutil.DefaultRequestTimeout
 )
 
-// Version information.
-var (
-	PDReleaseVersion = "None"
-	PDBuildTS        = "None"
-	PDGitHash        = "None"
-	PDGitBranch      = "None"
-	PDEdition        = "None"
-)
-
 // LogPDInfo prints the PD version information.
 func LogPDInfo() {
 	log.Info("Welcome to Placement Driver (PD)")
-	log.Info("PD", zap.String("release-version", PDReleaseVersion))
-	log.Info("PD", zap.String("edition", PDEdition))
-	log.Info("PD", zap.String("git-hash", PDGitHash))
-	log.Info("PD", zap.String("git-branch", PDGitBranch))
-	log.Info("PD", zap.String("utc-build-time", PDBuildTS))
+	log.Info("PD", zap.String("release-version", versioninfo.PDReleaseVersion))
+	log.Info("PD", zap.String("edition", versioninfo.PDEdition))
+	log.Info("PD", zap.String("git-hash", versioninfo.PDGitHash))
+	log.Info("PD", zap.String("git-branch", versioninfo.PDGitBranch))
+	log.Info("PD", zap.String("utc-build-time", versioninfo.PDBuildTS))
 }
 
 // PrintPDInfo prints the PD version information without log info.
 func PrintPDInfo() {
-	fmt.Println("Release Version:", PDReleaseVersion)
-	fmt.Println("Edition:", PDEdition)
-	fmt.Println("Git Commit Hash:", PDGitHash)
-	fmt.Println("Git Branch:", PDGitBranch)
-	fmt.Println("UTC Build Time: ", PDBuildTS)
+	fmt.Println("Release Version:", versioninfo.PDReleaseVersion)
+	fmt.Println("Edition:", versioninfo.PDEdition)
+	fmt.Println("Git Commit Hash:", versioninfo.PDGitHash)
+	fmt.Println("Git Branch:", versioninfo.PDGitBranch)
+	fmt.Println("UTC Build Time: ", versioninfo.PDBuildTS)
 }
 
 // PrintConfigCheckMsg prints the message about configuration checks.
@@ -78,8 +70,8 @@ func PrintConfigCheckMsg(cfg *config.Config) {
 // CheckPDVersion checks if PD needs to be upgraded.
 func CheckPDVersion(opt *config.PersistOptions) {
 	pdVersion := *cluster.MinSupportedVersion(cluster.Base)
-	if PDReleaseVersion != "None" {
-		pdVersion = *cluster.MustParseVersion(PDReleaseVersion)
+	if versioninfo.PDReleaseVersion != "None" {
+		pdVersion = *cluster.MustParseVersion(versioninfo.PDReleaseVersion)
 	}
 	clusterVersion := *opt.GetClusterVersion()
 	log.Info("load cluster version", zap.Stringer("cluster-version", clusterVersion))

--- a/server/versioninfo/versioninfo.go
+++ b/server/versioninfo/versioninfo.go
@@ -1,0 +1,28 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versioninfo
+
+const (
+	// CommunityEdition is the default edition for building.
+	CommunityEdition = "Community"
+)
+
+// Version information.
+var (
+	PDReleaseVersion = "None"
+	PDBuildTS        = "None"
+	PDGitHash        = "None"
+	PDGitBranch      = "None"
+	PDEdition        = CommunityEdition
+)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

* Update tidb-dashboard to v2020.07.15.
* Unified telemetry config name.
* Disable telemetry by default for non-community edition.

### What is changed and how it works?

* Update tidb-dashboard to v2020.07.15.
* Use `dashboard.enable-telemetry` in config. (`dashboard.disable-telemetry` is deprecated now).
* Disable telemetry by default for non-community edition.

### Check List

<!-- Remove the items that are not applicable. -->

- [x] This PR should be merged only after a new [tidb-dashboard release](https://github.com/pingcap-incubator/tidb-dashboard/releases) is created.

Tests

<!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)
  - `pd-ctl config show all | grep telemetry`

Code changes

- Has configuration change

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

* Update tidb-dashboard to v2020.07.15.
* Use `dashboard.enable-telemetry` in config. (`dashboard.disable-telemetry` is deprecated now).
* Disable telemetry by default for non-community edition.
