### PR TITLE
config, replica_strategy, filter: add new replication config isolation-level to isolate replicas explicitly and forcibly

### DIFF
--- a/pkg/mock/mockoption/mockoption.go
+++ b/pkg/mock/mockoption/mockoption.go
@@ -74,7 +74,7 @@ type ScheduleOptions struct {
 	MaxReplicas                  int
 	LocationLabels               []string
 	StrictlyMatchLabel           bool
-	IsolationLabel               string
+	IsolationLevel               string
 	HotRegionCacheHitsThreshold  int
 	TolerantSizeRatio            float64
 	LowSpaceRatio                float64
@@ -258,9 +258,9 @@ func (mso *ScheduleOptions) GetLocationLabels() []string {
 	return mso.LocationLabels
 }
 
-// GetIsolationLabel mocks method
-func (mso *ScheduleOptions) GetIsolationLabel() string {
-	return mso.IsolationLabel
+// GetIsolationLevel mocks method
+func (mso *ScheduleOptions) GetIsolationLevel() string {
+	return mso.IsolationLevel
 }
 
 // GetStrictlyMatchLabel mocks method

--- a/pkg/mock/mockoption/mockoption.go
+++ b/pkg/mock/mockoption/mockoption.go
@@ -74,6 +74,7 @@ type ScheduleOptions struct {
 	MaxReplicas                  int
 	LocationLabels               []string
 	StrictlyMatchLabel           bool
+	IsolationLabel               string
 	HotRegionCacheHitsThreshold  int
 	TolerantSizeRatio            float64
 	LowSpaceRatio                float64
@@ -255,6 +256,11 @@ func (mso *ScheduleOptions) GetMaxReplicas() int {
 // GetLocationLabels mocks method
 func (mso *ScheduleOptions) GetLocationLabels() []string {
 	return mso.LocationLabels
+}
+
+// GetIsolationLabel mocks method
+func (mso *ScheduleOptions) GetIsolationLabel() string {
+	return mso.IsolationLabel
 }
 
 // GetStrictlyMatchLabel mocks method

--- a/server/api/config_test.go
+++ b/server/api/config_test.go
@@ -168,25 +168,31 @@ func (s *testConfigSuite) TestConfigReplication(c *C) {
 	c.Assert(err, IsNil)
 
 	rc.MaxReplicas = 5
-
 	rc1 := map[string]int{"max-replicas": 5}
 	postData, err := json.Marshal(rc1)
 	c.Assert(err, IsNil)
 	err = postJSON(testDialClient, addr, postData)
 	c.Assert(err, IsNil)
-	rc.LocationLabels = []string{"zone", "rack"}
 
+	rc.LocationLabels = []string{"zone", "rack"}
 	rc2 := map[string]string{"location-labels": "zone,rack"}
 	postData, err = json.Marshal(rc2)
 	c.Assert(err, IsNil)
 	err = postJSON(testDialClient, addr, postData)
 	c.Assert(err, IsNil)
 
-	rc3 := &config.ReplicationConfig{}
-	err = readJSON(testDialClient, addr, rc3)
+	rc.IsolationLabel = "zone"
+	rc3 := map[string]string{"isolation-label": "zone"}
+	postData, err = json.Marshal(rc3)
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, addr, postData)
 	c.Assert(err, IsNil)
 
-	c.Assert(*rc, DeepEquals, *rc3)
+	rc4 := &config.ReplicationConfig{}
+	err = readJSON(testDialClient, addr, rc4)
+	c.Assert(err, IsNil)
+
+	c.Assert(*rc, DeepEquals, *rc4)
 }
 
 func (s *testConfigSuite) TestConfigLabelProperty(c *C) {

--- a/server/api/config_test.go
+++ b/server/api/config_test.go
@@ -181,8 +181,8 @@ func (s *testConfigSuite) TestConfigReplication(c *C) {
 	err = postJSON(testDialClient, addr, postData)
 	c.Assert(err, IsNil)
 
-	rc.IsolationLabel = "zone"
-	rc3 := map[string]string{"isolation-label": "zone"}
+	rc.IsolationLevel = "zone"
+	rc3 := map[string]string{"isolation-level": "zone"}
 	postData, err = json.Marshal(rc3)
 	c.Assert(err, IsNil)
 	err = postJSON(testDialClient, addr, postData)

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1439,6 +1439,11 @@ func (c *RaftCluster) GetLocationLabels() []string {
 	return c.opt.GetLocationLabels()
 }
 
+// GetIsolationLabel returns the isolation label for each region.
+func (c *RaftCluster) GetIsolationLabel() string {
+	return c.opt.GetIsolationLabel()
+}
+
 // GetStrictlyMatchLabel returns if the strictly label check is enabled.
 func (c *RaftCluster) GetStrictlyMatchLabel() bool {
 	return c.opt.GetStrictlyMatchLabel()

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1439,9 +1439,9 @@ func (c *RaftCluster) GetLocationLabels() []string {
 	return c.opt.GetLocationLabels()
 }
 
-// GetIsolationLabel returns the isolation label for each region.
-func (c *RaftCluster) GetIsolationLabel() string {
-	return c.opt.GetIsolationLabel()
+// GetIsolationLevel returns the isolation label for each region.
+func (c *RaftCluster) GetIsolationLevel() string {
+	return c.opt.GetIsolationLevel()
 }
 
 // GetStrictlyMatchLabel returns if the strictly label check is enabled.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -979,23 +979,21 @@ func (c *ReplicationConfig) clone() *ReplicationConfig {
 // Validate is used to validate if some replication configurations are right.
 func (c *ReplicationConfig) Validate() error {
 	validIsolationLabel := false
+	if len(c.IsolationLabel) <= 0 {
+		validIsolationLabel = true
+	}
 	for _, label := range c.LocationLabels {
 		err := ValidateLabels([]*metapb.StoreLabel{{Key: label}})
 		if err != nil {
 			return err
 		}
+		// IsolationLabel should be empty or one of LocationLabels
 		if !validIsolationLabel && label == c.IsolationLabel {
 			validIsolationLabel = true
 		}
 	}
-	if len(c.IsolationLabel) > 0 {
-		if !validIsolationLabel {
-			return errors.New("invalid isolation-label")
-		}
-		err := ValidateLabels([]*metapb.StoreLabel{{Key: c.IsolationLabel}})
-		if err != nil {
-			return err
-		}
+	if !validIsolationLabel {
+		return errors.New("isolation-label must be one of location-labels")
 	}
 	return nil
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -961,7 +961,7 @@ type ReplicationConfig struct {
 	// For example, with isolation-label = zone, PD ensure that all replicas be placed in different zones.
 	// Even if a zone is down, PD will not try to make up replicas in other zone
 	// because other zones already have replicas on it.
-	IsolationLabel string `toml:"isolation-label" json:"isolation-label,string"`
+	IsolationLabel string `toml:"isolation-label" json:"isolation-label"`
 }
 
 func (c *ReplicationConfig) clone() *ReplicationConfig {

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -123,9 +123,9 @@ func (o *PersistOptions) GetLocationLabels() []string {
 	return o.GetReplicationConfig().LocationLabels
 }
 
-// GetIsolationLabel returns the isolation label for each region.
-func (o *PersistOptions) GetIsolationLabel() string {
-	return o.GetReplicationConfig().IsolationLabel
+// GetIsolationLevel returns the isolation label for each region.
+func (o *PersistOptions) GetIsolationLevel() string {
+	return o.GetReplicationConfig().IsolationLevel
 }
 
 // IsPlacementRulesEnabled returns if the placement rules is enabled.

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -123,6 +123,11 @@ func (o *PersistOptions) GetLocationLabels() []string {
 	return o.GetReplicationConfig().LocationLabels
 }
 
+// GetIsolationLabel returns the isolation label for each region.
+func (o *PersistOptions) GetIsolationLabel() string {
+	return o.GetReplicationConfig().IsolationLabel
+}
+
 // IsPlacementRulesEnabled returns if the placement rules is enabled.
 func (o *PersistOptions) IsPlacementRulesEnabled() bool {
 	return o.GetReplicationConfig().EnablePlacementRules

--- a/server/schedule/checker/replica_checker.go
+++ b/server/schedule/checker/replica_checker.go
@@ -245,7 +245,7 @@ func (r *ReplicaChecker) strategy(region *core.RegionInfo) *ReplicaStrategy {
 		checkerName:    replicaCheckerName,
 		cluster:        r.cluster,
 		locationLabels: r.cluster.GetLocationLabels(),
-		isolationLabel: r.cluster.GetIsolationLabel(),
+		isolationLevel: r.cluster.GetIsolationLevel(),
 		region:         region,
 	}
 }

--- a/server/schedule/checker/replica_checker.go
+++ b/server/schedule/checker/replica_checker.go
@@ -245,6 +245,7 @@ func (r *ReplicaChecker) strategy(region *core.RegionInfo) *ReplicaStrategy {
 		checkerName:    replicaCheckerName,
 		cluster:        r.cluster,
 		locationLabels: r.cluster.GetLocationLabels(),
+		isolationLabel: r.cluster.GetIsolationLabel(),
 		region:         region,
 	}
 }

--- a/server/schedule/checker/replica_checker.go
+++ b/server/schedule/checker/replica_checker.go
@@ -147,7 +147,7 @@ func (r *ReplicaChecker) checkMakeUpReplica(region *core.RegionInfo) *operator.O
 		extraFilters = make([]filter.Filter, 0)
 	)
 	// IsolationLevel should only be available when PlacementRulesEnabled is false
-	if !r.cluster.IsPlacementRulesEnabled() {
+	if !r.cluster.IsPlacementRulesEnabled() && len(strategy.locationLabels) > 0 && len(strategy.isolationLevel) > 0 {
 		extraFilters = append(extraFilters, filter.NewIsolationFilter(replicaCheckerName, strategy.isolationLevel, strategy.locationLabels, regionStores))
 	}
 	target := strategy.SelectStoreToAdd(regionStores, extraFilters...)

--- a/server/schedule/checker/replica_checker.go
+++ b/server/schedule/checker/replica_checker.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/pd/v4/server/core"
+	"github.com/pingcap/pd/v4/server/schedule/filter"
 	"github.com/pingcap/pd/v4/server/schedule/operator"
 	"github.com/pingcap/pd/v4/server/schedule/opt"
 	"go.uber.org/zap"
@@ -140,8 +141,16 @@ func (r *ReplicaChecker) checkMakeUpReplica(region *core.RegionInfo) *operator.O
 		return nil
 	}
 	log.Debug("region has fewer than max replicas", zap.Uint64("region-id", region.GetID()), zap.Int("peers", len(region.GetPeers())))
-	regionStores := r.cluster.GetRegionStores(region)
-	target := r.strategy(region).SelectStoreToAdd(regionStores)
+	var (
+		strategy     = r.strategy(region)
+		regionStores = r.cluster.GetRegionStores(region)
+		extraFilters = make([]filter.Filter, 0)
+	)
+	// IsolationLevel should only be available when PlacementRulesEnabled is false
+	if !r.cluster.IsPlacementRulesEnabled() {
+		extraFilters = append(extraFilters, filter.NewIsolationFilter(replicaCheckerName, strategy.isolationLevel, strategy.locationLabels, regionStores))
+	}
+	target := strategy.SelectStoreToAdd(regionStores, extraFilters...)
 	if target == 0 {
 		log.Debug("no store to add replica", zap.Uint64("region-id", region.GetID()))
 		checkerCounter.WithLabelValues("replica_checker", "no-target-store").Inc()

--- a/server/schedule/checker/replica_strategy.go
+++ b/server/schedule/checker/replica_strategy.go
@@ -57,10 +57,6 @@ func (s *ReplicaStrategy) SelectStoreToAdd(coLocationStores []*core.StoreInfo, e
 		filter.NewSpecialUseFilter(s.checkerName),
 		filter.StoreStateFilter{ActionScope: s.checkerName, MoveRegion: true, AllowTemporaryStates: true},
 	}
-	// IsolationLevel should only be available when PlacementRulesEnabled is false
-	if s.cluster.IsPlacementRulesEnabled() {
-		filters = append(filters, filter.NewIsolationFilter(s.checkerName, s.isolationLevel, s.locationLabels, coLocationStores))
-	}
 	if len(extraFilters) > 0 {
 		filters = append(filters, extraFilters...)
 	}

--- a/server/schedule/checker/replica_strategy.go
+++ b/server/schedule/checker/replica_strategy.go
@@ -51,13 +51,15 @@ func (s *ReplicaStrategy) SelectStoreToAdd(coLocationStores []*core.StoreInfo, e
 	//
 	// The reason for it is to prevent the non-optimal replica placement due
 	// to the short-term state, resulting in redundant scheduling.
-
 	filters := []filter.Filter{
 		filter.NewExcludedFilter(s.checkerName, nil, s.region.GetStoreIds()),
-		filter.NewIsolationFilter(s.checkerName, s.isolationLevel, s.locationLabels, s.cluster.GetRegionStores(s.region)),
 		filter.NewStorageThresholdFilter(s.checkerName),
 		filter.NewSpecialUseFilter(s.checkerName),
 		filter.StoreStateFilter{ActionScope: s.checkerName, MoveRegion: true, AllowTemporaryStates: true},
+	}
+	// IsolationLevel should only be available when PlacementRulesEnabled is false
+	if s.cluster.IsPlacementRulesEnabled() {
+		filters = append(filters, filter.NewIsolationFilter(s.checkerName, s.isolationLevel, s.locationLabels, coLocationStores))
 	}
 	if len(extraFilters) > 0 {
 		filters = append(filters, extraFilters...)

--- a/server/schedule/checker/replica_strategy.go
+++ b/server/schedule/checker/replica_strategy.go
@@ -27,7 +27,7 @@ type ReplicaStrategy struct {
 	checkerName    string // replica-checker / rule-checker
 	cluster        opt.Cluster
 	locationLabels []string
-	isolationLabel string
+	isolationLevel string
 	region         *core.RegionInfo
 	extraFilters   []filter.Filter
 }
@@ -54,7 +54,7 @@ func (s *ReplicaStrategy) SelectStoreToAdd(coLocationStores []*core.StoreInfo, e
 
 	filters := []filter.Filter{
 		filter.NewExcludedFilter(s.checkerName, nil, s.region.GetStoreIds()),
-		filter.NewIsolationFilter(s.checkerName, s.isolationLabel, s.locationLabels, s.cluster.GetRegionStores(s.region)),
+		filter.NewIsolationFilter(s.checkerName, s.isolationLevel, s.locationLabels, s.cluster.GetRegionStores(s.region)),
 		filter.NewStorageThresholdFilter(s.checkerName),
 		filter.NewSpecialUseFilter(s.checkerName),
 		filter.StoreStateFilter{ActionScope: s.checkerName, MoveRegion: true, AllowTemporaryStates: true},

--- a/server/schedule/checker/replica_strategy.go
+++ b/server/schedule/checker/replica_strategy.go
@@ -27,6 +27,7 @@ type ReplicaStrategy struct {
 	checkerName    string // replica-checker / rule-checker
 	cluster        opt.Cluster
 	locationLabels []string
+	isolationLabel string
 	region         *core.RegionInfo
 	extraFilters   []filter.Filter
 }
@@ -53,6 +54,7 @@ func (s *ReplicaStrategy) SelectStoreToAdd(coLocationStores []*core.StoreInfo, e
 
 	filters := []filter.Filter{
 		filter.NewExcludedFilter(s.checkerName, nil, s.region.GetStoreIds()),
+		filter.NewIsolationFilter(s.checkerName, s.isolationLabel, s.locationLabels, s.cluster.GetRegionStores(s.region)),
 		filter.NewStorageThresholdFilter(s.checkerName),
 		filter.NewSpecialUseFilter(s.checkerName),
 		filter.StoreStateFilter{ActionScope: s.checkerName, MoveRegion: true, AllowTemporaryStates: true},

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -664,7 +664,7 @@ func (f *isolationFilter) Target(opt opt.Options, store *core.StoreInfo) bool {
 			// Check every constraint in constrainList
 			match = store.GetLabelValue(f.locationLabels[idx]) == constraint && match
 		}
-		if match {
+		if len(constrainList) > 0 && match {
 			return false
 		}
 	}

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -607,31 +607,31 @@ type isolationFilter struct {
 	constraintSet [][]*placement.LabelConstraint
 }
 
-// NewIsolationFilter creates a filter that filters out stores with isolationLabel
+// NewIsolationFilter creates a filter that filters out stores with isolationLevel
 // For example, a region has 3 replicas in z1, z2 and z3 individually.
-// With isolationLabel = zone, if the region on z1 is down, we need to filter out z2 and z3
+// With isolationLevel = zone, if the region on z1 is down, we need to filter out z2 and z3
 // because these two zones already have one of the region's replicas on them.
-// We need to choose a store on z1 or z4 to place the new replica to meet the isolationLabel explicitly and forcibly.
-func NewIsolationFilter(scope, isolationLabel string, locationLabels []string, regionStores []*core.StoreInfo) Filter {
+// We need to choose a store on z1 or z4 to place the new replica to meet the isolationLevel explicitly and forcibly.
+func NewIsolationFilter(scope, isolationLevel string, locationLabels []string, regionStores []*core.StoreInfo) Filter {
 	isolationFilter := &isolationFilter{
 		scope:         scope,
 		constraintSet: make([][]*placement.LabelConstraint, 0),
 	}
-	if len(isolationLabel) <= 0 || len(locationLabels) <= 0 {
+	if len(isolationLevel) <= 0 || len(locationLabels) <= 0 {
 		return isolationFilter
 	}
-	// Get which level this isolationLabel at according to locationLabels
-	var isolationLevel int
+	// Get which idx this isolationLevel at according to locationLabels
+	var isolationLevelIdx int
 	for level, label := range locationLabels {
-		if label == isolationLabel {
-			isolationLevel = level
+		if label == isolationLevel {
+			isolationLevelIdx = level
 			break
 		}
 	}
 	// Collect all constraints for given isolationLevel
 	for _, regionStore := range regionStores {
 		constraintList := make([]*placement.LabelConstraint, 0)
-		for i := 0; i <= isolationLevel; i++ {
+		for i := 0; i <= isolationLevelIdx; i++ {
 			constraintList = append(constraintList, &placement.LabelConstraint{
 				Key:    locationLabels[i],
 				Op:     "in",

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -662,12 +662,7 @@ func (f *isolationFilter) Target(opt opt.Options, store *core.StoreInfo) bool {
 		match := true
 		for idx, constraint := range constrainList {
 			// Check every constraint in constrainList
-			labelConstraint := &placement.LabelConstraint{
-				Key:    f.locationLabels[idx],
-				Op:     "in",
-				Values: []string{constraint},
-			}
-			match = labelConstraint.MatchStore(store) && match
+			match = store.GetLabelValue(f.locationLabels[idx]) == constraint && match
 		}
 		if match {
 			return false

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -619,9 +619,6 @@ func NewIsolationFilter(scope, isolationLevel string, locationLabels []string, r
 		locationLabels: locationLabels,
 		constraintSet:  make([][]string, 0),
 	}
-	if len(isolationLevel) <= 0 || len(locationLabels) <= 0 {
-		return isolationFilter
-	}
 	// Get which idx this isolationLevel at according to locationLabels
 	var isolationLevelIdx int
 	for level, label := range locationLabels {

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -601,3 +601,74 @@ const (
 
 var allSpecialUses = []string{SpecialUseHotRegion, SpecialUseReserved}
 var allSpeicalEngines = []string{EngineTiFlash}
+
+type isolationFilter struct {
+	scope         string
+	constraintSet [][]*placement.LabelConstraint
+}
+
+// NewIsolationFilter creates a filter that filters out stores with isolationLabel
+// For example, a region has 3 replicas in z1, z2 and z3 individually.
+// With isolationLabel = zone, if the region on z1 is down, we need to filter out z2 and z3
+// because these two zones already have one of the region's replicas on them.
+// We need to choose a store on z1 or z4 to place the new replica to meet the isolationLabel explicitly and forcibly.
+func NewIsolationFilter(scope, isolationLabel string, locationLabels []string, regionStores []*core.StoreInfo) Filter {
+	isolationFilter := &isolationFilter{
+		scope:         scope,
+		constraintSet: make([][]*placement.LabelConstraint, 0),
+	}
+	if len(isolationLabel) <= 0 || len(locationLabels) <= 0 {
+		return isolationFilter
+	}
+	// Get which level this isolationLabel at according to locationLabels
+	var isolationLevel int
+	for level, label := range locationLabels {
+		if label == isolationLabel {
+			isolationLevel = level
+			break
+		}
+	}
+	// Collect all constraints for given isolationLevel
+	for _, regionStore := range regionStores {
+		constraintList := make([]*placement.LabelConstraint, 0)
+		for i := 0; i <= isolationLevel; i++ {
+			constraintList = append(constraintList, &placement.LabelConstraint{
+				Key:    locationLabels[i],
+				Op:     "in",
+				Values: []string{regionStore.GetLabelValue(locationLabels[i])},
+			})
+		}
+		isolationFilter.constraintSet = append(isolationFilter.constraintSet, constraintList)
+	}
+	return isolationFilter
+}
+
+func (f *isolationFilter) Scope() string {
+	return f.scope
+}
+
+func (f *isolationFilter) Type() string {
+	return "isolation-filter"
+}
+
+func (f *isolationFilter) Source(opt opt.Options, store *core.StoreInfo) bool {
+	return true
+}
+
+func (f *isolationFilter) Target(opt opt.Options, store *core.StoreInfo) bool {
+	// No isolation constraint to fit
+	if len(f.constraintSet) <= 0 {
+		return true
+	}
+	for _, constrainList := range f.constraintSet {
+		match := true
+		for _, constrain := range constrainList {
+			// Check every constrain in constrainList
+			match = constrain.MatchStore(store) && match
+		}
+		if match {
+			return false
+		}
+	}
+	return true
+}

--- a/server/schedule/filter/filters_test.go
+++ b/server/schedule/filter/filters_test.go
@@ -135,6 +135,73 @@ func (s *testFiltersSuite) TestStoreStateFilter(c *C) {
 	check(3, store, true, true)
 }
 
+func (s *testFiltersSuite) TestIsolationFilter(c *C) {
+	opt := mockoption.NewScheduleOptions()
+	opt.LocationLabels = []string{"zone", "rack", "host"}
+	testCluster := mockcluster.NewCluster(opt)
+	allStores := []struct {
+		storeID     uint64
+		regionCount int
+		labels      map[string]string
+	}{
+		{1, 1, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"}},
+		{2, 1, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"}},
+		{3, 1, map[string]string{"zone": "z1", "rack": "r1", "host": "h2"}},
+		{4, 1, map[string]string{"zone": "z1", "rack": "r2", "host": "h1"}},
+		{5, 1, map[string]string{"zone": "z1", "rack": "r3", "host": "h1"}},
+		{6, 1, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"}},
+		{7, 1, map[string]string{"zone": "z3", "rack": "r3", "host": "h1"}},
+	}
+	for _, store := range allStores {
+		testCluster.AddLabelsStore(store.storeID, store.regionCount, store.labels)
+	}
+
+	testCases := []struct {
+		region         *core.RegionInfo
+		isolationLabel string
+		sourceRes      []bool
+		targetRes      []bool
+	}{
+		{
+			core.NewRegionInfo(&metapb.Region{Peers: []*metapb.Peer{
+				{Id: 1, StoreId: 1},
+				{Id: 2, StoreId: 6},
+			}}, &metapb.Peer{StoreId: 1, Id: 1}),
+			"zone",
+			[]bool{true, true, true, true, true, true, true},
+			[]bool{false, false, false, false, false, false, true},
+		},
+		{
+			core.NewRegionInfo(&metapb.Region{Peers: []*metapb.Peer{
+				{Id: 1, StoreId: 1},
+				{Id: 2, StoreId: 4},
+				{Id: 3, StoreId: 7},
+			}}, &metapb.Peer{StoreId: 1, Id: 1}),
+			"rack",
+			[]bool{true, true, true, true, true, true, true},
+			[]bool{false, false, false, false, true, true, false},
+		},
+		{
+			core.NewRegionInfo(&metapb.Region{Peers: []*metapb.Peer{
+				{Id: 1, StoreId: 1},
+				{Id: 2, StoreId: 4},
+				{Id: 3, StoreId: 6},
+			}}, &metapb.Peer{StoreId: 1, Id: 1}),
+			"host",
+			[]bool{true, true, true, true, true, true, true},
+			[]bool{false, false, true, false, true, false, true},
+		},
+	}
+
+	for _, tc := range testCases {
+		filter := NewIsolationFilter("", tc.isolationLabel, testCluster.GetLocationLabels(), testCluster.GetRegionStores(tc.region))
+		for idx, store := range allStores {
+			c.Assert(filter.Source(testCluster, testCluster.GetStore(store.storeID)), Equals, tc.sourceRes[idx])
+			c.Assert(filter.Target(testCluster, testCluster.GetStore(store.storeID)), Equals, tc.targetRes[idx])
+		}
+	}
+}
+
 func (s *testFiltersSuite) TestPlacementGuard(c *C) {
 	opt := mockoption.NewScheduleOptions()
 	opt.LocationLabels = []string{"zone"}

--- a/server/schedule/filter/filters_test.go
+++ b/server/schedule/filter/filters_test.go
@@ -158,7 +158,7 @@ func (s *testFiltersSuite) TestIsolationFilter(c *C) {
 
 	testCases := []struct {
 		region         *core.RegionInfo
-		isolationLabel string
+		isolationLevel string
 		sourceRes      []bool
 		targetRes      []bool
 	}{
@@ -194,7 +194,7 @@ func (s *testFiltersSuite) TestIsolationFilter(c *C) {
 	}
 
 	for _, tc := range testCases {
-		filter := NewIsolationFilter("", tc.isolationLabel, testCluster.GetLocationLabels(), testCluster.GetRegionStores(tc.region))
+		filter := NewIsolationFilter("", tc.isolationLevel, testCluster.GetLocationLabels(), testCluster.GetRegionStores(tc.region))
 		for idx, store := range allStores {
 			c.Assert(filter.Source(testCluster, testCluster.GetStore(store.storeID)), Equals, tc.sourceRes[idx])
 			c.Assert(filter.Target(testCluster, testCluster.GetStore(store.storeID)), Equals, tc.targetRes[idx])

--- a/server/schedule/opt/opts.go
+++ b/server/schedule/opt/opts.go
@@ -49,7 +49,7 @@ type Options interface {
 	GetLocationLabels() []string
 	GetStrictlyMatchLabel() bool
 	IsPlacementRulesEnabled() bool
-	GetIsolationLabel() string
+	GetIsolationLevel() string
 
 	GetHotRegionCacheHitsThreshold() int
 	GetTolerantSizeRatio() float64

--- a/server/schedule/opt/opts.go
+++ b/server/schedule/opt/opts.go
@@ -49,6 +49,7 @@ type Options interface {
 	GetLocationLabels() []string
 	GetStrictlyMatchLabel() bool
 	IsPlacementRulesEnabled() bool
+	GetIsolationLabel() string
 
 	GetHotRegionCacheHitsThreshold() int
 	GetTolerantSizeRatio() float64

--- a/server/statistics/schedule_options.go
+++ b/server/statistics/schedule_options.go
@@ -24,6 +24,7 @@ import (
 // TODO: merge the Options to schedule.Options
 type ScheduleOptions interface {
 	GetLocationLabels() []string
+	GetIsolationLabel() string
 
 	GetLowSpaceRatio() float64
 	GetHighSpaceRatio() float64

--- a/server/statistics/schedule_options.go
+++ b/server/statistics/schedule_options.go
@@ -24,7 +24,7 @@ import (
 // TODO: merge the Options to schedule.Options
 type ScheduleOptions interface {
 	GetLocationLabels() []string
-	GetIsolationLabel() string
+	GetIsolationLevel() string
 
 	GetLowSpaceRatio() float64
 	GetHighSpaceRatio() float64


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Add a new replication config named `isolation-level` according to #2528 #2418 

### What is changed and how it works?

With the new config `isolation-level`, `SelectStoreToAdd` in `replica_strategy.go` will filter out stores to isolate replicas explicitly and forcibly. For example, a region has 3 replicas in z1, z2 and z3 individually. With IsolationLevel = zone, if the region on z1 is down, we need to filter out z2 and z3 because these two zones already have one of the region's replicas on them. We need to choose a store on z1 or z4 to place the new replica to meet the `isolation-level`.

### Check List

Tests

- Unit test
- Integration test

Code changes

- Has configuration change
- Has `replica_strategy` change
- Has `filter` change

### Release note

Add a new replication config named `isolation-level` to isolate replicas explicitly and forcibly.
