### PR TITLE
pd-ctl: make the hint message consistent with code

### DIFF
--- a/tests/pdctl/store/store_test.go
+++ b/tests/pdctl/store/store_test.go
@@ -196,11 +196,11 @@ func (s *storeTestSuite) TestStore(c *C) {
 	limit2 = leaderServer.GetRaftCluster().GetStoreLimitByType(2, storelimit.RemovePeer)
 	c.Assert(limit2, Equals, float64(25))
 
-	// store limit all 0
+	// store limit all 0 is invalid
 	args = []string{"-u", pdAddr, "store", "limit", "all", "0"}
 	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
 	c.Assert(err, IsNil)
-	c.Assert(strings.Contains(string(output), "invalid"), IsTrue)
+	c.Assert(strings.Contains(string(output), "rate should be a number that > 0"), IsTrue)
 
 	// store limit <type>
 	echo := pdctl.GetEcho([]string{"-u", pdAddr, "store", "limit"})

--- a/tools/pd-ctl/pdctl/command/store_command.go
+++ b/tools/pd-ctl/pdctl/command/store_command.go
@@ -376,7 +376,7 @@ func storeLimitCommandFunc(cmd *cobra.Command, args []string) {
 		cmd.Println(r)
 	case 2, 3:
 		rate, err := strconv.ParseFloat(args[1], 64)
-		if err != nil || rate < 0 {
+		if err != nil || rate <= 0 {
 			cmd.Println("rate should be a number that > 0.")
 			return
 		}

--- a/tools/pd-ctl/pdctl/command/store_command.go
+++ b/tools/pd-ctl/pdctl/command/store_command.go
@@ -377,7 +377,7 @@ func storeLimitCommandFunc(cmd *cobra.Command, args []string) {
 	case 2, 3:
 		rate, err := strconv.ParseFloat(args[1], 64)
 		if err != nil || rate < 0 {
-			cmd.Println("rate should be a number that >= 0.")
+			cmd.Println("rate should be a number that > 0.")
 			return
 		}
 		// if the storeid is "all", set limits for all stores
@@ -449,7 +449,7 @@ func setAllLimitCommandFunc(cmd *cobra.Command, args []string) {
 	}
 	rate, err := strconv.ParseFloat(args[0], 64)
 	if err != nil || rate < 0 {
-		cmd.Println("rate should be a number that >= 0.")
+		cmd.Println("rate should be a number that > 0.")
 		return
 	}
 	prefix := path.Join(storesPrefix, "limit")

--- a/tools/pd-ctl/pdctl/command/store_command.go
+++ b/tools/pd-ctl/pdctl/command/store_command.go
@@ -448,7 +448,7 @@ func setAllLimitCommandFunc(cmd *cobra.Command, args []string) {
 		return
 	}
 	rate, err := strconv.ParseFloat(args[0], 64)
-	if err != nil || rate < 0 {
+	if err != nil || rate <= 0 {
 		cmd.Println("rate should be a number that > 0.")
 		return
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Previous PR #2586 prevents store limit from being zero. But the hint message of `pd-ctl` is still `>=0`.

### What is changed and how it works?

This PR makes the hint message consistent with code.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

- No code

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
