### PR TITLE
tso, server, tests: add a test case for tso allocation bug

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -99,7 +99,10 @@ type Server struct {
 	serverLoopCancel func()
 	serverLoopWg     sync.WaitGroup
 
-	lease  *member.LeaderLease
+	// leader lease
+	lease   *member.LeaderLease
+	leaseMu sync.RWMutex
+
 	member *member.Member
 	// etcd client
 	client *clientv3.Client
@@ -643,11 +646,15 @@ func (s *Server) GetMember() *member.Member {
 
 // GetLease returns the lease of member and only leader server's lease is not nil.
 func (s *Server) GetLease() *member.LeaderLease {
+	s.leaseMu.RLock()
+	defer s.leaseMu.RUnlock()
 	return s.lease
 }
 
 // SetLease changes the lease.
 func (s *Server) SetLease(lease *member.LeaderLease) {
+	s.leaseMu.Lock()
+	defer s.leaseMu.Unlock()
 	s.lease = lease
 }
 

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/pd/v4/server/core"
 	"github.com/pingcap/pd/v4/server/id"
 	"github.com/pingcap/pd/v4/server/join"
+	"github.com/pingcap/pd/v4/server/member"
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/clientv3"
 	"go.uber.org/zap"
@@ -324,6 +325,19 @@ func (s *TestServer) BootstrapCluster() error {
 	_, err := s.server.Bootstrap(context.Background(), bootstrapReq)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+// WaitLease is used to get leader lease.
+// If it exceeds the maximum number of loops, it will return nil.
+func (s *TestServer) WaitLease() *member.LeaderLease {
+	for i := 0; i < 100; i++ {
+		lease := s.server.GetLease()
+		if lease != nil {
+			return lease
+		}
+		time.Sleep(WaitLeaderCheckInterval)
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Previous PR #2665 tries to fix a bug that tso allocation may fail though it's already a PD leader, which lacks of a test case can cover this situation. This pr adds a test case and makes some slight changes than before.

According to these two TiDB jenkins tests, tso may still have some problems when leader changes. I need more logs to figure out why, so this pr also adds some log info when a tso request arrive.

* https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb_ghpr_check_2/detail/tidb_ghpr_check_2/42444/pipeline/
* https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb_ghpr_check_2/detail/tidb_ghpr_check_2/42068/pipeline/

### What is changed and how it works?

* Try to set `lease` as soon as possible in `SyncTimestamp`.
* Add some new methods to `Server` for test purpose.
* Add more logs.

### Check List

Tests

- Unit test
- Integration test

Related changes

- PR #2665 

### Release note

Add more tests and logs for TSO request.


