### PR TITLE
Add leader filter in hot region scheduler

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -215,7 +215,12 @@ func (mc *Cluster) AddRegionStore(storeID uint64, regionCount int) {
 	stats.Capacity = 1000 * (1 << 20)
 	stats.Available = stats.Capacity - uint64(regionCount)*10
 	store := core.NewStoreInfo(
-		&metapb.Store{Id: storeID},
+		&metapb.Store{Id: storeID, Labels: []*metapb.StoreLabel{
+			{
+				Key:   "ID",
+				Value: fmt.Sprintf("%v", storeID),
+			},
+		}},
 		core.SetStoreStats(stats),
 		core.SetRegionCount(regionCount),
 		core.SetRegionSize(int64(regionCount)*10),

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -77,9 +77,6 @@ func Target(opt opt.Options, store *core.StoreInfo, filters []Filter) bool {
 	storeAddress := store.GetAddress()
 	storeID := fmt.Sprintf("%d", store.GetID())
 	for _, filter := range filters {
-		if filter == nil {
-			continue
-		}
 		if !filter.Target(opt, store) {
 			filterCounter.WithLabelValues("filter-target", storeAddress, storeID, filter.Scope(), filter.Type()).Inc()
 			return false

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -77,6 +77,9 @@ func Target(opt opt.Options, store *core.StoreInfo, filters []Filter) bool {
 	storeAddress := store.GetAddress()
 	storeID := fmt.Sprintf("%d", store.GetID())
 	for _, filter := range filters {
+		if filter == nil {
+			continue
+		}
 		if !filter.Target(opt, store) {
 			filterCounter.WithLabelValues("filter-target", storeAddress, storeID, filter.Scope(), filter.Type()).Inc()
 			return false

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -795,7 +795,9 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*storeLoadDetail {
 		filters = []filter.Filter{
 			filter.StoreStateFilter{ActionScope: bs.sche.GetName(), TransferLeader: true},
 			filter.NewSpecialUseFilter(bs.sche.GetName(), filter.SpecialUseHotRegion),
-			filter.NewPlacementLeaderSafeguard(bs.sche.GetName(), bs.cluster, bs.cur.region, srcStore),
+		}
+		if leaderFilter := filter.NewPlacementLeaderSafeguard(bs.sche.GetName(), bs.cluster, bs.cur.region, srcStore); leaderFilter != nil {
+			filters = append(filters, leaderFilter)
 		}
 
 		candidates = bs.cluster.GetFollowerStores(bs.cur.region)

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -775,13 +775,13 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*storeLoadDetail {
 		filters    []filter.Filter
 		candidates []*core.StoreInfo
 	)
+	srcStore := bs.cluster.GetStore(bs.cur.srcStoreID)
+	if srcStore == nil {
+		return nil
+	}
 
 	switch bs.opTy {
 	case movePeer:
-		srcStore := bs.cluster.GetStore(bs.cur.srcStoreID)
-		if srcStore == nil {
-			return nil
-		}
 		filters = []filter.Filter{
 			filter.StoreStateFilter{ActionScope: bs.sche.GetName(), MoveRegion: true},
 			filter.NewExcludedFilter(bs.sche.GetName(), bs.cur.region.GetStoreIds(), bs.cur.region.GetStoreIds()),
@@ -795,6 +795,7 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*storeLoadDetail {
 		filters = []filter.Filter{
 			filter.StoreStateFilter{ActionScope: bs.sche.GetName(), TransferLeader: true},
 			filter.NewSpecialUseFilter(bs.sche.GetName(), filter.SpecialUseHotRegion),
+			filter.NewPlacementLeaderSafeguard(bs.sche.GetName(), bs.cluster, bs.cur.region, srcStore),
 		}
 
 		candidates = bs.cluster.GetFollowerStores(bs.cur.region)

--- a/server/schedulers/hot_test.go
+++ b/server/schedulers/hot_test.go
@@ -15,6 +15,7 @@ package schedulers
 
 import (
 	"context"
+	"encoding/hex"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -26,6 +27,7 @@ import (
 	"github.com/pingcap/pd/v4/server/kv"
 	"github.com/pingcap/pd/v4/server/schedule"
 	"github.com/pingcap/pd/v4/server/schedule/operator"
+	"github.com/pingcap/pd/v4/server/schedule/placement"
 	"github.com/pingcap/pd/v4/server/statistics"
 )
 
@@ -472,6 +474,78 @@ func (s *testHotWriteRegionSchedulerSuite) TestWithPendingInfluence(c *C) {
 	}
 }
 
+func (s *testHotWriteRegionSchedulerSuite) TestWithRuleEnabled(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	statistics.Denoising = false
+	opt := mockoption.NewScheduleOptions()
+	opt.EnablePlacementRules = true
+	hb, err := schedule.CreateScheduler(HotWriteRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), nil)
+	c.Assert(err, IsNil)
+	opt.HotRegionCacheHitsThreshold = 0
+	tc := mockcluster.NewCluster(opt)
+	key, err := hex.DecodeString("")
+	c.Assert(err, IsNil)
+	err = tc.SetRule(&placement.Rule{
+		GroupID:  "pd",
+		ID:       "leader",
+		Index:    1,
+		Override: true,
+		Role:     placement.Leader,
+		Count:    1,
+		LabelConstraints: []placement.LabelConstraint{
+			{
+				Key:    "ID",
+				Op:     placement.In,
+				Values: []string{"2", "1"},
+			},
+		},
+		StartKey: key,
+		EndKey:   key,
+	})
+	c.Assert(err, IsNil)
+	err = tc.SetRule(&placement.Rule{
+		GroupID:  "pd",
+		ID:       "voter",
+		Index:    2,
+		Override: false,
+		Role:     placement.Voter,
+		Count:    2,
+		StartKey: key,
+		EndKey:   key,
+	})
+	c.Assert(err, IsNil)
+
+	tc.AddRegionStore(1, 20)
+	tc.AddRegionStore(2, 20)
+	tc.AddRegionStore(3, 20)
+
+	tc.UpdateStorageWrittenBytes(1, 10*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageWrittenBytes(2, 10*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageWrittenBytes(3, 10*MB*statistics.StoreHeartBeatReportInterval)
+
+	tc.UpdateStorageWrittenKeys(1, 10*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageWrittenKeys(2, 10*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageWrittenKeys(3, 10*MB*statistics.StoreHeartBeatReportInterval)
+
+	addRegionInfo(tc, write, []testRegionInfo{
+		{1, []uint64{1, 2, 3}, 0.5 * MB, 1 * MB},
+		{2, []uint64{1, 2, 3}, 0.5 * MB, 1 * MB},
+		{3, []uint64{2, 1, 3}, 0.5 * MB, 1 * MB},
+		{4, []uint64{2, 1, 3}, 0.5 * MB, 1 * MB},
+		{5, []uint64{2, 1, 3}, 0.5 * MB, 1 * MB},
+		{6, []uint64{2, 1, 3}, 0.5 * MB, 1 * MB},
+		{7, []uint64{2, 1, 3}, 0.5 * MB, 1 * MB},
+	})
+
+	for i := 0; i < 100; i++ {
+		hb.(*hotScheduler).clearPendingInfluence()
+		op := hb.Schedule(tc)[0]
+		testutil.CheckTransferLeader(c, op, operator.OpHotRegion, 2, 1)
+		c.Assert(hb.Schedule(tc), HasLen, 0)
+	}
+}
+
 var _ = Suite(&testHotReadRegionSchedulerSuite{})
 
 type testHotReadRegionSchedulerSuite struct{}
@@ -899,7 +973,8 @@ func (s *testHotCacheSuite) TestByteAndKey(c *C) {
 }
 
 type testRegionInfo struct {
-	id       uint64
+	id uint64
+	// the storeID list for the peers, the leader is stored in the first store
 	peers    []uint64
 	byteRate float64
 	keyRate  float64

--- a/server/schedulers/hot_test.go
+++ b/server/schedulers/hot_test.go
@@ -541,6 +541,7 @@ func (s *testHotWriteRegionSchedulerSuite) TestWithRuleEnabled(c *C) {
 	for i := 0; i < 100; i++ {
 		hb.(*hotScheduler).clearPendingInfluence()
 		op := hb.Schedule(tc)[0]
+		// The targetID should always be 1 as leader is only allowed to be placed in store1 or store2 by placement rule
 		testutil.CheckTransferLeader(c, op, operator.OpHotRegion, 2, 1)
 		c.Assert(hb.Schedule(tc), HasLen, 0)
 	}


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
During `filterDstStores` in hot region scheduler, it didn't consider the placement rule enabled in `transferLeader` case.

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?
This requests add `PlacementLeaderSafeguard` filter in the `filterDstStores` 



### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
