### PR TITLE
placement: api for adding rules in one request

### DIFF
--- a/server/api/router.go
+++ b/server/api/router.go
@@ -91,6 +91,7 @@ func createRouter(ctx context.Context, prefix string, svr *server.Server) *mux.R
 
 	rulesHandler := newRulesHandler(svr, rd)
 	clusterRouter.HandleFunc("/config/rules", rulesHandler.GetAll).Methods("GET")
+	clusterRouter.HandleFunc("/config/rules", rulesHandler.SetAll).Methods("POST")
 	clusterRouter.HandleFunc("/config/rules/group/{group}", rulesHandler.GetAllByGroup).Methods("GET")
 	clusterRouter.HandleFunc("/config/rules/region/{region}", rulesHandler.GetAllByRegion).Methods("GET")
 	clusterRouter.HandleFunc("/config/rules/key/{key}", rulesHandler.GetAllByKey).Methods("GET")

--- a/server/api/rule.go
+++ b/server/api/rule.go
@@ -62,7 +62,7 @@ func (h *ruleHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 // @Tags rule
 // @Summary Set all rules for the cluster.
 // @Produce json
-// @Param {array}placement.Rule
+// @Param rules body []placement.Rule true "Parameters of rules"
 // @Success 200 {string} string "Update rules successfully."
 // @Failure 400 {string} string "The input is invalid."
 // @Failure 412 {string} string "Placement rules feature is disabled."

--- a/server/api/rule.go
+++ b/server/api/rule.go
@@ -60,6 +60,38 @@ func (h *ruleHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 }
 
 // @Tags rule
+// @Summary Set all rules for the cluster.
+// @Produce json
+// @Param {array}placement.Rule
+// @Success 200 {string} string "Update rules successfully."
+// @Failure 400 {string} string "The input is invalid."
+// @Failure 412 {string} string "Placement rules feature is disabled."
+// @Failure 500 {string} string "PD server failed to proceed the request."
+// @Router /config/rules [get]
+func (h *ruleHandler) SetAll(w http.ResponseWriter, r *http.Request) {
+	cluster := getCluster(r.Context())
+	if !cluster.IsPlacementRulesEnabled() {
+		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
+		return
+	}
+	var rules []*placement.Rule
+	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &rules); err != nil {
+		return
+	}
+	for _, rule := range rules {
+		if err := h.checkRule(rule); err != nil {
+			h.rd.JSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+	if err := cluster.GetRuleManager().SetRules(rules); err != nil {
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.rd.JSON(w, http.StatusOK, "Update rules successfully.")
+}
+
+// @Tags rule
 // @Summary List all rules of cluster by group.
 // @Param group path string true "The name of group"
 // @Produce json

--- a/server/api/rule_test.go
+++ b/server/api/rule_test.go
@@ -170,6 +170,74 @@ func (s *testRuleSuite) TestGetAll(c *C) {
 	c.Assert(len(resp2), GreaterEqual, 1)
 }
 
+func (s *testRuleSuite) TestSetAll(c *C) {
+	rule1 := placement.Rule{GroupID: "a", ID: "10", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1}
+	rule2 := placement.Rule{GroupID: "a", ID: "10", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1}
+	rule3 := placement.Rule{GroupID: "a", ID: "10", StartKeyHex: "XXXX", EndKeyHex: "3333", Role: "voter", Count: 1}
+	rule4 := placement.Rule{GroupID: "a", ID: "10", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: -1}
+
+	successData, err := json.Marshal([]*placement.Rule{&rule1, &rule2})
+	c.Assert(err, IsNil)
+
+	checkErrData, err := json.Marshal([]*placement.Rule{&rule1, &rule3})
+	c.Assert(err, IsNil)
+
+	setErrData, err := json.Marshal([]*placement.Rule{&rule1, &rule4})
+	c.Assert(err, IsNil)
+
+	testcases := []struct {
+		name     string
+		rawData  []byte
+		success  bool
+		response string
+	}{
+		{
+			name:     "Set rules successfully",
+			rawData:  successData,
+			success:  true,
+			response: "",
+		},
+		{
+			name:    "Parse Json failed",
+			rawData: []byte("foo"),
+			success: false,
+			response: `{
+  "code": "input",
+  "msg": "invalid character 'o' in literal false (expecting 'a')",
+  "data": {
+    "Offset": 2
+  }
+}
+`,
+		},
+		{
+			name:    "Check rule failed",
+			rawData: checkErrData,
+			success: false,
+			response: `"start key is not in hex format: encoding/hex: invalid byte: U+0058 'X'"
+`,
+		},
+		{
+			name:    "Set Rule Failed",
+			rawData: setErrData,
+			success: false,
+			response: `"invalid count -1"
+`,
+		},
+	}
+
+	for _, testcase := range testcases {
+		c.Log(testcase.name)
+		err := postJSON(testDialClient, s.urlPrefix+"/rules", testcase.rawData)
+		if testcase.success {
+			c.Assert(err, IsNil)
+		} else {
+			c.Assert(err, NotNil)
+			c.Assert(err.Error(), Equals, testcase.response)
+		}
+	}
+}
+
 func (s *testRuleSuite) TestGetAllByGroup(c *C) {
 	rule := placement.Rule{GroupID: "c", ID: "20", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1}
 	data, err := json.Marshal(rule)

--- a/server/api/rule_test.go
+++ b/server/api/rule_test.go
@@ -171,10 +171,10 @@ func (s *testRuleSuite) TestGetAll(c *C) {
 }
 
 func (s *testRuleSuite) TestSetAll(c *C) {
-	rule1 := placement.Rule{GroupID: "a", ID: "10", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1}
-	rule2 := placement.Rule{GroupID: "a", ID: "10", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1}
-	rule3 := placement.Rule{GroupID: "a", ID: "10", StartKeyHex: "XXXX", EndKeyHex: "3333", Role: "voter", Count: 1}
-	rule4 := placement.Rule{GroupID: "a", ID: "10", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: -1}
+	rule1 := placement.Rule{GroupID: "a", ID: "12", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1}
+	rule2 := placement.Rule{GroupID: "b", ID: "12", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1}
+	rule3 := placement.Rule{GroupID: "a", ID: "12", StartKeyHex: "XXXX", EndKeyHex: "3333", Role: "voter", Count: 1}
+	rule4 := placement.Rule{GroupID: "a", ID: "12", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: -1}
 
 	successData, err := json.Marshal([]*placement.Rule{&rule1, &rule2})
 	c.Assert(err, IsNil)
@@ -192,7 +192,7 @@ func (s *testRuleSuite) TestSetAll(c *C) {
 		response string
 	}{
 		{
-			name:     "Set rules successfully",
+			name:     "Set rules successfully, with oldRules full of nil",
 			rawData:  successData,
 			success:  true,
 			response: "",

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -275,12 +275,13 @@ func (m *RuleManager) FitRegion(stores StoreSet, region *core.RegionInfo) *Regio
 	return FitRegion(stores, region, rules)
 }
 
-func (m *RuleManager) setRule(rule *Rule) *Rule {
+func (m *RuleManager) swapRule(rule *Rule) *Rule {
 	old := m.rules[rule.Key()]
 	m.rules[rule.Key()] = rule
 	return old
 }
 
+// SetRules inserts or updates lots of Rules at once.
 func (m *RuleManager) SetRules(rules []*Rule) error {
 	for _, rule := range rules {
 		err := m.adjustRule(rule)
@@ -295,7 +296,7 @@ func (m *RuleManager) SetRules(rules []*Rule) error {
 	oldRules := make(map[[2]string]*Rule)
 
 	for _, rule := range rules {
-		oldRules[rule.Key()] = m.setRule(rule)
+		oldRules[rule.Key()] = m.swapRule(rule)
 	}
 
 	ruleList, err := buildRuleList(m.rules)

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"sync"
 
 	"github.com/pingcap/log"
@@ -272,4 +273,53 @@ func (m *RuleManager) GetRulesForApplyRegion(region *core.RegionInfo) []*Rule {
 func (m *RuleManager) FitRegion(stores StoreSet, region *core.RegionInfo) *RegionFit {
 	rules := m.GetRulesForApplyRegion(region)
 	return FitRegion(stores, region, rules)
+}
+
+func (m *RuleManager) setRule(rule *Rule) *Rule {
+	old := m.rules[rule.Key()]
+	m.rules[rule.Key()] = rule
+	return old
+}
+
+func (m *RuleManager) SetRules(rules []*Rule) error {
+	for _, rule := range rules {
+		err := m.adjustRule(rule)
+		if err != nil {
+			return err
+		}
+	}
+
+	m.Lock()
+	defer m.Unlock()
+
+	oldRules := make(map[[2]string]*Rule)
+
+	for _, rule := range rules {
+		oldRules[rule.Key()] = m.setRule(rule)
+	}
+
+	ruleList, err := buildRuleList(m.rules)
+	if err == nil {
+		for _, rule := range rules {
+			err = m.store.SaveRule(rule.StoreKey(), rule)
+			if err != nil {
+				break
+			}
+		}
+	}
+
+	if err != nil {
+		for key, rule := range oldRules {
+			if rule == nil {
+				delete(m.rules, key)
+			} else {
+				m.rules[key] = rule
+			}
+		}
+		return err
+	}
+
+	m.ruleList = ruleList
+	log.Info("placement rule updated", zap.String("rules", fmt.Sprint(rules)))
+	return nil
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related to #2680.

Now one can post an array of rules to `/config/rules`, to set all rules in one request. In case there is an error, all modifications are cancelled.

### Check List

Tests

- Unit test
- Integration test

Code changes

- Has HTTP API interfaces change

### Release note

- atomic POST api `/config/rules` for setting all rules in one request, parameter is an array of rules
