### PR TITLE
pd-ctl: make use of new batch ruledef api

### DIFF
--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -16,7 +16,6 @@ package command
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"path"

--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -521,10 +521,10 @@ func putPlacementRulesFunc(cmd *cobra.Command, args []string) {
 	}
 
 	n := len(validRules)
-	for k := 0; k < n ; k++ {
+	for k := 0; k < n; k++ {
 		r := validRules[k]
 		if r.Count == 0 {
-			validRules[k], validRules[n - 1] = validRules[n - 1], validRules[k]
+			validRules[k], validRules[n-1] = validRules[n-1], validRules[k]
 			n--
 		}
 	}

--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -515,13 +515,13 @@ func putPlacementRulesFunc(cmd *cobra.Command, args []string) {
 	}
 
 	validOpts := opts[:0]
-	for _, Op := range opts {
-		if Op.Count > 0 {
-			Op.Action = placement.RuleOpAdd
-			validOpts = append(validOpts, Op)
-		} else if Op.Count == 0 {
-			Op.Action = placement.RuleOpDel
-			validOpts = append(validOpts, Op)
+	for _, op := range opts {
+		if op.Count > 0 {
+			op.Action = placement.RuleOpAdd
+			validOpts = append(validOpts, op)
+		} else if op.Count == 0 {
+			op.Action = placement.RuleOpDel
+			validOpts = append(validOpts, op)
 		}
 	}
 


### PR DESCRIPTION
### What problem does this PR solve?

#2694, as title, save rules using the new api.

### Check List

Tests

- Manual test

Test save rules with `[{count=3}, {count=0}, {count=0}, {count=3}]`, and `[{count=3}, {count=3}, {count=0}]`.

### Release note

- No release note
