### PR TITLE
placement: support batch deletions, with insertions

### DIFF
--- a/server/api/router.go
+++ b/server/api/router.go
@@ -92,6 +92,7 @@ func createRouter(ctx context.Context, prefix string, svr *server.Server) *mux.R
 	rulesHandler := newRulesHandler(svr, rd)
 	clusterRouter.HandleFunc("/config/rules", rulesHandler.GetAll).Methods("GET")
 	clusterRouter.HandleFunc("/config/rules", rulesHandler.SetAll).Methods("POST")
+	clusterRouter.HandleFunc("/config/rules/batch", rulesHandler.Batch).Methods("POST")
 	clusterRouter.HandleFunc("/config/rules/group/{group}", rulesHandler.GetAllByGroup).Methods("GET")
 	clusterRouter.HandleFunc("/config/rules/region/{region}", rulesHandler.GetAllByRegion).Methods("GET")
 	clusterRouter.HandleFunc("/config/rules/key/{key}", rulesHandler.GetAllByKey).Methods("GET")

--- a/server/api/rule.go
+++ b/server/api/rule.go
@@ -61,7 +61,7 @@ func (h *ruleHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 }
 
 // @Tags rule
-// @Summary Set all rules for the cluster. If there is an error, modifications are promised to be cancelled in memory, but not disk. You propabably want to request again to make rules in memory/disk consistent.
+// @Summary Set all rules for the cluster. If there is an error, modifications are promised to be rollback in memory, but may fail to rollback disk. You propabably want to request again to make rules in memory/disk consistent.
 // @Produce json
 // @Param rules body []placement.Rule true "Parameters of rules"
 // @Success 200 {string} string "Update rules successfully."
@@ -294,7 +294,7 @@ func (h *ruleHandler) Delete(w http.ResponseWriter, r *http.Request) {
 }
 
 // @Tags rule
-// @Summary Batch operations for the cluster. Operations should be independent(differnt ID). If there is an error, modifications are promised to be cancelled in memory, but not disk. You propabably want to request again to make rules in memory/disk consistent.
+// @Summary Batch operations for the cluster. Operations should be independent(differnt ID). If there is an error, modifications are promised to be rollback in memory, but may fail to rollback disk. You propabably want to request again to make rules in memory/disk consistent.
 // @Produce json
 // @Param operations body []placement.Batch true "Parameters of rule operations"
 // @Success 200 {string} string "Batch operations successfully."

--- a/server/api/rule.go
+++ b/server/api/rule.go
@@ -61,7 +61,7 @@ func (h *ruleHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 }
 
 // @Tags rule
-// @Summary Set all rules for the cluster.
+// @Summary Set all rules for the cluster. If there is an error, modifications are promised to be cancelled in memory, but not disk. You propabably want to request again to make rules in memory/disk consistent.
 // @Produce json
 // @Param rules body []placement.Rule true "Parameters of rules"
 // @Success 200 {string} string "Update rules successfully."
@@ -294,7 +294,7 @@ func (h *ruleHandler) Delete(w http.ResponseWriter, r *http.Request) {
 }
 
 // @Tags rule
-// @Summary Batch operations for the cluster. Operations should be independent.
+// @Summary Batch operations for the cluster. Operations should be independent(differnt ID). If there is an error, modifications are promised to be cancelled in memory, but not disk. You propabably want to request again to make rules in memory/disk consistent.
 // @Produce json
 // @Param operations body []placement.Batch true "Parameters of rule operations"
 // @Success 200 {string} string "Batch operations successfully."

--- a/server/api/rule.go
+++ b/server/api/rule.go
@@ -294,7 +294,7 @@ func (h *ruleHandler) Delete(w http.ResponseWriter, r *http.Request) {
 }
 
 // @Tags rule
-// @Summary Batch operations for the cluster. Operations should be independent(differnt ID). If there is an error, modifications are promised to be rollback in memory, but may fail to rollback disk. You propabably want to request again to make rules in memory/disk consistent.
+// @Summary Batch operations for the cluster. Operations should be independent(different ID). If there is an error, modifications are promised to be rollback in memory, but may fail to rollback disk. You propabably want to request again to make rules in memory/disk consistent.
 // @Produce json
 // @Param operations body []placement.RuleOp true "Parameters of rule operations"
 // @Success 200 {string} string "Batch operations successfully."

--- a/server/api/rule.go
+++ b/server/api/rule.go
@@ -296,7 +296,7 @@ func (h *ruleHandler) Delete(w http.ResponseWriter, r *http.Request) {
 // @Tags rule
 // @Summary Batch operations for the cluster. Operations should be independent(differnt ID). If there is an error, modifications are promised to be rollback in memory, but may fail to rollback disk. You propabably want to request again to make rules in memory/disk consistent.
 // @Produce json
-// @Param operations body []placement.Batch true "Parameters of rule operations"
+// @Param operations body []placement.RuleOp true "Parameters of rule operations"
 // @Success 200 {string} string "Batch operations successfully."
 // @Failure 400 {string} string "The input is invalid."
 // @Failure 412 {string} string "Placement rules feature is disabled."
@@ -308,13 +308,13 @@ func (h *ruleHandler) Batch(w http.ResponseWriter, r *http.Request) {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
 	}
-	var opts []placement.Batch
+	var opts []placement.RuleOp
 	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &opts); err != nil {
 		return
 	}
 	for _, opt := range opts {
 		switch opt.Action {
-		case placement.BatchAdd:
+		case placement.RuleOpAdd:
 			if err := h.checkRule(opt.Rule); err != nil {
 				h.rd.JSON(w, http.StatusBadRequest, err.Error())
 				return

--- a/server/api/rule.go
+++ b/server/api/rule.go
@@ -292,3 +292,38 @@ func (h *ruleHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 	h.rd.JSON(w, http.StatusOK, "Delete rule successfully.")
 }
+
+// @Tags rule
+// @Summary Batch operations for the cluster. Operations should be independent.
+// @Produce json
+// @Param operations body []placement.Batch true "Parameters of rule operations"
+// @Success 200 {string} string "Batch operations successfully."
+// @Failure 400 {string} string "The input is invalid."
+// @Failure 412 {string} string "Placement rules feature is disabled."
+// @Failure 500 {string} string "PD server failed to proceed the request."
+// @Router /config/rules/batch [post]
+func (h *ruleHandler) Batch(w http.ResponseWriter, r *http.Request) {
+	cluster := getCluster(r.Context())
+	if !cluster.IsPlacementRulesEnabled() {
+		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
+		return
+	}
+	var opts []placement.Batch
+	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &opts); err != nil {
+		return
+	}
+	for _, opt := range opts {
+		switch opt.Action {
+		case placement.BatchAdd:
+			if err := h.checkRule(opt.Rule); err != nil {
+				h.rd.JSON(w, http.StatusBadRequest, err.Error())
+				return
+			}
+		}
+	}
+	if err := cluster.GetRuleManager().Batch(opts); err != nil {
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.rd.JSON(w, http.StatusOK, "Batch operations successfully.")
+}

--- a/server/api/rule_test.go
+++ b/server/api/rule_test.go
@@ -498,57 +498,57 @@ func compareRule(c *C, r1 *placement.Rule, r2 *placement.Rule) {
 }
 
 func (s *testRuleSuite) TestBatch(c *C) {
-	opt1 := placement.Batch{
-		Action: placement.BatchAdd,
+	opt1 := placement.RuleOp{
+		Action: placement.RuleOpAdd,
 		Rule:   &placement.Rule{GroupID: "a", ID: "13", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1},
 	}
-	opt2 := placement.Batch{
-		Action: placement.BatchAdd,
+	opt2 := placement.RuleOp{
+		Action: placement.RuleOpAdd,
 		Rule:   &placement.Rule{GroupID: "b", ID: "13", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1},
 	}
-	opt3 := placement.Batch{
-		Action: placement.BatchAdd,
+	opt3 := placement.RuleOp{
+		Action: placement.RuleOpAdd,
 		Rule:   &placement.Rule{GroupID: "a", ID: "14", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1},
 	}
-	opt4 := placement.Batch{
-		Action: placement.BatchAdd,
+	opt4 := placement.RuleOp{
+		Action: placement.RuleOpAdd,
 		Rule:   &placement.Rule{GroupID: "a", ID: "15", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1},
 	}
-	opt5 := placement.Batch{
-		Action: placement.BatchDel,
+	opt5 := placement.RuleOp{
+		Action: placement.RuleOpDel,
 		Rule:   &placement.Rule{GroupID: "a", ID: "14"},
 	}
-	opt6 := placement.Batch{
-		Action:           placement.BatchDel,
+	opt6 := placement.RuleOp{
+		Action:           placement.RuleOpDel,
 		Rule:             &placement.Rule{GroupID: "b", ID: "1"},
 		DeleteByIDPrefix: true,
 	}
-	opt7 := placement.Batch{
-		Action: placement.BatchDel,
+	opt7 := placement.RuleOp{
+		Action: placement.RuleOpDel,
 		Rule:   &placement.Rule{GroupID: "a", ID: "1"},
 	}
-	opt8 := placement.Batch{
-		Action: placement.BatchAdd,
+	opt8 := placement.RuleOp{
+		Action: placement.RuleOpAdd,
 		Rule:   &placement.Rule{GroupID: "a", ID: "16", StartKeyHex: "XXXX", EndKeyHex: "3333", Role: "voter", Count: 1},
 	}
-	opt9 := placement.Batch{
-		Action: placement.BatchAdd,
+	opt9 := placement.RuleOp{
+		Action: placement.RuleOpAdd,
 		Rule:   &placement.Rule{GroupID: "a", ID: "17", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: -1},
 	}
 
-	successData1, err := json.Marshal([]placement.Batch{opt1, opt2, opt3})
+	successData1, err := json.Marshal([]placement.RuleOp{opt1, opt2, opt3})
 	c.Assert(err, IsNil)
 
-	successData2, err := json.Marshal([]placement.Batch{opt5, opt7})
+	successData2, err := json.Marshal([]placement.RuleOp{opt5, opt7})
 	c.Assert(err, IsNil)
 
-	successData3, err := json.Marshal([]placement.Batch{opt4, opt6})
+	successData3, err := json.Marshal([]placement.RuleOp{opt4, opt6})
 	c.Assert(err, IsNil)
 
-	checkErrData, err := json.Marshal([]placement.Batch{opt8})
+	checkErrData, err := json.Marshal([]placement.RuleOp{opt8})
 	c.Assert(err, IsNil)
 
-	setErrData, err := json.Marshal([]placement.Batch{opt9})
+	setErrData, err := json.Marshal([]placement.RuleOp{opt9})
 	c.Assert(err, IsNil)
 
 	testcases := []struct {

--- a/server/api/rule_test.go
+++ b/server/api/rule_test.go
@@ -519,9 +519,9 @@ func (s *testRuleSuite) TestBatch(c *C) {
 		Rule:   &placement.Rule{GroupID: "a", ID: "14"},
 	}
 	opt6 := placement.Batch{
-		Action:  placement.BatchDel,
-		Rule:    &placement.Rule{GroupID: "b", ID: "1"},
-		MatchID: true,
+		Action:           placement.BatchDel,
+		Rule:             &placement.Rule{GroupID: "b", ID: "1"},
+		DeleteByIDPrefix: true,
 	}
 	opt7 := placement.Batch{
 		Action: placement.BatchDel,

--- a/server/api/rule_test.go
+++ b/server/api/rule_test.go
@@ -508,15 +508,15 @@ func (s *testRuleSuite) TestBatch(c *C) {
 	}
 	opt3 := placement.Batch{
 		Action: placement.BatchAdd,
-		Rule:   &placement.Rule{GroupID: "c", ID: "13", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1},
+		Rule:   &placement.Rule{GroupID: "a", ID: "14", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1},
 	}
 	opt4 := placement.Batch{
 		Action: placement.BatchAdd,
-		Rule:   &placement.Rule{GroupID: "d", ID: "13", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1},
+		Rule:   &placement.Rule{GroupID: "a", ID: "15", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1},
 	}
 	opt5 := placement.Batch{
 		Action: placement.BatchDel,
-		Rule:   &placement.Rule{GroupID: "c", ID: "13"},
+		Rule:   &placement.Rule{GroupID: "a", ID: "14"},
 	}
 	opt6 := placement.Batch{
 		Action:  placement.BatchDel,
@@ -529,11 +529,11 @@ func (s *testRuleSuite) TestBatch(c *C) {
 	}
 	opt8 := placement.Batch{
 		Action: placement.BatchAdd,
-		Rule:   &placement.Rule{GroupID: "e", ID: "13", StartKeyHex: "XXXX", EndKeyHex: "3333", Role: "voter", Count: 1},
+		Rule:   &placement.Rule{GroupID: "a", ID: "16", StartKeyHex: "XXXX", EndKeyHex: "3333", Role: "voter", Count: 1},
 	}
 	opt9 := placement.Batch{
 		Action: placement.BatchAdd,
-		Rule:   &placement.Rule{GroupID: "f", ID: "13", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: -1},
+		Rule:   &placement.Rule{GroupID: "a", ID: "17", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: -1},
 	}
 
 	successData1, err := json.Marshal([]placement.Batch{opt1, opt2, opt3})

--- a/server/api/rule_test.go
+++ b/server/api/rule_test.go
@@ -615,4 +615,3 @@ func (s *testRuleSuite) TestBatch(c *C) {
 		}
 	}
 }
-

--- a/server/api/rule_test.go
+++ b/server/api/rule_test.go
@@ -496,3 +496,123 @@ func compareRule(c *C, r1 *placement.Rule, r2 *placement.Rule) {
 	c.Assert(r1.Role, Equals, r2.Role)
 	c.Assert(r1.Count, Equals, r2.Count)
 }
+
+func (s *testRuleSuite) TestBatch(c *C) {
+	opt1 := placement.Batch{
+		Action: placement.BatchAdd,
+		Rule:   &placement.Rule{GroupID: "a", ID: "13", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1},
+	}
+	opt2 := placement.Batch{
+		Action: placement.BatchAdd,
+		Rule:   &placement.Rule{GroupID: "b", ID: "13", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1},
+	}
+	opt3 := placement.Batch{
+		Action: placement.BatchAdd,
+		Rule:   &placement.Rule{GroupID: "c", ID: "13", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1},
+	}
+	opt4 := placement.Batch{
+		Action: placement.BatchAdd,
+		Rule:   &placement.Rule{GroupID: "d", ID: "13", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1},
+	}
+	opt5 := placement.Batch{
+		Action: placement.BatchDel,
+		Rule:   &placement.Rule{GroupID: "c", ID: "13"},
+	}
+	opt6 := placement.Batch{
+		Action:  placement.BatchDel,
+		Rule:    &placement.Rule{GroupID: "b", ID: "1"},
+		MatchID: true,
+	}
+	opt7 := placement.Batch{
+		Action: placement.BatchDel,
+		Rule:   &placement.Rule{GroupID: "a", ID: "1"},
+	}
+	opt8 := placement.Batch{
+		Action: placement.BatchAdd,
+		Rule:   &placement.Rule{GroupID: "e", ID: "13", StartKeyHex: "XXXX", EndKeyHex: "3333", Role: "voter", Count: 1},
+	}
+	opt9 := placement.Batch{
+		Action: placement.BatchAdd,
+		Rule:   &placement.Rule{GroupID: "f", ID: "13", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: -1},
+	}
+
+	successData1, err := json.Marshal([]placement.Batch{opt1, opt2, opt3})
+	c.Assert(err, IsNil)
+
+	successData2, err := json.Marshal([]placement.Batch{opt5, opt7})
+	c.Assert(err, IsNil)
+
+	successData3, err := json.Marshal([]placement.Batch{opt4, opt6})
+	c.Assert(err, IsNil)
+
+	checkErrData, err := json.Marshal([]placement.Batch{opt8})
+	c.Assert(err, IsNil)
+
+	setErrData, err := json.Marshal([]placement.Batch{opt9})
+	c.Assert(err, IsNil)
+
+	testcases := []struct {
+		name     string
+		rawData  []byte
+		success  bool
+		response string
+	}{
+		{
+			name:     "Batch adds successfully",
+			rawData:  successData1,
+			success:  true,
+			response: "",
+		},
+		{
+			name:     "Batch removes successfully",
+			rawData:  successData2,
+			success:  true,
+			response: "",
+		},
+		{
+			name:     "Batch add and remove successfully",
+			rawData:  successData3,
+			success:  true,
+			response: "",
+		},
+		{
+			name:    "Parse Json failed",
+			rawData: []byte("foo"),
+			success: false,
+			response: `{
+  "code": "input",
+  "msg": "invalid character 'o' in literal false (expecting 'a')",
+  "data": {
+    "Offset": 2
+  }
+}
+`,
+		},
+		{
+			name:    "Check rule failed",
+			rawData: checkErrData,
+			success: false,
+			response: `"start key is not in hex format: encoding/hex: invalid byte: U+0058 'X'"
+`,
+		},
+		{
+			name:    "Set Rule Failed",
+			rawData: setErrData,
+			success: false,
+			response: `"invalid count -1"
+`,
+		},
+	}
+
+	for _, testcase := range testcases {
+		c.Log(testcase.name)
+		err := postJSON(testDialClient, s.urlPrefix+"/rules/batch", testcase.rawData)
+		if testcase.success {
+			c.Assert(err, IsNil)
+		} else {
+			c.Assert(err, NotNil)
+			c.Assert(err.Error(), Equals, testcase.response)
+		}
+	}
+}
+

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -385,9 +385,9 @@ const (
 // Batch is for batching placement rule actions. The action type is
 // distinguished by the field `Action`.
 type Batch struct {
-	*Rule               // infomation of the placement rule
+	*Rule               // information of the placement rule to add/delete
 	Action  BatchAction `json:"action"`   // the operation type
-	MatchID bool        `json:"match_id"` // only take effect if action is deletion
+	MatchID bool        `json:"match_id"` // only take effect if action is deletion, will match the prefix of id
 }
 
 // Batch execute a series of actions at once.

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -372,13 +372,13 @@ func (m *RuleManager) delRule(t *Batch, oldRules map[[2]string]*Rule) {
 	}
 }
 
-// The operation type for Batch
+// BatchAction indicates the operation type
 type BatchAction byte
 
 const (
-	// Add a placement rule, only need to specify the field *Rule
+	// BatchAdd a placement rule, only need to specify the field *Rule
 	BatchAdd BatchAction = iota + 1
-	// Del a placement rule, only need to specify the field `GroupID`, `ID`, `MatchID`
+	// BatchDel a placement rule, only need to specify the field `GroupID`, `ID`, `MatchID`
 	BatchDel
 )
 

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -372,17 +372,22 @@ func (m *RuleManager) delRule(t *Batch, oldRules map[[2]string]*Rule) {
 	}
 }
 
+// The operation type for Batch
 type BatchAction byte
 
 const (
+	// Add a placement rule, only need to specify the field *Rule
 	BatchAdd BatchAction = iota + 1
+	// Del a placement rule, only need to specify the field `GroupID`, `ID`, `MatchID`
 	BatchDel
 )
 
+// Batch is for batching placement rule actions. The action type is
+// distinguished by the field `Action`.
 type Batch struct {
-	*Rule
-	Action  BatchAction
-	MatchID bool
+	*Rule               // infomation of the placement rule
+	Action  BatchAction `json:"action"`   // the operation type
+	MatchID bool        `json:"match_id"` // only take effect if action is deletion
 }
 
 // Batch execute a series of actions at once.

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -370,7 +370,7 @@ func (m *RuleManager) delRule(t *RuleOp, oldRules map[[2]string]*Rule) {
 	}
 }
 
-// BatchAction indicates the operation type
+// RuleOpType indicates the operation type
 type RuleOpType string
 
 const (

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -358,7 +358,7 @@ func (m *RuleManager) delRuleByID(group, id string, oldRules map[[2]string]*Rule
 	oldRules[key] = old
 }
 
-func (m *RuleManager) delRule(t *Batch, oldRules map[[2]string]*Rule) {
+func (m *RuleManager) delRule(t *RuleOp, oldRules map[[2]string]*Rule) {
 	if !t.DeleteByIDPrefix {
 		m.delRuleByID(t.GroupID, t.ID, oldRules)
 	} else {
@@ -371,28 +371,28 @@ func (m *RuleManager) delRule(t *Batch, oldRules map[[2]string]*Rule) {
 }
 
 // BatchAction indicates the operation type
-type BatchAction string
+type RuleOpType string
 
 const (
-	// BatchAdd a placement rule, only need to specify the field *Rule
-	BatchAdd BatchAction = "add"
-	// BatchDel a placement rule, only need to specify the field `GroupID`, `ID`, `MatchID`
-	BatchDel BatchAction = "del"
+	// RuleOpAdd a placement rule, only need to specify the field *Rule
+	RuleOpAdd RuleOpType = "add"
+	// RuleOpDel a placement rule, only need to specify the field `GroupID`, `ID`, `MatchID`
+	RuleOpDel RuleOpType = "del"
 )
 
-// Batch is for batching placement rule actions. The action type is
+// RuleOp is for batching placement rule actions. The action type is
 // distinguished by the field `Action`.
-type Batch struct {
-	*Rule                        // information of the placement rule to add/delete
-	Action           BatchAction `json:"action"`       // the operation type
-	DeleteByIDPrefix bool        `json:"delete_by_id_prefix"` // if action == delete, delete by the prefix of id
+type RuleOp struct {
+	*Rule                       // information of the placement rule to add/delete
+	Action           RuleOpType `json:"action"`              // the operation type
+	DeleteByIDPrefix bool       `json:"delete_by_id_prefix"` // if action == delete, delete by the prefix of id
 }
 
 // Batch executes a series of actions at once.
-func (m *RuleManager) Batch(todo []Batch) error {
+func (m *RuleManager) Batch(todo []RuleOp) error {
 	for _, t := range todo {
 		switch t.Action {
-		case BatchAdd:
+		case RuleOpAdd:
 			err := m.adjustRule(t.Rule)
 			if err != nil {
 				return err
@@ -407,9 +407,9 @@ func (m *RuleManager) Batch(todo []Batch) error {
 
 	for _, t := range todo {
 		switch t.Action {
-		case BatchAdd:
+		case RuleOpAdd:
 			m.addRule(t.Rule, oldRules)
-		case BatchDel:
+		case RuleOpDel:
 			m.delRule(&t, oldRules)
 		}
 	}

--- a/server/schedule/placement/rule_manager_test.go
+++ b/server/schedule/placement/rule_manager_test.go
@@ -99,8 +99,8 @@ func (s *testManagerSuite) TestKeys(c *C) {
 	for _, r := range rules {
 		s.manager.SetRule(r)
 		toDelete = append(toDelete, Batch{
-			Rule: r,
-			Action: BatchDel,
+			Rule:    r,
+			Action:  BatchDel,
 			MatchID: false,
 		})
 	}

--- a/server/schedule/placement/rule_manager_test.go
+++ b/server/schedule/placement/rule_manager_test.go
@@ -99,9 +99,9 @@ func (s *testManagerSuite) TestKeys(c *C) {
 	for _, r := range rules {
 		s.manager.SetRule(r)
 		toDelete = append(toDelete, Batch{
-			Rule:    r,
-			Action:  BatchDel,
-			MatchID: false,
+			Rule:             r,
+			Action:           BatchDel,
+			DeleteByIDPrefix: false,
 		})
 	}
 	s.manager.Batch(toDelete)

--- a/server/schedule/placement/rule_manager_test.go
+++ b/server/schedule/placement/rule_manager_test.go
@@ -93,12 +93,23 @@ func (s *testManagerSuite) TestKeys(c *C) {
 		{GroupID: "1", ID: "1", Role: "voter", Count: 1, StartKeyHex: "", EndKeyHex: ""},
 		{GroupID: "2", ID: "2", Role: "voter", Count: 1, StartKeyHex: "11", EndKeyHex: "ff"},
 		{GroupID: "2", ID: "3", Role: "voter", Count: 1, StartKeyHex: "22", EndKeyHex: "dd"},
-		{GroupID: "3", ID: "4", Role: "voter", Count: 1, StartKeyHex: "44", EndKeyHex: "ee"},
-		{GroupID: "3", ID: "5", Role: "voter", Count: 1, StartKeyHex: "44", EndKeyHex: "dd"},
 	}
+
+	toDelete := []Batch{}
 	for _, r := range rules {
 		s.manager.SetRule(r)
+		toDelete = append(toDelete, Batch{
+			Rule: r,
+			Action: BatchDel,
+			MatchID: false,
+		})
 	}
+	s.manager.Batch(toDelete)
+
+	rules = append(rules, &Rule{GroupID: "3", ID: "4", Role: "voter", Count: 1, StartKeyHex: "44", EndKeyHex: "ee"},
+		&Rule{GroupID: "3", ID: "5", Role: "voter", Count: 1, StartKeyHex: "44", EndKeyHex: "dd"})
+	s.manager.SetRules(rules)
+
 	s.manager.DeleteRule("pd", "default")
 
 	splitKeys := [][]string{

--- a/server/schedule/placement/rule_manager_test.go
+++ b/server/schedule/placement/rule_manager_test.go
@@ -95,12 +95,12 @@ func (s *testManagerSuite) TestKeys(c *C) {
 		{GroupID: "2", ID: "3", Role: "voter", Count: 1, StartKeyHex: "22", EndKeyHex: "dd"},
 	}
 
-	toDelete := []Batch{}
+	toDelete := []RuleOp{}
 	for _, r := range rules {
 		s.manager.SetRule(r)
-		toDelete = append(toDelete, Batch{
+		toDelete = append(toDelete, RuleOp{
 			Rule:             r,
-			Action:           BatchDel,
+			Action:           RuleOpDel,
 			DeleteByIDPrefix: false,
 		})
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Related to #2680.

Now one can post an array of operations(insert/delete) to `/config/rules/batch` in one request. In case there is an error, all modifications are cancelled.

Two notable points:
1. Operations should be independent. Their IDs should be different.
2. I noticed that this PR and the previous PR is not completely safe. See https://github.com/xhebox/pd/blob/delete/server/schedule/placement/rule_manager.go#L294-L299.

### Check List

Tests

- Unit test
- Integration test

Code changes

- Has HTTP API interfaces change

### Release note

- atomic POST api `/config/rules/batcch` for batch(insert/delete) rules in one request
