### PR TITLE
server/cluster: fix storing old store info into storage when handling heartbeat

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -497,7 +497,7 @@ func (c *RaftCluster) HandleStoreHeartbeat(stats *pdpb.StoreStats) error {
 			zap.Uint64("available", newStore.GetAvailable()))
 	}
 	if newStore.NeedPersist() && c.storage != nil {
-		if err := c.storage.SaveStore(store.GetMeta()); err != nil {
+		if err := c.storage.SaveStore(newStore.GetMeta()); err != nil {
 			log.Error("failed to persist store", zap.Uint64("store-id", newStore.GetID()))
 		} else {
 			newStore = newStore.Clone(core.SetLastPersistTime(time.Now()))

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -48,6 +48,7 @@ func (s *testClusterInfoSuite) TestStoreHeartbeat(c *C) {
 
 	n, np := uint64(3), uint64(3)
 	stores := newTestStores(n)
+	storeMetasAfterHeartbeat := make([]*metapb.Store, 0, n)
 	regions := newTestRegions(n, np)
 
 	for _, region := range regions {
@@ -74,16 +75,18 @@ func (s *testClusterInfoSuite) TestStoreHeartbeat(c *C) {
 		s := cluster.GetStore(store.GetID())
 		c.Assert(s.GetLastHeartbeatTS().UnixNano(), Not(Equals), int64(0))
 		c.Assert(s.GetStoreStats(), DeepEquals, storeStats)
+
+		storeMetasAfterHeartbeat = append(storeMetasAfterHeartbeat, s.GetMeta())
 	}
 
 	c.Assert(cluster.GetStoreCount(), Equals, int(n))
 
-	for _, store := range stores {
+	for i, store := range stores {
 		tmp := &metapb.Store{}
 		ok, err := cluster.storage.LoadStore(store.GetID(), tmp)
 		c.Assert(ok, IsTrue)
 		c.Assert(err, IsNil)
-		c.Assert(tmp, DeepEquals, store.GetMeta())
+		c.Assert(tmp, DeepEquals, storeMetasAfterHeartbeat[i])
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Howard Lau <howardlau1999@hotmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

When handling store heartbeats, pd needs to persist store info with new stats and heartbeatTS. However, after checking if the new store info needs to persist, pd wrongly stores the original store info into storage.

### What is changed and how it works?

Store the new store info with latest heartbeatTS and stats instead of the original one.

### Tests

- Unit test

### Release note

- No release note
