### PR TITLE
pd-analysis: Fix mv peer log parse bug

### DIFF
--- a/tools/pd-analysis/analysis/parse_log.go
+++ b/tools/pd-analysis/analysis/parse_log.go
@@ -25,6 +25,8 @@ import (
 )
 
 var supportOperators = []string{"balance-region", "balance-leader", "transfer-hot-read-leader", "move-hot-read-region", "transfer-hot-write-leader", "move-hot-write-region"}
+var regionOperators = []string{"balance-region", "move-hot-read-region", "move-hot-write-region"}
+var leaderOperators = []string{"balance-leader", "transfer-hot-read-leader", "transfer-hot-write-leader"}
 
 // DefaultLayout is the default layout to parse log.
 const DefaultLayout = "2006/01/02 15:04:05"
@@ -44,8 +46,14 @@ func (c *TransferCounter) CompileRegex(operator string) (*regexp.Regexp, error) 
 	var r *regexp.Regexp
 	var err error
 
-	for _, supportOperator := range supportOperators {
-		if operator == supportOperator {
+	for _, regionOperator := range regionOperators {
+		if operator == regionOperator {
+			r, err = regexp.Compile(".*?operator finish.*?region-id=([0-9]*).*?" + operator + ".*?store \\[([0-9]*)\\] to \\[([0-9]*)\\].*?")
+		}
+	}
+
+	for _, regionOperator := range leaderOperators {
+		if operator == regionOperator {
 			r, err = regexp.Compile(".*?operator finish.*?region-id=([0-9]*).*?" + operator + ".*?store ([0-9]*) to ([0-9]*).*?")
 		}
 	}

--- a/tools/pd-analysis/analysis/parse_log.go
+++ b/tools/pd-analysis/analysis/parse_log.go
@@ -51,8 +51,8 @@ func (c *TransferCounter) CompileRegex(operator string) (*regexp.Regexp, error) 
 		}
 	}
 
-	for _, regionOperator := range leaderOperators {
-		if operator == regionOperator {
+	for _, leaderOperator := range leaderOperators {
+		if operator == leaderOperator {
 			r, err = regexp.Compile(".*?operator finish.*?region-id=([0-9]*).*?" + operator + ".*?store ([0-9]*) to ([0-9]*).*?")
 		}
 	}

--- a/tools/pd-analysis/analysis/parse_log.go
+++ b/tools/pd-analysis/analysis/parse_log.go
@@ -24,7 +24,6 @@ import (
 	"time"
 )
 
-var supportOperators = []string{"balance-region", "balance-leader", "transfer-hot-read-leader", "move-hot-read-region", "transfer-hot-write-leader", "move-hot-write-region"}
 var regionOperators = []string{"balance-region", "move-hot-read-region", "move-hot-write-region"}
 var leaderOperators = []string{"balance-leader", "transfer-hot-read-leader", "transfer-hot-write-leader"}
 

--- a/tools/pd-analysis/analysis/parse_log_test.go
+++ b/tools/pd-analysis/analysis/parse_log_test.go
@@ -51,7 +51,7 @@ func (t *testParseLog) TestTransferCounterParseLog(c *C) {
 	}
 	{
 		operator := "balance-region"
-		content := "[2019/09/03 17:42:07.898 +08:00] [INFO] [operator_controller.go:119] [\"operator finish\"] [region-id=24622] [operator=\"\"balance-region {mv peer: store 6 to 1} (kind:region,balance, region:24622(1,1), createAt:2019-09-03 17:42:06.602589701 +0800 CST m=+737.457773921, startAt:2019-09-03 17:42:06.602849306 +0800 CST m=+737.458033475, currentStep:3, steps:[add learner peer 64064 on store 1, promote learner peer 64064 on store 1 to voter, remove peer on store 6]) finished\"\"]\""
+		content := "[2019/09/03 17:42:07.898 +08:00] [INFO] [operator_controller.go:119] [\"operator finish\"] [region-id=24622] [operator=\"\"balance-region {mv peer: store [6] to [1]} (kind:region,balance, region:24622(1,1), createAt:2019-09-03 17:42:06.602589701 +0800 CST m=+737.457773921, startAt:2019-09-03 17:42:06.602849306 +0800 CST m=+737.458033475, currentStep:3, steps:[add learner peer 64064 on store 1, promote learner peer 64064 on store 1 to voter, remove peer on store 6]) finished\"\"]\""
 		var expect = []uint64{24622, 6, 1}
 		c.Assert(transferCounterParseLog(operator, content, expect), Equals, true)
 	}
@@ -63,7 +63,7 @@ func (t *testParseLog) TestTransferCounterParseLog(c *C) {
 	}
 	{
 		operator := "move-hot-write-region"
-		content := "[2019/09/05 14:05:54.311 +08:00] [INFO] [operator_controller.go:119] [\"operator finish\"] [region-id=98] [operator=\"\"move-hot-write-region {mv peer: store 2 to 10} (kind:region,hot-region, region:98(1,1), createAt:2019-09-05 14:05:49.718201432 +0800 CST m=+21.997446945, startAt:2019-09-05 14:05:49.718336308 +0800 CST m=+21.997581822, currentStep:3, steps:[add learner peer 2048 on store 10, promote learner peer 2048 on store 10 to voter, remove peer on store 2]) finished\"\"]"
+		content := "[2019/09/05 14:05:54.311 +08:00] [INFO] [operator_controller.go:119] [\"operator finish\"] [region-id=98] [operator=\"\"move-hot-write-region {mv peer: store [2] to [10]} (kind:region,hot-region, region:98(1,1), createAt:2019-09-05 14:05:49.718201432 +0800 CST m=+21.997446945, startAt:2019-09-05 14:05:49.718336308 +0800 CST m=+21.997581822, currentStep:3, steps:[add learner peer 2048 on store 10, promote learner peer 2048 on store 10 to voter, remove peer on store 2]) finished\"\"]"
 		var expect = []uint64{98, 2, 10}
 		c.Assert(transferCounterParseLog(operator, content, expect), Equals, true)
 	}
@@ -75,7 +75,7 @@ func (t *testParseLog) TestTransferCounterParseLog(c *C) {
 	}
 	{
 		operator := "move-hot-read-region"
-		content := "[2019/09/05 14:19:15.066 +08:00] [INFO] [operator_controller.go:119] [\"operator finish\"] [region-id=389] [operator=\"\"move-hot-read-region {mv peer: store 5 to 4} (kind:leader,region,hot-region, region:389(1,1), createAt:2019-09-05 14:19:13.576359364 +0800 CST m=+25.855737101, startAt:2019-09-05 14:19:13.576556556 +0800 CST m=+25.855934288, currentStep:4, steps:[add learner peer 2014 on store 4, promote learner peer 2014 on store 4 to voter, transfer leader from store 5 to store 3, remove peer on store 5]) finished\"\"]"
+		content := "[2019/09/05 14:19:15.066 +08:00] [INFO] [operator_controller.go:119] [\"operator finish\"] [region-id=389] [operator=\"\"move-hot-read-region {mv peer: store [5] to [4]} (kind:leader,region,hot-region, region:389(1,1), createAt:2019-09-05 14:19:13.576359364 +0800 CST m=+25.855737101, startAt:2019-09-05 14:19:13.576556556 +0800 CST m=+25.855934288, currentStep:4, steps:[add learner peer 2014 on store 4, promote learner peer 2014 on store 4 to voter, transfer leader from store 5 to store 3, remove peer on store 5]) finished\"\"]"
 		var expect = []uint64{389, 5, 4}
 		c.Assert(transferCounterParseLog(operator, content, expect), Equals, true)
 	}


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->
When parse log by pd-analysis, run
`./bin/pd-analysis -input temp_log -operator balance-region -style transfer-counter`
get
`[2020/08/06 12:00:39.900 +08:00] [FATAL] [main.go:73] ["strconv.ParseInt: parsing \"\": invalid syntax"] [stack="main.main\n\t/Users/zeyuantan/Temp/my/pd/tools/pd-analysis/main.go:73\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:203"]`

### What is changed and how it works?

Move peer operator log is `store [1] to [2]` instead of `store 1 to 2`, fix parsing format.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

- If operator needs move peer, fix store parse format.

Side effects



Related changes



### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
- Fix pd-analysis parse log bug.
<!-- - No release note -->
