### PR TITLE
tests: fix the vet warning in go1.15

### DIFF
--- a/tests/pdctl/member/member_test.go
+++ b/tests/pdctl/member/member_test.go
@@ -16,6 +16,7 @@ package member_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -108,7 +109,7 @@ func (s *memberTestSuite) TestMember(c *C) {
 	c.Assert(len(members.Members), Equals, 2)
 
 	// member delete id <member_id>
-	args = []string{"-u", pdAddr, "member", "delete", "id", string(id)}
+	args = []string{"-u", pdAddr, "member", "delete", "id", fmt.Sprint(id)}
 	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
 	c.Assert(err, IsNil)
 	members, err = etcdutil.ListEtcdMembers(client)


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

In go1.15, the vet tool now warns about conversions of the form `string(x)` where `x` has an integer type other than rune or byte. Because of this, pd will not pass tests with go1.15. This pr fix this wrong usage.

More details: https://golang.org/doc/go1.15#vet

### What is changed and how it works?

`string(id)` -> `fmt.Sprint(id)`

### Check List

Tests

- Unit test

### Release note

Fix a bug that pd will not pass the vet check in go1.15.