### PR TITLE
autoscaling: use variables to control scale step

### DIFF
--- a/pkg/typeutil/comparison.go
+++ b/pkg/typeutil/comparison.go
@@ -1,0 +1,40 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typeutil
+
+import "time"
+
+// MinUint64 returns the min value between two variables whose type are uint64.
+func MinUint64(a, b uint64) uint64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// MaxUint64 returns the max value between two variables whose type are uint64.
+func MaxUint64(a, b uint64) uint64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// MinDuration returns the min value between two variables whose type are time.Duration.
+func MinDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/typeutil/comparison_test.go
+++ b/pkg/typeutil/comparison_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package schedulers
+package typeutil
 
 import (
 	"testing"
@@ -20,12 +20,7 @@ import (
 	. "github.com/pingcap/check"
 )
 
-const (
-	KB = 1024
-	MB = 1024 * KB
-)
-
-func TestSchedulers(t *testing.T) {
+func TestComparison(t *testing.T) {
 	TestingT(t)
 }
 
@@ -34,19 +29,19 @@ var _ = Suite(&testMinMaxSuite{})
 type testMinMaxSuite struct{}
 
 func (s *testMinMaxSuite) TestMinUint64(c *C) {
-	c.Assert(minUint64(1, 2), Equals, uint64(1))
-	c.Assert(minUint64(2, 1), Equals, uint64(1))
-	c.Assert(minUint64(1, 1), Equals, uint64(1))
+	c.Assert(MinUint64(1, 2), Equals, uint64(1))
+	c.Assert(MinUint64(2, 1), Equals, uint64(1))
+	c.Assert(MinUint64(1, 1), Equals, uint64(1))
 }
 
 func (s *testMinMaxSuite) TestMaxUint64(c *C) {
-	c.Assert(maxUint64(1, 2), Equals, uint64(2))
-	c.Assert(maxUint64(2, 1), Equals, uint64(2))
-	c.Assert(maxUint64(1, 1), Equals, uint64(1))
+	c.Assert(MaxUint64(1, 2), Equals, uint64(2))
+	c.Assert(MaxUint64(2, 1), Equals, uint64(2))
+	c.Assert(MaxUint64(1, 1), Equals, uint64(1))
 }
 
 func (s *testMinMaxSuite) TestMinDuration(c *C) {
-	c.Assert(minDuration(time.Minute, time.Second), Equals, time.Second)
-	c.Assert(minDuration(time.Second, time.Minute), Equals, time.Second)
-	c.Assert(minDuration(time.Second, time.Second), Equals, time.Second)
+	c.Assert(MinDuration(time.Minute, time.Second), Equals, time.Second)
+	c.Assert(MinDuration(time.Second, time.Minute), Equals, time.Second)
+	c.Assert(MinDuration(time.Second, time.Second), Equals, time.Second)
 }

--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/pd/v4/pkg/mock/mockhbstream"
 	"github.com/pingcap/pd/v4/pkg/testutil"
+	"github.com/pingcap/pd/v4/pkg/typeutil"
 	"github.com/pingcap/pd/v4/server/config"
 	"github.com/pingcap/pd/v4/server/core"
 	"github.com/pingcap/pd/v4/server/kv"
@@ -273,16 +274,6 @@ func (s *testCoordinatorSuite) TestCollectMetrics(c *C) {
 	wg.Wait()
 }
 
-func MaxUint64(nums ...uint64) uint64 {
-	result := uint64(0)
-	for _, num := range nums {
-		if num > result {
-			result = num
-		}
-	}
-	return result
-}
-
 func prepare(setCfg func(*config.ScheduleConfig), setTc func(*testCluster), run func(*coordinator), c *C) (*testCluster, *coordinator, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cfg, opt, err := newTestScheduleConfig()
@@ -371,7 +362,7 @@ func (s *testCoordinatorSuite) TestCheckerIsBusy(c *C) {
 	defer cleanup()
 
 	c.Assert(tc.addRegionStore(1, 0), IsNil)
-	num := 1 + MaxUint64(co.cluster.GetReplicaScheduleLimit(), co.cluster.GetMergeScheduleLimit())
+	num := 1 + typeutil.MaxUint64(co.cluster.GetReplicaScheduleLimit(), co.cluster.GetMergeScheduleLimit())
 	var operatorKinds = []operator.OpKind{
 		operator.OpReplica, operator.OpRegion | operator.OpMerge,
 	}

--- a/server/schedulers/base_scheduler.go
+++ b/server/schedulers/base_scheduler.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/pingcap/log"
+	"github.com/pingcap/pd/v4/pkg/typeutil"
 	"github.com/pingcap/pd/v4/server/schedule"
 	"github.com/pingcap/pd/v4/server/schedule/opt"
 )
@@ -44,9 +45,9 @@ const (
 func intervalGrow(x time.Duration, maxInterval time.Duration, typ intervalGrowthType) time.Duration {
 	switch typ {
 	case exponentialGrowth:
-		return minDuration(time.Duration(float64(x)*ScheduleIntervalFactor), maxInterval)
+		return typeutil.MinDuration(time.Duration(float64(x)*ScheduleIntervalFactor), maxInterval)
 	case linearGrowth:
-		return minDuration(x+MinSlowScheduleInterval, maxInterval)
+		return typeutil.MinDuration(x+MinSlowScheduleInterval, maxInterval)
 	case zeroGrowth:
 		return x
 	default:

--- a/server/schedulers/scheduler_test.go
+++ b/server/schedulers/scheduler_test.go
@@ -15,6 +15,7 @@ package schedulers
 
 import (
 	"context"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/v4/pkg/mock/mockcluster"
@@ -27,6 +28,11 @@ import (
 	"github.com/pingcap/pd/v4/server/schedule/opt"
 	"github.com/pingcap/pd/v4/server/schedule/placement"
 	"github.com/pingcap/pd/v4/server/statistics"
+)
+
+const (
+	KB = 1024
+	MB = 1024 * KB
 )
 
 var _ = Suite(&testShuffleLeaderSuite{})

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -17,10 +17,10 @@ import (
 	"math"
 	"net/url"
 	"strconv"
-	"time"
 
 	"github.com/montanaflynn/stats"
 	"github.com/pingcap/log"
+	"github.com/pingcap/pd/v4/pkg/typeutil"
 	"github.com/pingcap/pd/v4/server/core"
 	"github.com/pingcap/pd/v4/server/schedule/operator"
 	"github.com/pingcap/pd/v4/server/schedule/opt"
@@ -44,27 +44,6 @@ var (
 	// ErrScheduleConfigNotExist the config is not correct.
 	ErrScheduleConfigNotExist = errors.New("the config does not exist")
 )
-
-func minUint64(a, b uint64) uint64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func maxUint64(a, b uint64) uint64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func minDuration(a, b time.Duration) time.Duration {
-	if a < b {
-		return a
-	}
-	return b
-}
 
 func shouldBalance(cluster opt.Cluster, source, target *core.StoreInfo, region *core.RegionInfo, kind core.ScheduleKind, opInfluence operator.OpInfluence, scheduleName string) bool {
 	// The reason we use max(regionSize, averageRegionSize) to check is:
@@ -144,7 +123,7 @@ func adjustBalanceLimit(cluster opt.Cluster, kind core.ResourceKind) uint64 {
 		}
 	}
 	limit, _ := stats.StandardDeviation(counts)
-	return maxUint64(1, uint64(limit))
+	return typeutil.MaxUint64(1, uint64(limit))
 }
 
 func getKeyRanges(args []string) ([]core.KeyRange, error) {


### PR DESCRIPTION
### What problem does this PR solve?

According to the [comment](https://github.com/pingcap/pd/pull/2738#discussion_r467715596), it's better to support the customized scale in/out step. After this PR, we need to make `MaxScaleOutStep` and `MaxScaleInStep` configurable, see #2754.

### What is changed and how it works?

This PR moves out some common functions from `scheduler/utils.go` to `pkg/comparison.go` and use the `MaxScale*Step` to control the max step of scaling in/out.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
