### PR TITLE
Add priority schedule after scatter check failed.

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -39,7 +39,8 @@ type Cluster struct {
 	*placement.RuleManager
 	*statistics.HotCache
 	*statistics.StoresStats
-	ID uint64
+	ID             uint64
+	suspectRegions map[uint64]struct{}
 }
 
 // NewCluster creates a new Cluster
@@ -53,6 +54,7 @@ func NewCluster(opt *mockoption.ScheduleOptions) *Cluster {
 		RuleManager:     ruleManager,
 		HotCache:        statistics.NewHotCache(),
 		StoresStats:     statistics.NewStoresStats(),
+		suspectRegions:  map[uint64]struct{}{},
 	}
 }
 
@@ -632,4 +634,19 @@ func (mc *Cluster) SetStoreLabel(storeID uint64, labels map[string]string) {
 	}
 	newStore := store.Clone(core.SetStoreLabels(newLabels))
 	mc.PutStore(newStore)
+}
+
+func (mc *Cluster) AddSuspectRegions(ids ...uint64) {
+	for _, id := range ids {
+		mc.suspectRegions[id] = struct{}{}
+	}
+}
+
+func (mc *Cluster) CheckRegionUnderSuspect(id uint64) bool {
+	_, ok := mc.suspectRegions[id]
+	return ok
+}
+
+func (mc *Cluster) ResetSuspectRegions() {
+	mc.suspectRegions = map[uint64]struct{}{}
 }

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -636,17 +636,20 @@ func (mc *Cluster) SetStoreLabel(storeID uint64, labels map[string]string) {
 	mc.PutStore(newStore)
 }
 
+// AddSuspectRegions mock method
 func (mc *Cluster) AddSuspectRegions(ids ...uint64) {
 	for _, id := range ids {
 		mc.suspectRegions[id] = struct{}{}
 	}
 }
 
+// CheckRegionUnderSuspect only used for unit test
 func (mc *Cluster) CheckRegionUnderSuspect(id uint64) bool {
 	_, ok := mc.suspectRegions[id]
 	return ok
 }
 
+// ResetSuspectRegions only used for unit test
 func (mc *Cluster) ResetSuspectRegions() {
 	mc.suspectRegions = map[uint64]struct{}{}
 }

--- a/server/schedule/opt/opts.go
+++ b/server/schedule/opt/opts.go
@@ -89,6 +89,7 @@ type Cluster interface {
 	AllocID() (uint64, error)
 	FitRegion(*core.RegionInfo) *placement.RegionFit
 	RemoveScheduler(name string) error
+	AddSuspectRegions(ids ...uint64)
 }
 
 // HeartbeatStream is an interface.

--- a/server/schedule/region_scatterer.go
+++ b/server/schedule/region_scatterer.go
@@ -127,6 +127,7 @@ func newEngineContext(filters ...filter.Filter) engineContext {
 // Scatter relocates the region.
 func (r *RegionScatterer) Scatter(region *core.RegionInfo) (*operator.Operator, error) {
 	if !opt.IsRegionReplicated(r.cluster, region) {
+		r.cluster.AddSuspectRegions(region.GetID())
 		return nil, errors.Errorf("region %d is not fully replicated", region.GetID())
 	}
 

--- a/server/schedule/region_scatterer_test.go
+++ b/server/schedule/region_scatterer_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pingcap/pd/v4/pkg/mock/mockcluster"
 	"github.com/pingcap/pd/v4/pkg/mock/mockhbstream"
 	"github.com/pingcap/pd/v4/pkg/mock/mockoption"
+	"github.com/pingcap/pd/v4/server/core"
 	"github.com/pingcap/pd/v4/server/schedule/operator"
 	"github.com/pingcap/pd/v4/server/schedule/placement"
 )
@@ -225,5 +226,48 @@ func (s *testScatterRegionSuite) TestStoreLimit(c *C) {
 		if op, _ := scatterer.Scatter(region); op != nil {
 			c.Assert(oc.AddWaitingOperator(op), Equals, 1)
 		}
+	}
+}
+
+func (s *testScatterRegionSuite) TestScatterCheck(c *C) {
+	opt := mockoption.NewScheduleOptions()
+	tc := mockcluster.NewCluster(opt)
+	// Add 5 stores.
+	for i := uint64(1); i <= 5; i++ {
+		tc.AddRegionStore(i, 0)
+	}
+	testcases := []struct {
+		name        string
+		checkRegion *core.RegionInfo
+		needFix     bool
+	}{
+		{
+			name:        "region with 4 replicas",
+			checkRegion: tc.AddLeaderRegion(1, 1, 2, 3, 4),
+			needFix:     true,
+		},
+		{
+			name:        "region with 3 replicas",
+			checkRegion: tc.AddLeaderRegion(1, 1, 2, 3),
+			needFix:     false,
+		},
+		{
+			name:        "region with 2 replicas",
+			checkRegion: tc.AddLeaderRegion(1, 1, 2),
+			needFix:     true,
+		},
+	}
+	for _, testcase := range testcases {
+		c.Logf(testcase.name)
+		scatterer := NewRegionScatterer(tc)
+		_, err := scatterer.Scatter(testcase.checkRegion)
+		if testcase.needFix {
+			c.Assert(err, NotNil)
+			c.Assert(tc.CheckRegionUnderSuspect(1), Equals, true)
+		} else {
+			c.Assert(err, IsNil)
+			c.Assert(tc.CheckRegionUnderSuspect(1), Equals, false)
+		}
+		tc.ResetSuspectRegions()
 	}
 }


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Before region scattering, scatter will check the region status, if the region is not valid, scatter will refuse to scatter the region and wait coordinator to fix it.

This request let scatter put the invalid region into high priority schedule queue instead of discarding it directly.

<!-- Add the issue link with a summary if it exists. -->
ref https://github.com/pingcap/pd/issues/2733

#2736 is over-designed, this request simplies it.

### What is changed and how it works?
Add a new interface called HighPrioritySchedule to handle the regions for high priority scheduling need.


### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
