### PR TITLE
placement: add stringer for RuleOp

### DIFF
--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -350,6 +350,11 @@ type RuleOp struct {
 	DeleteByIDPrefix bool       `json:"delete_by_id_prefix"` // if action == delete, delete by the prefix of id
 }
 
+func (r RuleOp) String() string {
+	b, _ := json.Marshal(r)
+	return string(b)
+}
+
 // Batch executes a series of actions at once.
 func (m *RuleManager) Batch(todo []RuleOp) error {
 	for _, t := range todo {


### PR DESCRIPTION
### What problem does this PR solve?

> If an operand implements method String() string, that method will be invoked to convert the object to a string, which will then be formatted as required by the verb (if any).

Due to this behavior, the line 388 in rule_manager.go:

```
 log.Info("placement rules updated", zap.String("batch", fmt.Sprint(todo)))
```

did not print all fields in `RuleOp`. This PR adds an explicit stringer interface for `RuleOp` to display all infomation.

### Check List

Tests

- Unit test
- Integration test

### Release note

- No release note
